### PR TITLE
docs: add Scoop troubleshooting note

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,11 @@ scoop install shiki
 (or, without adding a bucket — a one-off install that `scoop update` won't track:
 `scoop install https://raw.githubusercontent.com/sazardev/shiki/main/packaging/scoop/shiki.json`)
 
+> **Troubleshooting:** `scoop install shiki` failing with `Couldn't find manifest for 'shiki'`
+> means the `sazardev` bucket isn't added yet (run the `scoop bucket add` line above first) —
+> or, if you'd added it a while ago, Scoop's local copy of it is stale; run `scoop update` first,
+> then `scoop install shiki` again.
+
 **Prebuilt binary (Linux/Windows/macOS), no package manager:**
 
 Download the archive for your platform from the

--- a/docs/index.html
+++ b/docs/index.html
@@ -249,6 +249,9 @@
 scoop install shiki</pre>
             <button class="copy-btn" type="button" aria-label="Copy command">Copy</button>
           </div>
+          <p class="theme-note">Getting <code>Couldn't find manifest for 'shiki'</code>? Run the
+          <code>scoop bucket add</code> line first if you haven't, or <code>scoop update</code> if
+          you added the bucket a while ago, then retry <code>scoop install shiki</code>.</p>
         </div>
         <div class="install-card">
           <h3>Prebuilt binary</h3>


### PR DESCRIPTION
## Summary
- Follow-up to #9. Adds a troubleshooting note to `README.md` and `docs/index.html`'s Scoop install card for `Couldn't find manifest for 'shiki'` — a different failure than the extract_dir/shim bug, caused by the `sazardev` bucket not being added yet, or being added before `scoop update` refreshed it.
- Both files already had the correct `scoop bucket add` + `scoop install shiki` commands; this only adds the troubleshooting callout underneath.

## Test plan
- [x] Reviewed rendered Markdown/HTML diff for formatting

🤖 Generated with [Claude Code](https://claude.com/claude-code)