### PR TITLE
Fix Scoop install: add extract_dir so shiki.exe is found

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -155,6 +155,15 @@ jobs:
                   f"shiki-v{version}-x86_64-pc-windows-msvc.zip"
               )
               data["architecture"]["64bit"]["hash"] = f"sha256:{sha256}"
+              # The zip's own top-level entry is this same
+              # shiki-v{version}-x86_64-pc-windows-msvc/ folder (see the
+              # release job's "Package (zip)" step) — Scoop does not
+              # auto-strip a single nested top-level folder on extract, so
+              # without extract_dir it looks for shiki.exe directly under
+              # the app's version dir and fails to shim it (issue #8).
+              data["architecture"]["64bit"]["extract_dir"] = (
+                  f"shiki-v{version}-x86_64-pc-windows-msvc"
+              )
               with open(path, "w") as f:
                   json.dump(data, f, indent=4)
                   f.write("\n")

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,8 @@
 /target
 /nul
+# scripts/screenshots.sh's default output — generated marketing screenshots,
+# not source
+/screenshots
 
 # Claude Code CLI / Serena MCP local tooling artifacts (skill installs, project
 # index/cache), not project source

--- a/bucket/shiki.json
+++ b/bucket/shiki.json
@@ -6,7 +6,8 @@
     "architecture": {
         "64bit": {
             "url": "https://github.com/sazardev/shiki/releases/download/v0.8.1/shiki-v0.8.1-x86_64-pc-windows-msvc.zip",
-            "hash": "sha256:e268cc5e253aeccf177f810376143fb7756772fc43bf12883187416db585d604"
+            "hash": "sha256:e268cc5e253aeccf177f810376143fb7756772fc43bf12883187416db585d604",
+            "extract_dir": "shiki-v0.8.1-x86_64-pc-windows-msvc"
         }
     },
     "bin": "shiki.exe",
@@ -16,7 +17,8 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/sazardev/shiki/releases/download/v$version/shiki-v$version-x86_64-pc-windows-msvc.zip"
+                "url": "https://github.com/sazardev/shiki/releases/download/v$version/shiki-v$version-x86_64-pc-windows-msvc.zip",
+                "extract_dir": "shiki-v$version-x86_64-pc-windows-msvc"
             }
         }
     }

--- a/packaging/scoop/shiki.json
+++ b/packaging/scoop/shiki.json
@@ -6,7 +6,8 @@
     "architecture": {
         "64bit": {
             "url": "https://github.com/sazardev/shiki/releases/download/v0.8.1/shiki-v0.8.1-x86_64-pc-windows-msvc.zip",
-            "hash": "sha256:e268cc5e253aeccf177f810376143fb7756772fc43bf12883187416db585d604"
+            "hash": "sha256:e268cc5e253aeccf177f810376143fb7756772fc43bf12883187416db585d604",
+            "extract_dir": "shiki-v0.8.1-x86_64-pc-windows-msvc"
         }
     },
     "bin": "shiki.exe",
@@ -16,7 +17,8 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/sazardev/shiki/releases/download/v$version/shiki-v$version-x86_64-pc-windows-msvc.zip"
+                "url": "https://github.com/sazardev/shiki/releases/download/v$version/shiki-v$version-x86_64-pc-windows-msvc.zip",
+                "extract_dir": "shiki-v$version-x86_64-pc-windows-msvc"
             }
         }
     }


### PR DESCRIPTION
## Summary
- Fixes #8 — the release zip's `shiki.exe` lives inside a `shiki-v{version}-x86_64-pc-windows-msvc/` subfolder, but Scoop doesn't auto-strip a single nested top-level folder on extract. With no `extract_dir` in the manifest, Scoop looked for `shiki.exe` directly at the app root and failed to shim it.
- Adds `extract_dir` to both `packaging/scoop/shiki.json` and `bucket/shiki.json` for the current 0.8.1 release — this fixes existing installs immediately, no new version tag required.
- Updates `.github/workflows/release.yml`'s manifest-patching script (and the `autoupdate` block) to keep writing `extract_dir` automatically on every future release, so this doesn't regress.

## Test plan
- [x] Verified the actual v0.8.1 release zip layout (`shiki.exe` nested under `shiki-v0.8.1-x86_64-pc-windows-msvc/`) matches the fix
- [x] Both manifest JSON files still parse and remain byte-identical to each other
- [ ] Confirm on Windows: `scoop uninstall shiki` (if previously attempted) then `scoop install shiki` from this branch's manifest succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)