### PR TITLE
v0.8.3: /-menu snippets, @ quick-template dropdown, editor word-wrap fix, 9 new templates

### DIFF
--- a/.github/workflows/nix-package-check.yml
+++ b/.github/workflows/nix-package-check.yml
@@ -1,0 +1,24 @@
+name: Nix package check
+
+# Scratch workflow to validate nix/shiki-package-test.nix (a draft of the
+# derivation intended for nixpkgs) actually builds, without needing a local
+# Nix install. Manual-trigger only — this is a one-off verification aid, not
+# part of the regular CI gate.
+on:
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: DeterminateSystems/nix-installer-action@main
+
+      - name: Build
+        run: nix-build nix/shiki-package-test.nix -o result
+
+      - name: Verify binary
+        run: |
+          ./result/bin/shiki --version
+          file ./result/bin/shiki

--- a/.github/workflows/nix-package-check.yml
+++ b/.github/workflows/nix-package-check.yml
@@ -6,6 +6,8 @@ name: Nix package check
 # part of the regular CI gate.
 on:
   workflow_dispatch:
+  push:
+    branches: [ nix-package-check ]
 
 jobs:
   build:

--- a/.github/workflows/nix-package-check.yml
+++ b/.github/workflows/nix-package-check.yml
@@ -17,10 +17,19 @@ jobs:
 
       - uses: DeterminateSystems/nix-installer-action@main
 
-      - name: Build
+      - name: Build (local src draft)
         run: nix-build nix/shiki-package-test.nix -o result
 
-      - name: Verify binary
+      - name: Verify binary (local src draft)
         run: |
           ./result/bin/shiki --version
           file ./result/bin/shiki
+
+      - name: Build (final fetchFromGitHub draft)
+        run: |
+          nix-build -E 'with import (fetchTarball "https://github.com/NixOS/nixpkgs/archive/nixos-unstable.tar.gz") { }; callPackage ./nix/shiki-package-final.nix { }' -o result-final
+
+      - name: Verify binary (final fetchFromGitHub draft)
+        run: |
+          ./result-final/bin/shiki --version
+          file ./result-final/bin/shiki

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,40 @@ All notable changes to shiki are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this project doesn't follow strict
 semver yet (pre-1.0), but version bumps are still meaningful and tracked here.
 
+## [0.8.3] - 2026-07-27
+
+### Added
+
+- Menu `/` en el editor inline: escribir `/` como primer caracter de una linea abre un mini-menu
+  buscable (filtra al seguir escribiendo, `↑`/`↓` navega, `Enter` inserta, `Esc` cierra el menu sin
+  salir de edicion) con bloques listos para insertar — `h1`/`h2`/`h3`, bloque de codigo, bloque de
+  math, tabla, checklist, quote, divider, fecha de hoy, linea de tags, y un bloque de frontmatter
+  YAML. `/` en cualquier otra posicion de la linea (una URL, una fraccion) sigue siendo un caracter
+  normal.
+- Los comandos del menu `/` son totalmente personalizables via `[snippets.<trigger>]` en
+  `config.toml` — cada entrada puede agregar un bloque nuevo o redefinir uno existente (mismo
+  trigger, case-insensitive). Soporta `{{title}}`/`{{date}}` (igual que los templates de notas) y
+  un marcador `{{cursor}}` que indica donde queda el cursor despues de insertar.
+- Dropdown `@` en el prompt de nota nueva (`a`): escribir `@` despues del titulo (o solo, sin
+  titulo) abre un dropdown con `today`/`yesterday`/`tomorrow` (fecha calculada, sin template) mas
+  cada template disponible — filtra al escribir, `Enter` crea la nota y salta directo a edicion,
+  saltandose el flujo normal de "titulo → Enter → elegir template".
+- 9 templates nuevos ademas de los 3 existentes (`default`/`daily`/`meeting`): `bug`, `spec`,
+  `review`, `postmortem` (dev), `standup`, `retro`, `1on1`, `weekly` (productividad/reuniones) y
+  `brainstorm` (general) — se generan automaticamente en `~/.config/shiki/templates/` en el
+  proximo arranque sin tocar ningun template ya personalizado.
+- El editor inline muestra un placeholder ("Type '/' for quick blocks...") cuando la nota esta
+  vacia, para que el menu `/` sea descubrible sin tener que leer la documentacion.
+
+### Fixed
+
+- El editor inline ahora envuelve las lineas largas dentro del ancho del panel (igual que PREVIEW)
+  en vez de scrollear horizontalmente y sacarlas de la vista — `tui-textarea` no soporta wrap en
+  ninguna version publicada, asi que el render del editor ahora se calcula a mano (mismo wrap tanto
+  para dibujar como para ubicar el cursor, para que nunca puedan desincronizarse), mientras que
+  toda la edicion real (insertar/borrar/deshacer/seleccion) sigue pasando por `tui-textarea` sin
+  cambios.
+
 ## [0.8.2] - 2026-07-24
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2294,7 +2294,7 @@ checksum = "dc6fe69c597f9c37bfeeeeeb33da3530379845f10be461a66d16d03eca2ded77"
 
 [[package]]
 name = "shiki-cli"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2311,7 +2311,7 @@ dependencies = [
 
 [[package]]
 name = "shiki-config"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "anyhow",
  "directories",
@@ -2323,7 +2323,7 @@ dependencies = [
 
 [[package]]
 name = "shiki-core"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "chrono",
  "git2",
@@ -2339,7 +2339,7 @@ dependencies = [
 
 [[package]]
 name = "shiki-tui"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "anyhow",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.8.2"
+version = "0.8.3"
 edition = "2021"
 authors = ["Omar"]
 license = "MIT"

--- a/IDEA.md
+++ b/IDEA.md
@@ -234,7 +234,7 @@ sync attempt (manual or automatic) just tries the push again.
 
 | Key | Action |
 |---|---|
-| `a` | New note (empty title stamps today's date). After the title, a template picker opens — every `.md` file in `~/.config/shiki/templates/` plus a "blank" option; `j`/`k` browse, `Enter` picks one and jumps straight to editing (`{{title}}`/`{{date}}` already substituted), `Esc`/`q` cancels the note entirely |
+| `a` | New note (empty title stamps today's date). After the title, a template picker opens — every `.md` file in `~/.config/shiki/templates/` plus a "blank" option; `j`/`k` browse, `Enter` picks one and jumps straight to editing (`{{title}}`/`{{date}}` already substituted), `Esc`/`q` cancels the note entirely. Typing `@` anywhere in the title prompt (with or without a title before it) opens a quick dropdown instead — `today`/`yesterday`/`tomorrow` (a computed date, no template) plus every available template, fuzzy-filtered as you keep typing; `Enter` creates the note and jumps straight to editing, skipping the title→Enter→pick-a-template two-step entirely |
 | `f` | New folder — empty name cancels rather than creating something unnamed. Created at the current breadcrumb depth, so it can be nested arbitrarily by descending first |
 | `r` | Rename note |
 | `d` | Delete the selected note *or* folder (with confirmation) — a folder deletes everything inside it too. In `v` select mode, deletes every selected item at once. Moved to the trash rather than permanently removed, so leader+`u` can undo it |
@@ -257,6 +257,23 @@ sync attempt (manual or automatic) just tries the push again.
 | `E` | Edit externally ($EDITOR) |
 | `H` | Note history — every commit that changed this specific note, newest first, real git history (not a separate versioning system). `j`/`k`/`PageUp`/`PageDown`/`Home`/`End` move, `Enter` views a revision's full content (frontmatter included, since that's what's actually in the commit), `r` reverts to the highlighted (or currently-viewed) revision — behind a confirmation, since it overwrites the current content. The revert itself doesn't commit; it shows up as a normal pending change, picked up by `s`/`u`/`auto_sync` like any other edit. The footer shows the count while reading a note (`{n} changes`) |
 | `L` | Links — the selected note's outgoing `[[wikilinks]]` (resolved against every note in the notebook, any folder depth) plus every other note that links back to it ("Outgoing"/"Backlinks" sections; a section with nothing in it is omitted). `j`/`k`/`PageUp`/`PageDown`/`Home`/`End` move, `Enter` jumps to the selected note (an unresolved outgoing link reports that instead of jumping), `Esc`/`q` closes |
+
+#### Inside the inline editor (`i`)
+
+Long lines wrap to the panel's width, the same as PREVIEW — they never scroll off the edge of the
+screen. A completely empty note shows a dim placeholder hint ("Type `/` for quick blocks…"),
+gone the instant you type anything.
+
+Typing `/` as the very first character of a line (nothing to its left — a `/` anywhere else, e.g.
+mid-sentence or in a URL/fraction, is just a literal slash) opens a small searchable menu right
+under the cursor: keep typing to filter by name, `↑`/`↓` to move, `Enter` to insert the highlighted
+block, `Esc` to dismiss the menu without leaving edit mode (a second `Esc` then saves and exits, as
+usual). Built-in blocks: `h1`/`h2`/`h3`, a code fence, a math (`$$…$$`) block, a table skeleton, a
+checklist item, a quote, a divider, today's date, a `Tags:` line, and a YAML frontmatter skeleton.
+
+Every command is customizable from `config.toml` under `[snippets.<trigger>]` — see the
+Configuration section below. A custom entry with the same trigger as a built-in (case-insensitive)
+replaces it instead of adding a duplicate, so nothing here is off-limits to redefine.
 
 ---
 
@@ -474,6 +491,21 @@ remote_template = ""
 auto_sync = true
 auto_sync_every = 3
 auto_push = true
+
+# Custom entries for the inline editor's `/`-menu, keyed by trigger. Empty by
+# default — the built-in commands (h1/h2/h3/code/math/table/check/quote/
+# divider/date/tags/frontmatter) aren't listed here at all, only your own
+# additions/overrides. `label` falls back to the trigger when omitted; `body`
+# supports {{title}}/{{date}} (substituted the same way note templates are)
+# plus a {{cursor}} marker for where the cursor lands after insertion.
+[snippets.note]
+label = "Callout note"
+body = "> **Note:** {{cursor}}"
+
+# Same trigger as a built-in (case-insensitive) replaces it instead of
+# adding a duplicate — every command in the menu is customizable this way.
+[snippets.h1]
+body = "# [{{title}}] {{cursor}}"
 ```
 
 ---

--- a/docs/documentation.html
+++ b/docs/documentation.html
@@ -201,7 +201,7 @@
       <table class="ref-table">
         <thead><tr><th>Key</th><th>Action</th></tr></thead>
         <tbody>
-          <tr><td><code>a</code></td><td>New note (empty title stamps today's date). After the title, a template picker opens — every <code>.md</code> file in <code>~/.config/shiki/templates/</code> plus a "blank" option; <code>j</code>/<code>k</code> browse, <code>Enter</code> picks one and jumps straight to editing (<code>{{title}}</code>/<code>{{date}}</code> already substituted), <code>Esc</code>/<code>q</code> cancels the note entirely</td></tr>
+          <tr><td><code>a</code></td><td>New note (empty title stamps today's date). After the title, a template picker opens — every <code>.md</code> file in <code>~/.config/shiki/templates/</code> plus a "blank" option; <code>j</code>/<code>k</code> browse, <code>Enter</code> picks one and jumps straight to editing (<code>{{title}}</code>/<code>{{date}}</code> already substituted), <code>Esc</code>/<code>q</code> cancels the note entirely. Typing <code>@</code> anywhere in the title prompt (with or without a title before it) opens a quick dropdown instead — <code>today</code>/<code>yesterday</code>/<code>tomorrow</code> (a computed date, no template) plus every available template, fuzzy-filtered as you keep typing; <code>Enter</code> creates the note and jumps straight to editing, skipping the title→Enter→pick-a-template two-step entirely</td></tr>
           <tr><td><code>f</code></td><td>New folder — empty name cancels rather than creating something unnamed. Created at the current breadcrumb depth, so it can be nested arbitrarily by descending first</td></tr>
           <tr><td><code>r</code></td><td>Rename note</td></tr>
           <tr><td><code>d</code></td><td>Delete the selected note <em>or</em> folder (with confirmation) — a folder deletes everything inside it too. In <code>v</code> select mode, deletes every selected item at once. Moved to the trash rather than permanently removed, so leader+<code>u</code> can undo it</td></tr>
@@ -228,6 +228,29 @@
           <tr><td><code>L</code></td><td>Links — the selected note's outgoing <code>[[wikilinks]]</code> (resolved against every note in the notebook, any folder depth) plus every other note that links back to it ("Outgoing"/"Backlinks" sections; a section with nothing in it is omitted). <code>j</code>/<code>k</code>/<code>PageUp</code>/<code>PageDown</code>/<code>Home</code>/<code>End</code> move, <code>Enter</code> jumps to the selected note (an unresolved outgoing link reports that instead of jumping), <code>Esc</code>/<code>q</code> closes</td></tr>
         </tbody>
       </table>
+
+      <h3>Inside the inline editor (<code>i</code>)</h3>
+      <p>
+        Long lines wrap to the panel's width, the same as PREVIEW — they never scroll off the edge
+        of the screen. A completely empty note shows a dim placeholder hint ("Type <code>/</code>
+        for quick blocks…"), gone the instant you type anything.
+      </p>
+      <p>
+        Typing <code>/</code> as the very first character of a line (nothing to its left — a
+        <code>/</code> anywhere else, e.g. mid-sentence or in a URL/fraction, is just a literal
+        slash) opens a small searchable menu right under the cursor: keep typing to filter by name,
+        <code>↑</code>/<code>↓</code> to move, <code>Enter</code> to insert the highlighted block,
+        <code>Esc</code> to dismiss the menu without leaving edit mode (a second <code>Esc</code>
+        then saves and exits, as usual). Built-in blocks: <code>h1</code>/<code>h2</code>/<code>h3</code>,
+        a code fence, a math (<code>$$…$$</code>) block, a table skeleton, a checklist item, a
+        quote, a divider, today's date, a <code>Tags:</code> line, and a YAML frontmatter skeleton.
+      </p>
+      <p>
+        Every command is customizable from <code>config.toml</code> under
+        <code>[snippets.&lt;trigger&gt;]</code> — see the config reference below. A custom entry
+        with the same trigger as a built-in (case-insensitive) replaces it instead of adding a
+        duplicate, so nothing here is off-limits to redefine.
+      </p>
     </div>
   </section>
 
@@ -450,7 +473,22 @@ remote_template = ""
 [notebooks.work]
 auto_sync = true
 auto_sync_every = 3
-auto_push = true</pre>
+auto_push = true
+
+# Custom entries for the inline editor's `/`-menu, keyed by trigger. Empty by
+# default — the built-in commands (h1/h2/h3/code/math/table/check/quote/
+# divider/date/tags/frontmatter) aren't listed here at all, only your own
+# additions/overrides. `label` falls back to the trigger when omitted; `body`
+# supports {{title}}/{{date}} (substituted the same way note templates are)
+# plus a {{cursor}} marker for where the cursor lands after insertion.
+[snippets.note]
+label = "Callout note"
+body = "> **Note:** {{cursor}}"
+
+# Same trigger as a built-in (case-insensitive) replaces it instead of
+# adding a duplicate — every command in the menu is customizable this way.
+[snippets.h1]
+body = "# [{{title}}] {{cursor}}"</pre>
       <p class="muted" style="font-size:0.9rem;">
         Every default shown above matches the current release — if this page and a fresh
         <code>shiki</code> install ever disagree, trust the install.

--- a/docs/index.html
+++ b/docs/index.html
@@ -50,7 +50,7 @@
     "downloadUrl": "https://github.com/sazardev/shiki/releases/latest",
     "applicationCategory": "Utility",
     "operatingSystem": "Linux, Windows, macOS",
-    "softwareVersion": "0.8.1",
+    "softwareVersion": "0.8.3",
     "programmingLanguage": "Rust",
     "license": "https://github.com/sazardev/shiki/blob/main/LICENSE",
     "codeRepository": "https://github.com/sazardev/shiki",

--- a/nix/shiki-package-final.nix
+++ b/nix/shiki-package-final.nix
@@ -1,0 +1,59 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  pkg-config,
+  cmake,
+  perl,
+  nasm,
+  stdenv,
+  openssl,
+  oniguruma,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "shiki";
+  version = "0.8.2";
+
+  src = fetchFromGitHub {
+    owner = "sazardev";
+    repo = "shiki";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-A78tDlq6FdWD3KhfWWlTJHhTg4dW0/FKDLQq6Kec1pU=";
+  };
+
+  cargoLock.lockFile = "${finalAttrs.src}/Cargo.lock";
+
+  nativeBuildInputs = [
+    pkg-config
+    cmake
+    perl
+  ] ++ lib.optionals stdenv.hostPlatform.isx86_64 [ nasm ];
+
+  buildInputs = [
+    openssl
+    oniguruma
+  ];
+
+  env = {
+    # git2's Cargo.toml hardcodes the "vendored-openssl" feature (needed for
+    # shiki's own cross-platform release binaries, built outside nixpkgs);
+    # this overrides openssl-sys's build.rs to link nixpkgs' own openssl
+    # instead of compiling OpenSSL from source (same as nixpkgs' gitui
+    # package, which hits the identical git2 vendored-openssl situation).
+    OPENSSL_NO_VENDOR = 1;
+    # syntect's default features pull in onig_sys (the oniguruma C library)
+    # for regex-onig; this links nixpkgs' oniguruma via pkg-config instead
+    # of compiling its own bundled copy (same as nixpkgs' atac package).
+    RUSTONIG_SYSTEM_LIBONIG = true;
+  };
+
+  meta = {
+    description = "TUI note-taking app with a Yazi-style three-pane layout and modal navigation, notes as plain Markdown + YAML frontmatter, each notebook its own git repo";
+    homepage = "https://github.com/sazardev/shiki";
+    changelog = "https://github.com/sazardev/shiki/blob/v${finalAttrs.version}/CHANGELOG.md";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ sazardev ];
+    mainProgram = "shiki";
+  };
+})

--- a/nix/shiki-package-test.nix
+++ b/nix/shiki-package-test.nix
@@ -1,0 +1,46 @@
+# Scratch derivation used only to validate the future nixpkgs package.nix
+# draft against this repo's own checkout, in CI (see
+# .github/workflows/nix-package-check.yml). Not the final nixpkgs submission
+# file — that one will fetch the tagged release via fetchFromGitHub instead
+# of using `src = ./..`, and won't live in this repo at all.
+{ pkgs ? import (fetchTarball "https://github.com/NixOS/nixpkgs/archive/nixos-unstable.tar.gz") { } }:
+
+pkgs.rustPlatform.buildRustPackage {
+  pname = "shiki";
+  version = "0.8.2";
+
+  src = ./..;
+
+  cargoLock.lockFile = ../Cargo.lock;
+
+  nativeBuildInputs = with pkgs; [
+    pkg-config
+    cmake
+    perl
+  ] ++ pkgs.lib.optionals pkgs.stdenv.hostPlatform.isx86_64 [ pkgs.nasm ];
+
+  buildInputs = with pkgs; [
+    openssl
+    oniguruma
+  ];
+
+  env = {
+    # git2's Cargo.toml hardcodes the "vendored-openssl" feature (needed for
+    # the project's own cross-platform release binaries); this overrides
+    # openssl-sys's build.rs to link nixpkgs' own openssl instead of
+    # compiling OpenSSL from source, same trick nixpkgs' gitui package uses
+    # for the identical git2 vendored-openssl situation.
+    OPENSSL_NO_VENDOR = 1;
+    # syntect's default features pull in onig_sys (oniguruma C library) for
+    # regex-onig; this links nixpkgs' oniguruma via pkg-config instead of
+    # compiling its own bundled copy, same as nixpkgs' atac package.
+    RUSTONIG_SYSTEM_LIBONIG = true;
+  };
+
+  meta = {
+    description = "TUI note-taking app with a Yazi-style three-pane layout";
+    homepage = "https://github.com/sazardev/shiki";
+    license = pkgs.lib.licenses.mit;
+    mainProgram = "shiki";
+  };
+}

--- a/shiki-config/src/config.rs
+++ b/shiki-config/src/config.rs
@@ -544,6 +544,44 @@ pub struct ResolvedSync {
     pub auto_sync_every: u32,
 }
 
+/// One entry in the inline editor's `/`-menu, defined under
+/// `[snippets.<trigger>]` in `config.toml` — e.g.:
+///
+/// ```toml
+/// [snippets.note]
+/// label = "Callout note"
+/// body = "> **Note:** {{cursor}}"
+/// ```
+///
+/// Keyed by trigger (a `HashMap`, like `[notebooks.<name>]` above) rather
+/// than an array of `{ trigger, label, body }` tables — deliberately not
+/// `Vec<SnippetConfig>` with `[[snippets]]`: `Config::save` always writes
+/// every field including empty ones, and an empty `Vec` serializes as a
+/// bare `snippets = []` line, which conflicts as a "duplicate key" with
+/// any `[[snippets]]` block a user later appends by hand (hit for real
+/// while dogfooding this — a fresh install's already-written `config.toml`
+/// has `snippets = []` from the very first launch, before anyone's added
+/// one). An empty `HashMap` instead serializes as a bare `[snippets]`
+/// table header, and TOML lets `[snippets.note]` extend that table
+/// afterward with no conflict — the same reason `[notebooks.work]` already
+/// composes cleanly with the auto-written `[notebooks]`.
+///
+/// The map key is what filters the `/`-menu (and, if it matches a built-in
+/// command's trigger case-insensitively, *replaces* that built-in instead
+/// of adding a duplicate — every command in the menu is customizable this
+/// way, not just ones added from scratch). `label` falls back to the
+/// trigger when omitted. `body` supports the same `{{title}}`/`{{date}}`
+/// placeholders note templates do (`shiki_core::Template::render`), plus a
+/// `{{cursor}}` marker (not a template placeholder — resolved separately)
+/// marking where the cursor lands after insertion; omit it to leave the
+/// cursor at the end of the inserted text.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SnippetConfig {
+    #[serde(default)]
+    pub label: Option<String>,
+    pub body: String,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct Config {
     #[serde(default)]
@@ -558,6 +596,12 @@ pub struct Config {
     /// `[notebooks.work]` with `auto_push = true`. See `NotebookGitOverride`.
     #[serde(default)]
     pub notebooks: std::collections::HashMap<String, NotebookGitOverride>,
+    /// User-defined `/`-menu commands for the inline editor, keyed by
+    /// trigger — see `SnippetConfig`. Empty by default; the built-in
+    /// commands (`shiki-tui`'s `slash_menu::builtins`) aren't stored here
+    /// at all, only ever the user's own additions/overrides.
+    #[serde(default)]
+    pub snippets: std::collections::HashMap<String, SnippetConfig>,
 }
 
 impl Config {

--- a/shiki-core/src/templates.rs
+++ b/shiki-core/src/templates.rs
@@ -37,14 +37,38 @@ pub const DEFAULT_TEMPLATE: &str = "# {{title}}\n\n";
 pub const DAILY_TEMPLATE: &str = "# {{date}}\n\n## Tasks\n\n- [ ] \n\n## Notes\n\n";
 pub const MEETING_TEMPLATE: &str =
     "# {{title}}\n\nDate: {{date}}\n\n## Attendees\n\n## Agenda\n\n## Notes\n\n## Action Items\n\n";
+pub const STANDUP_TEMPLATE: &str =
+    "# {{title}}\n\nDate: {{date}}\n\n## Yesterday\n\n## Today\n\n## Blockers\n\n";
+pub const RETRO_TEMPLATE: &str = "# {{title}}\n\nDate: {{date}}\n\n## What Went Well\n\n## What Didn't Go Well\n\n## Action Items\n\n- [ ] \n";
+pub const ONE_ON_ONE_TEMPLATE: &str =
+    "# {{title}}\n\nDate: {{date}}\n\n## Talking Points\n\n## Notes\n\n## Action Items\n\n- [ ] \n";
+pub const BUG_TEMPLATE: &str = "# {{title}}\n\nDate: {{date}}\nSeverity: \nStatus: Open\n\n## Summary\n\n## Steps to Reproduce\n\n1. \n2. \n3. \n\n## Expected Behavior\n\n## Actual Behavior\n\n## Environment\n\n- \n\n## Fix Notes\n\n";
+pub const SPEC_TEMPLATE: &str = "# {{title}}\n\nDate: {{date}}\nStatus: Draft\n\n## Problem\n\n## Goals\n\n## Non-Goals\n\n## Proposal\n\n## Alternatives Considered\n\n## Open Questions\n\n";
+pub const POSTMORTEM_TEMPLATE: &str = "# {{title}}\n\nDate: {{date}}\nSeverity: \nStatus: Draft\n\n## Summary\n\n## Timeline\n\n## Root Cause\n\n## Impact\n\n## Action Items\n\n- [ ] \n\n## Lessons Learned\n\n";
+pub const REVIEW_TEMPLATE: &str = "# {{title}}\n\nDate: {{date}}\nPR/MR: \n\n## Summary\n\n## Comments\n\n## Decision\n\n- [ ] Approved\n- [ ] Changes requested\n";
+pub const WEEKLY_TEMPLATE: &str = "# {{title}}\n\nWeek of: {{date}}\n\n## Highlights\n\n## Metrics\n\n## Challenges\n\n## Next Week Priorities\n\n- [ ] \n";
+pub const BRAINSTORM_TEMPLATE: &str = "# {{title}}\n\nDate: {{date}}\n\n## Problem / Prompt\n\n## Ideas\n\n- \n\n## Next Steps\n\n- [ ] \n";
 
-/// Creates the default templates in `templates_dir` if they don't exist yet.
+/// Creates the default templates in `templates_dir` if they don't exist yet
+/// — one file per const above, `if !path.exists()` so re-running this
+/// (it happens on every CLI/TUI launch, `shiki-cli/src/main.rs`'s
+/// `Context::load`) only ever fills in newly-added templates and never
+/// overwrites one a user has since customized.
 pub fn ensure_defaults(templates_dir: &Path) -> Result<()> {
     std::fs::create_dir_all(templates_dir)?;
     let defaults = [
         ("default.md", DEFAULT_TEMPLATE),
         ("daily.md", DAILY_TEMPLATE),
         ("meeting.md", MEETING_TEMPLATE),
+        ("standup.md", STANDUP_TEMPLATE),
+        ("retro.md", RETRO_TEMPLATE),
+        ("1on1.md", ONE_ON_ONE_TEMPLATE),
+        ("bug.md", BUG_TEMPLATE),
+        ("spec.md", SPEC_TEMPLATE),
+        ("postmortem.md", POSTMORTEM_TEMPLATE),
+        ("review.md", REVIEW_TEMPLATE),
+        ("weekly.md", WEEKLY_TEMPLATE),
+        ("brainstorm.md", BRAINSTORM_TEMPLATE),
     ];
     for (filename, contents) in defaults {
         let path = templates_dir.join(filename);

--- a/shiki-tui/src/app.rs
+++ b/shiki-tui/src/app.rs
@@ -124,13 +124,67 @@ impl PendingInput {
     /// explicitly by whatever starts that particular input instead.
     pub(crate) fn title(self) -> &'static str {
         match self {
-            PendingInput::NewNote => " New note ",
+            PendingInput::NewNote => " New note (@ for quick date/template) ",
             PendingInput::NewNotebook => " New notebook ",
             PendingInput::NewFolder => " New folder ",
             PendingInput::RenameNote | PendingInput::RenameNotebook => " Rename ",
             PendingInput::Search => " Jump to note ",
             PendingInput::SetRemote => " Git remote (URL or local path) ",
             PendingInput::MoveOrCopy => " Move/copy to ",
+        }
+    }
+}
+
+/// A quick `@`-triggered shortcut typed into the `NewNote` title prompt —
+/// `today`/`yesterday`/`tomorrow` resolve to a computed date (no template),
+/// every other entry is a real `.md` file already sitting in the templates
+/// dir (same discovery `open_template_picker` does). Picking one from the
+/// dropdown finishes note creation immediately, skipping the normal
+/// "type a title, Enter, then pick a template from `show_template_picker`"
+/// two-step flow — that's the whole point of `@` being faster.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum QuickCommand {
+    Today,
+    Yesterday,
+    Tomorrow,
+    Template(String),
+}
+
+impl QuickCommand {
+    pub(crate) fn label(&self) -> String {
+        match self {
+            QuickCommand::Today => "today".to_string(),
+            QuickCommand::Yesterday => "yesterday".to_string(),
+            QuickCommand::Tomorrow => "tomorrow".to_string(),
+            QuickCommand::Template(name) => name.clone(),
+        }
+    }
+
+    /// `None` for `Template` — only the three date commands have one.
+    pub(crate) fn date(&self) -> Option<chrono::NaiveDate> {
+        let today = chrono::Local::now().date_naive();
+        match self {
+            QuickCommand::Today => Some(today),
+            QuickCommand::Yesterday => today.pred_opt(),
+            QuickCommand::Tomorrow => today.succ_opt(),
+            QuickCommand::Template(_) => None,
+        }
+    }
+
+    /// One line for the dropdown list — date commands preview the actual
+    /// resolved date (matching the `%Y-%m-%d` convention used everywhere
+    /// else dates are formatted, see `daily.rs`) so the user sees exactly
+    /// what they'll get before picking it.
+    pub(crate) fn display(&self) -> String {
+        match self {
+            QuickCommand::Template(name) => format!("{name}  (template)"),
+            _ => format!(
+                "{}  \u{2192} {}",
+                self.label(),
+                self.date()
+                    .map(|d| d.format("%Y-%m-%d").to_string())
+                    .unwrap_or_default()
+            ),
         }
     }
 }
@@ -232,6 +286,13 @@ pub struct App {
     pub input: InputBox,
     pub confirm: Option<confirm::ConfirmDialog>,
     pub editor: Option<InlineEditor<'static>>,
+    /// The inline editor's `/`-menu (see `slash_menu.rs`) — open only
+    /// while `Mode::Edit`'s current line reads exactly `/` up to the
+    /// cursor (checked live off `editor.textarea` itself in
+    /// `App::slash_query`, not tracked separately, so it can never
+    /// disagree with what's actually in the buffer).
+    pub(crate) show_slash_menu: bool,
+    pub(crate) slash_menu_selected: usize,
     /// Path + editor command to launch externally, picked up by `run()`
     /// between draw calls. The editor is resolved per-invocation (either the
     /// configured `general.editor` for `E`, or the detected OS favorite for
@@ -279,6 +340,12 @@ pub struct App {
     /// while the template picker is up — the note isn't actually created
     /// until a template (or "blank") is chosen.
     pub(crate) pending_new_note_title: String,
+    /// Selected row in the `@`-triggered quick-template dropdown (see
+    /// `QuickCommand`) — only meaningful while `NewNote`'s input contains an
+    /// `@`; reset to 0 on every keystroke that changes the filter, same
+    /// "never leave a stale out-of-range index" rule `which_key_selected`
+    /// already follows.
+    pub(crate) quick_template_selected: usize,
     pub show_tree: bool,
     pub(crate) tree_rows: Vec<crate::tree::TreeRow>,
     /// Index into just the `Note` rows of `tree_rows` (folder rows are
@@ -547,6 +614,8 @@ impl App {
             input: InputBox::default(),
             confirm: None,
             editor: None,
+            show_slash_menu: false,
+            slash_menu_selected: 0,
             want_external_edit: None,
             show_theme_picker: false,
             show_global_search: false,
@@ -560,6 +629,7 @@ impl App {
             template_picker_options: Vec::new(),
             template_picker_index: 0,
             pending_new_note_title: String::new(),
+            quick_template_selected: 0,
             show_tree: false,
             tree_rows: Vec::new(),
             tree_selected: 0,

--- a/shiki-tui/src/draw.rs
+++ b/shiki-tui/src/draw.rs
@@ -1,6 +1,6 @@
 use crate::app::{
     centered_rect, drawer_area, global_search_layout, global_search_popup_area, App, Mode,
-    UpdateState,
+    PendingInput, UpdateState,
 };
 use crate::icons;
 use crate::render::{hex_to_color, panel_block};
@@ -8,7 +8,7 @@ use crate::{
     layout, panel_drawer, panel_notebooks, panel_notes, panel_preview, panel_tags, status_bar,
     which,
 };
-use ratatui::layout::Rect;
+use ratatui::layout::{Constraint, Layout, Rect};
 use ratatui::style::{Modifier, Style};
 use ratatui::text::Line;
 use ratatui::text::Span;
@@ -26,7 +26,10 @@ pub fn draw(frame: &mut Frame, app: &App) {
     panel_notes::render(frame, areas.notes, app);
     if app.mode == Mode::Edit {
         if let Some(editor) = &app.editor {
-            frame.render_widget(&editor.textarea, areas.preview);
+            editor.render(frame, areas.preview);
+            if app.show_slash_menu {
+                render_slash_menu(frame, areas.preview, editor, app);
+            }
         }
     } else {
         panel_preview::render(frame, areas.preview, app);
@@ -34,14 +37,59 @@ pub fn draw(frame: &mut Frame, app: &App) {
     status_bar::render(frame, areas.status_bar, app);
 
     if let Some(kind) = app.pending_input {
-        let popup_area = centered_rect(frame.area(), (frame.area().width / 2).max(30), 3);
-        frame.render_widget(Clear, popup_area);
+        let quick_matches = if kind == PendingInput::NewNote {
+            app.quick_template_filtered()
+        } else {
+            Vec::new()
+        };
+        let width = (frame.area().width / 2).max(30);
         let title = app
             .pending_input_title
             .as_deref()
             .unwrap_or_else(|| kind.title());
-        app.input
-            .render(frame, popup_area, title, hex_to_color(&app.theme.accent));
+
+        if app.quick_template_query().is_some() {
+            // Same height budget `render_template_picker` uses (option
+            // count + 2 for the list's own border, capped so a long
+            // template list can't ever push the popup off-screen), stacked
+            // under the input's own fixed 3 rows instead of replacing it —
+            // the title text stays visible and editable while the dropdown
+            // is up.
+            let list_height = (quick_matches.len() as u16 + 2).min(frame.area().height / 2);
+            let popup_area = centered_rect(frame.area(), width, 3 + list_height);
+            frame.render_widget(Clear, popup_area);
+            let [input_area, list_area] =
+                Layout::vertical([Constraint::Length(3), Constraint::Length(list_height)])
+                    .areas(popup_area);
+            app.input
+                .render(frame, input_area, title, hex_to_color(&app.theme.accent));
+
+            let items: Vec<ListItem> = quick_matches
+                .iter()
+                .map(|cmd| ListItem::new(cmd.display()))
+                .collect();
+            let highlight_symbol = format!("{} ", icons::ARROW);
+            let list_title = format!(" {}  Quick template ", icons::CALENDAR);
+            let list = List::new(items)
+                .block(panel_block(Line::from(list_title), true, &app.theme))
+                .highlight_style(
+                    Style::default()
+                        .bg(hex_to_color(&app.theme.selection))
+                        .fg(hex_to_color(&app.theme.accent))
+                        .add_modifier(Modifier::BOLD),
+                )
+                .highlight_symbol(&highlight_symbol);
+            let mut state = ListState::default();
+            if !quick_matches.is_empty() {
+                state.select(Some(app.quick_template_selected));
+            }
+            frame.render_stateful_widget(list, list_area, &mut state);
+        } else {
+            let popup_area = centered_rect(frame.area(), width, 3);
+            frame.render_widget(Clear, popup_area);
+            app.input
+                .render(frame, popup_area, title, hex_to_color(&app.theme.accent));
+        }
     }
 
     if app.show_tags {
@@ -454,6 +502,67 @@ fn render_history(frame: &mut Frame, frame_area: Rect, app: &App) {
     let mut state = ListState::default();
     if !app.history_entries.is_empty() {
         state.select(Some(app.history_selected));
+    }
+    frame.render_stateful_widget(list, popup_area, &mut state);
+}
+
+/// Anchors the `/`-menu right under the current line inside the editor's
+/// own inner area (`editor.cursor_screen_row()`, computed by
+/// `InlineEditor::render` the same pass that just ran) — falls back to
+/// showing it *above* the line instead when there isn't enough room below,
+/// e.g. typing `/` on the last visible line of a long note.
+fn render_slash_menu(
+    frame: &mut Frame,
+    area: Rect,
+    editor: &crate::editor::InlineEditor,
+    app: &App,
+) {
+    let inner = match editor.textarea.block() {
+        Some(block) => block.inner(area),
+        None => area,
+    };
+    if inner.width < 10 || inner.height < 3 {
+        return;
+    }
+    let matches = app.slash_menu_filtered();
+    let width = inner.width.min(44);
+    let max_height = inner.height.saturating_sub(1).max(3);
+    let height = (matches.len() as u16 + 2).clamp(3, max_height);
+
+    let cursor_row = editor.cursor_screen_row();
+    let below_y = inner.y + cursor_row + 1;
+    let popup_y = if below_y + height <= inner.y + inner.height {
+        below_y
+    } else {
+        inner.y + cursor_row.saturating_sub(height)
+    };
+
+    let popup_area = Rect {
+        x: inner.x,
+        y: popup_y,
+        width,
+        height,
+    };
+    frame.render_widget(Clear, popup_area);
+
+    let items: Vec<ListItem> = matches
+        .iter()
+        .map(|cmd| ListItem::new(format!("/{}  {}", cmd.trigger, cmd.label)))
+        .collect();
+    let highlight_symbol = format!("{} ", icons::ARROW);
+    let title = format!(" {}  Slash menu ", icons::PENCIL);
+    let list = List::new(items)
+        .block(panel_block(Line::from(title), true, &app.theme))
+        .highlight_style(
+            Style::default()
+                .bg(hex_to_color(&app.theme.selection))
+                .fg(hex_to_color(&app.theme.accent))
+                .add_modifier(Modifier::BOLD),
+        )
+        .highlight_symbol(&highlight_symbol);
+    let mut state = ListState::default();
+    if !matches.is_empty() {
+        state.select(Some(app.slash_menu_selected));
     }
     frame.render_stateful_widget(list, popup_area, &mut state);
 }

--- a/shiki-tui/src/editor.rs
+++ b/shiki-tui/src/editor.rs
@@ -1,8 +1,52 @@
+use std::cell::Cell;
+
+use ratatui::layout::Rect;
+use ratatui::style::{Color, Style};
+use ratatui::text::{Line, Span};
+use ratatui::widgets::Paragraph;
+use ratatui::Frame;
 use tui_textarea::TextArea;
 
-/// Thin wrapper over `tui-textarea` for the inline editor (key `e`).
+/// Thin wrapper over `tui-textarea` for the inline editor (key `e`/`i`).
+///
+/// `tui-textarea` 0.7 has no soft line-wrap at all — confirmed against its
+/// own `Widget for &TextArea` impl (`widget.rs` in the vendored crate
+/// source): it always renders exactly one screen row per *source* line and
+/// horizontally scrolls to keep the cursor visible instead
+/// (`scroll_top_col`/`next_scroll_top`), with no `set_wrap`-style toggle
+/// anywhere in its public API, at any published version. That's fine for
+/// the read-only PREVIEW panel, which builds its own plain `Paragraph` and
+/// turns on `Wrap { trim: false }` itself (`panel_preview.rs`) — but it
+/// meant a long line typed directly into the editor just ran off the edge
+/// of the panel instead of wrapping, only becoming visible again once you
+/// left edit mode and PREVIEW re-rendered the same text wrapped.
+///
+/// Rather than forking/patching `tui-textarea` (its `Widget` impl is the
+/// only place that would need the change, and it's not a project with
+/// fast-merging PRs to depend on for that), `render` bypasses its `Widget`
+/// impl entirely and draws the buffer itself — `TextArea` still owns every
+/// bit of actual editing (insert/delete/undo/cursor movement/selection all
+/// keep going through `editor.textarea.input(key)` unchanged in
+/// `key_handlers.rs`), it's just not used to *paint* itself anymore.
+/// `wrap_line` computes the word-wrap break points once and reuses the
+/// exact same ones both to lay out the visible text and to translate the
+/// cursor's logical (row, col) into a screen row/col, so the two can never
+/// disagree about where a wrapped line actually breaks.
 pub struct InlineEditor<'a> {
     pub textarea: TextArea<'a>,
+    /// Topmost visible *visual* (post-wrap) line, auto-following the
+    /// cursor on every render — replaces `tui-textarea`'s own private
+    /// `Viewport` scroll tracking (which only ever handled horizontal
+    /// scroll, and is bypassed along with the rest of its rendering). A
+    /// `Cell`, not a plain field, because `render` only borrows `&self` —
+    /// the same reason `tui-textarea` itself stores its `Viewport` in an
+    /// `AtomicU64` rather than a plain field: rendering can't take `&mut`.
+    scroll_top: Cell<u16>,
+    /// The cursor's screen row on the *last* render, relative to the
+    /// editor's own inner area (post-block, post-scroll) — lets `draw.rs`
+    /// anchor the `/`-menu popup right under the current line without
+    /// duplicating the wrap/scroll math `render` already does.
+    cursor_screen_row: Cell<u16>,
 }
 
 impl<'a> InlineEditor<'a> {
@@ -14,10 +58,341 @@ impl<'a> InlineEditor<'a> {
         };
         Self {
             textarea: TextArea::new(lines),
+            scroll_top: Cell::new(0),
+            cursor_screen_row: Cell::new(0),
         }
     }
 
     pub fn contents(&self) -> String {
         self.textarea.lines().join("\n")
+    }
+
+    /// The cursor's row within the editor's inner area as of the last
+    /// `render` call — see the field's own doc comment.
+    pub fn cursor_screen_row(&self) -> u16 {
+        self.cursor_screen_row.get()
+    }
+
+    /// Renders the buffer word-wrapped to `area`'s width, instead of
+    /// `tui-textarea`'s own unwrapped-with-horizontal-scroll rendering —
+    /// see the struct doc comment for why this exists at all.
+    pub fn render(&self, frame: &mut Frame, area: Rect) {
+        let inner = match self.textarea.block() {
+            Some(block) => {
+                frame.render_widget(block.clone(), area);
+                block.inner(area)
+            }
+            None => area,
+        };
+        if inner.width == 0 || inner.height == 0 {
+            return;
+        }
+        let width = inner.width as usize;
+        let height = inner.height as usize;
+
+        // Bypassing `tui-textarea`'s own `Widget` impl (see the struct doc
+        // comment) means its placeholder-when-empty behavior needs its own
+        // reimplementation too — same trigger condition as its `widget.rs`
+        // (`!placeholder.is_empty() && self.is_empty()`), reusing
+        // `wrap_line` so a long placeholder still wraps instead of running
+        // off the edge.
+        if !self.textarea.placeholder_text().is_empty() && self.textarea.is_empty() {
+            self.scroll_top.set(0);
+            self.cursor_screen_row.set(0);
+            let chars: Vec<char> = self.textarea.placeholder_text().chars().collect();
+            let style = self.textarea.placeholder_style().unwrap_or_default();
+            let lines: Vec<Line<'static>> = wrap_line(&chars, width)
+                .into_iter()
+                .map(|(s, e)| {
+                    Line::from(Span::styled(chars[s..e].iter().collect::<String>(), style))
+                })
+                .collect();
+            let paragraph = Paragraph::new(lines).style(self.textarea.style());
+            frame.render_widget(paragraph, inner);
+            return;
+        }
+
+        let source_lines = self.textarea.lines();
+        let char_rows: Vec<Vec<char>> = source_lines.iter().map(|l| l.chars().collect()).collect();
+        let wraps: Vec<Vec<(usize, usize)>> = char_rows
+            .iter()
+            .map(|chars| wrap_line(chars, width))
+            .collect();
+
+        let (cursor_row, cursor_col) = self.textarea.cursor();
+        let (cursor_local_row, _) = locate_in_wrap(&wraps[cursor_row], cursor_col);
+        let visual_offset_of: usize = wraps[..cursor_row].iter().map(Vec::len).sum();
+        let cursor_visual_row = visual_offset_of + cursor_local_row;
+        let total_visual_rows: usize = wraps.iter().map(Vec::len).sum();
+
+        let mut scroll_top = next_scroll_top(
+            self.scroll_top.get(),
+            cursor_visual_row as u16,
+            height as u16,
+        );
+        let max_scroll = total_visual_rows.saturating_sub(height) as u16;
+        scroll_top = scroll_top.min(max_scroll);
+        self.scroll_top.set(scroll_top);
+        let scroll_top = scroll_top as usize;
+        self.cursor_screen_row
+            .set((cursor_visual_row as u16).saturating_sub(scroll_top as u16));
+
+        let styles = RowStyles {
+            base: self.textarea.style(),
+            cursor: self.textarea.cursor_style(),
+            cursor_line: self.textarea.cursor_line_style(),
+            // `tui-textarea` only exposes `selection_style` via a getter
+            // that oddly takes `&mut self` (a quirk of its 0.7.0 API) and
+            // shiki never calls `set_selection_style`, so this is the same
+            // value `TextArea::default()` already uses internally.
+            select: Style::default().bg(Color::LightBlue),
+        };
+        let selection = self.textarea.selection_range();
+
+        let mut rendered: Vec<Line<'static>> = Vec::with_capacity(height);
+        let mut visual_row = 0usize;
+        'rows: for (row, chars) in char_rows.iter().enumerate() {
+            for (local_idx, &seg) in wraps[row].iter().enumerate() {
+                if visual_row >= scroll_top + height {
+                    break 'rows;
+                }
+                if visual_row >= scroll_top {
+                    let ctx = SegmentCtx {
+                        row,
+                        cursor_row,
+                        cursor_col,
+                        is_cursor_segment: row == cursor_row && local_idx == cursor_local_row,
+                        selection,
+                    };
+                    rendered.push(build_segment_line(chars, seg, &ctx, &styles));
+                }
+                visual_row += 1;
+            }
+        }
+
+        let paragraph = Paragraph::new(rendered)
+            .style(styles.base)
+            .alignment(self.textarea.alignment());
+        frame.render_widget(paragraph, inner);
+    }
+}
+
+struct RowStyles {
+    base: Style,
+    cursor: Style,
+    cursor_line: Style,
+    select: Style,
+}
+
+struct SegmentCtx {
+    row: usize,
+    cursor_row: usize,
+    cursor_col: usize,
+    /// Whether *this* wrapped segment (not just `row`) is the one
+    /// `locate_in_wrap` picked as the cursor's visual line — a row that
+    /// wraps into several segments must highlight the cursor in exactly
+    /// one of them, never zero or more than one.
+    is_cursor_segment: bool,
+    selection: Option<((usize, usize), (usize, usize))>,
+}
+
+impl SegmentCtx {
+    fn is_selected(&self, col: usize) -> bool {
+        let Some(((sr, sc), (er, ec))) = self.selection else {
+            return false;
+        };
+        if self.row < sr || self.row > er {
+            false
+        } else if sr == er {
+            col >= sc && col < ec
+        } else if self.row == sr {
+            col >= sc
+        } else if self.row == er {
+            col < ec
+        } else {
+            true
+        }
+    }
+}
+
+/// Builds one visual (already-wrapped) screen line's spans — plain runs
+/// get `cursor_line` style when `ctx.row` is the cursor's row (mirroring
+/// `tui-textarea`'s own current-line underline), individual selected
+/// characters get `select`, and the cursor's own cell gets `cursor`
+/// (a styled space past the last character when the cursor sits at the
+/// end of the line, same fallback `tui-textarea`'s `LineHighlighter` uses).
+fn build_segment_line(
+    chars: &[char],
+    (start, end): (usize, usize),
+    ctx: &SegmentCtx,
+    styles: &RowStyles,
+) -> Line<'static> {
+    let line_style = if ctx.row == ctx.cursor_row {
+        styles.cursor_line
+    } else {
+        Style::default()
+    };
+    let mut spans: Vec<Span<'static>> = Vec::new();
+    let mut plain = String::new();
+
+    for (col, &ch) in chars.iter().enumerate().take(end).skip(start) {
+        let is_cursor = ctx.is_cursor_segment && ctx.row == ctx.cursor_row && col == ctx.cursor_col;
+        if is_cursor {
+            if !plain.is_empty() {
+                spans.push(Span::styled(std::mem::take(&mut plain), line_style));
+            }
+            spans.push(Span::styled(ch.to_string(), styles.cursor));
+        } else if ctx.is_selected(col) {
+            if !plain.is_empty() {
+                spans.push(Span::styled(std::mem::take(&mut plain), line_style));
+            }
+            spans.push(Span::styled(ch.to_string(), styles.select));
+        } else {
+            plain.push(ch);
+        }
+    }
+    if !plain.is_empty() {
+        spans.push(Span::styled(plain, line_style));
+    }
+    if ctx.is_cursor_segment && ctx.row == ctx.cursor_row && ctx.cursor_col == end {
+        spans.push(Span::styled(" ", styles.cursor));
+    }
+
+    Line::from(spans)
+}
+
+/// Word-wraps `chars` to `width` columns, returning each visual sub-line's
+/// `(start, end)` char-index range (end exclusive). Computed ourselves —
+/// rather than relying on `ratatui::widgets::Paragraph`'s built-in wrap,
+/// whose exact break points aren't exposed by its public API — so the
+/// very same break points can also be used by `locate_in_wrap` to map the
+/// cursor's logical (row, col) onto the right visual row/col.
+fn wrap_line(chars: &[char], width: usize) -> Vec<(usize, usize)> {
+    let len = chars.len();
+    if len == 0 {
+        return vec![(0, 0)];
+    }
+    if width == 0 {
+        return vec![(0, len)];
+    }
+    let mut ranges = Vec::new();
+    let mut start = 0;
+    while len - start > width {
+        let limit = start + width;
+        let mut break_at = None;
+        let mut i = limit;
+        while i > start {
+            if chars[i] == ' ' {
+                break_at = Some(i);
+                break;
+            }
+            i -= 1;
+        }
+        let end = match break_at {
+            Some(pos) if pos > start => pos,
+            // No space anywhere in this width's worth of the line (one
+            // very long word) — hard-break mid-word, same as `Paragraph`'s
+            // own wrap does in that situation.
+            _ => limit,
+        };
+        ranges.push((start, end));
+        start = if chars.get(end) == Some(&' ') {
+            end + 1
+        } else {
+            end
+        };
+    }
+    ranges.push((start, len));
+    ranges
+}
+
+/// Maps a char-index `col` within a source line onto `(local visual row,
+/// visual col)` given that line's own `wrap_line` output. A `col` sitting
+/// exactly on a wrap boundary belongs to the *earlier* segment only when a
+/// space was actually dropped there (a soft break) — for a hard break
+/// (a word too long to fit, split with no space to drop) the boundary
+/// value is itself the first character of the *next* segment, so it must
+/// resolve there instead, or the cursor would visually land one segment
+/// too early.
+fn locate_in_wrap(ranges: &[(usize, usize)], col: usize) -> (usize, usize) {
+    for (i, &(s, e)) in ranges.iter().enumerate() {
+        let is_last = i + 1 == ranges.len();
+        let next_start = if is_last { e } else { ranges[i + 1].0 };
+        let boundary_is_gap = next_start > e;
+        if col < e || (col == e && (is_last || boundary_is_gap)) {
+            return (i, col - s);
+        }
+    }
+    let last = ranges.len() - 1;
+    (last, col - ranges[last].0)
+}
+
+/// Smallest vertical scroll adjustment that keeps `cursor` inside a
+/// `height`-row-tall viewport currently topped at `prev_top` — scrolls up
+/// the instant the cursor moves above it, or down the instant it moves
+/// past the bottom, and otherwise leaves the viewport exactly where it
+/// was (no re-centering on every keystroke).
+fn next_scroll_top(prev_top: u16, cursor: u16, height: u16) -> u16 {
+    if height == 0 {
+        return 0;
+    }
+    if cursor < prev_top {
+        cursor
+    } else if prev_top + height <= cursor {
+        cursor + 1 - height
+    } else {
+        prev_top
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn chars(s: &str) -> Vec<char> {
+        s.chars().collect()
+    }
+
+    #[test]
+    fn wraps_on_word_boundary() {
+        let line = chars("hello world foo");
+        let ranges = wrap_line(&line, 11);
+        assert_eq!(ranges, vec![(0, 11), (12, 15)]);
+    }
+
+    #[test]
+    fn hard_breaks_a_single_long_word() {
+        let line = chars("abcdefghijklmnopqrstu"); // 21 chars, no spaces
+        let ranges = wrap_line(&line, 5);
+        assert_eq!(ranges, vec![(0, 5), (5, 10), (10, 15), (15, 20), (20, 21)]);
+    }
+
+    #[test]
+    fn empty_line_yields_one_empty_range() {
+        assert_eq!(wrap_line(&[], 10), vec![(0, 0)]);
+    }
+
+    #[test]
+    fn locate_maps_cursor_after_a_dropped_space() {
+        // "hello world foo" wrapped at 11 -> [(0,11), (12,15)]; col 11 is
+        // the dropped space itself, so it belongs to the earlier segment.
+        let ranges = vec![(0, 11), (12, 15)];
+        assert_eq!(locate_in_wrap(&ranges, 11), (0, 11));
+        assert_eq!(locate_in_wrap(&ranges, 12), (1, 0));
+    }
+
+    #[test]
+    fn locate_maps_cursor_at_a_hard_break_boundary() {
+        // No space dropped here, so the boundary value belongs to the
+        // *next* segment (it's that segment's first real character).
+        let ranges = vec![(0, 5), (5, 10)];
+        assert_eq!(locate_in_wrap(&ranges, 5), (1, 0));
+    }
+
+    #[test]
+    fn scroll_follows_cursor_in_both_directions() {
+        assert_eq!(next_scroll_top(0, 3, 5), 0); // cursor already visible
+        assert_eq!(next_scroll_top(0, 7, 5), 3); // cursor below viewport
+        assert_eq!(next_scroll_top(4, 1, 5), 1); // cursor above viewport
     }
 }

--- a/shiki-tui/src/key_handlers.rs
+++ b/shiki-tui/src/key_handlers.rs
@@ -5,14 +5,14 @@ use shiki_core::Notebook;
 use crate::app::{
     drawer_area, global_search_layout, global_search_popup_area, is_notebook_git_action,
     looks_like_git_url, relative_folder, shift, App, BatchOp, DeleteTarget, Focus, Mode,
-    PendingInput, SelectedEntry, TrashedEntry, UpdateMsg, UpdateState, PAGE_STEP,
+    PendingInput, QuickCommand, SelectedEntry, TrashedEntry, UpdateMsg, UpdateState, PAGE_STEP,
 };
 use crate::editor::InlineEditor;
 use crate::icons;
 use crate::input::InputBox;
 use crate::keybindings::{action_label, Action};
 use crate::render::{hex_to_color, panel_block};
-use crate::{confirm, layout, panel_drawer, status_bar};
+use crate::{confirm, layout, panel_drawer, slash_menu, status_bar};
 
 impl App {
     fn open_theme_picker(&mut self) {
@@ -1029,6 +1029,32 @@ impl App {
             Err(e) => self.set_status(format!("daily note error: {e}")),
         }
     }
+    /// Every `.md` file currently in the templates dir, sorted — the raw
+    /// listing shared by `open_template_picker` (wrapped in `Option` there,
+    /// with a leading "blank") and `quick_command_options` (wrapped in
+    /// `QuickCommand::Template` there, with no "blank" — `@` typing an empty
+    /// query already shows every option, a blank-note entry has nothing
+    /// distinctive to filter towards).
+    fn template_names(&self) -> Vec<String> {
+        let Ok(dir) = Config::default_templates_dir() else {
+            return Vec::new();
+        };
+        let Ok(entries) = std::fs::read_dir(&dir) else {
+            return Vec::new();
+        };
+        let mut names: Vec<String> = entries
+            .filter_map(|e| e.ok())
+            .filter_map(|e| {
+                let path = e.path();
+                if path.extension().and_then(|s| s.to_str()) != Some("md") {
+                    return None;
+                }
+                path.file_stem().map(|s| s.to_string_lossy().to_string())
+            })
+            .collect();
+        names.sort();
+        names
+    }
     /// Opens the template picker for a note titled `title` — every `.md`
     /// file in the templates dir, plus a leading "blank" option, listed
     /// fresh each time (mirrors the tags/tree modals' "rebuild on open"
@@ -1037,25 +1063,87 @@ impl App {
     fn open_template_picker(&mut self, title: String) {
         self.pending_new_note_title = title;
         let mut options = vec![None];
-        if let Ok(dir) = Config::default_templates_dir() {
-            if let Ok(entries) = std::fs::read_dir(&dir) {
-                let mut names: Vec<String> = entries
-                    .filter_map(|e| e.ok())
-                    .filter_map(|e| {
-                        let path = e.path();
-                        if path.extension().and_then(|s| s.to_str()) != Some("md") {
-                            return None;
-                        }
-                        path.file_stem().map(|s| s.to_string_lossy().to_string())
-                    })
-                    .collect();
-                names.sort();
-                options.extend(names.into_iter().map(Some));
-            }
-        }
+        options.extend(self.template_names().into_iter().map(Some));
         self.template_picker_options = options;
         self.template_picker_index = 0;
         self.show_template_picker = true;
+    }
+    /// Full, unfiltered `@`-dropdown option list: the three relative-date
+    /// commands first (always available, don't depend on disk state), then
+    /// every real template — rebuilt on every keystroke the same way
+    /// `open_template_picker` rebuilds its own list on every open, so a
+    /// template added/removed mid-session is picked up immediately.
+    fn quick_command_options(&self) -> Vec<QuickCommand> {
+        let mut options = vec![
+            QuickCommand::Today,
+            QuickCommand::Yesterday,
+            QuickCommand::Tomorrow,
+        ];
+        options.extend(
+            self.template_names()
+                .into_iter()
+                .map(QuickCommand::Template),
+        );
+        options
+    }
+    /// The text after the *last* `@` in the `NewNote` input, if any — e.g.
+    /// `"errand @da"` yields `Some("da")`. `None` (not just an empty
+    /// string) means "no `@` typed at all yet", which is what gates the
+    /// dropdown's visibility — an empty-but-present query (`"@"` alone)
+    /// still yields `Some("")`, matching every option.
+    pub(crate) fn quick_template_query(&self) -> Option<&str> {
+        if self.pending_input != Some(PendingInput::NewNote) {
+            return None;
+        }
+        self.input.value.rsplit_once('@').map(|(_, after)| after)
+    }
+    /// `quick_command_options()` narrowed to whatever's typed after the
+    /// `@` — same case-insensitive substring match `which_key_filtered_entries`
+    /// already uses for its own typed filter.
+    pub(crate) fn quick_template_filtered(&self) -> Vec<QuickCommand> {
+        let Some(query) = self.quick_template_query() else {
+            return Vec::new();
+        };
+        let query = query.to_lowercase();
+        self.quick_command_options()
+            .into_iter()
+            .filter(|cmd| cmd.label().to_lowercase().contains(&query))
+            .collect()
+    }
+    /// Runs the chosen `@`-dropdown entry, finishing note creation right
+    /// away instead of handing off to `show_template_picker` — the title
+    /// text before the `@` becomes the note's title (for `Template`
+    /// entries; the three date commands ignore it and always use the
+    /// computed date instead, per their whole purpose).
+    fn apply_quick_template(&mut self, cmd: QuickCommand) {
+        let prefix = self
+            .input
+            .value
+            .rsplit_once('@')
+            .map(|(before, _)| before.trim().to_string())
+            .unwrap_or_default();
+        self.input.clear();
+        self.quick_template_selected = 0;
+        self.pending_input = None;
+        self.mode = Mode::Normal;
+
+        let (title, template_choice) = match &cmd {
+            QuickCommand::Today | QuickCommand::Yesterday | QuickCommand::Tomorrow => {
+                let date = cmd
+                    .date()
+                    .unwrap_or_else(|| chrono::Local::now().date_naive());
+                (date.format("%Y-%m-%d").to_string(), None)
+            }
+            QuickCommand::Template(name) => {
+                let title = if prefix.is_empty() {
+                    chrono::Local::now().format("%Y-%m-%d %H:%M").to_string()
+                } else {
+                    prefix
+                };
+                (title, Some(name.clone()))
+            }
+        };
+        self.create_note_with_template(title, template_choice);
     }
     fn handle_template_picker_key(&mut self, key: KeyEvent) {
         match key.code {
@@ -1078,9 +1166,9 @@ impl App {
             _ => {}
         }
     }
-    /// Creates the note with the chosen template's rendered body (or an
-    /// empty one, for "blank") — the actual creation `confirm_input`'s old
-    /// `NewNote` arm used to do directly, now happening here once a
+    /// Reads the picker's current selection and hands off to
+    /// `create_note_with_template` — the actual creation `confirm_input`'s
+    /// old `NewNote` arm used to do directly, now happening once a
     /// template's actually been picked instead of always being empty.
     fn confirm_template_choice(&mut self) {
         let title = std::mem::take(&mut self.pending_new_note_title);
@@ -1090,7 +1178,15 @@ impl App {
             .cloned()
             .flatten();
         self.show_template_picker = false;
-
+        self.create_note_with_template(title, template_choice);
+    }
+    /// Creates a note titled `title` in the current folder, with the given
+    /// template's rendered body (or an empty one for `None`, "blank") — the
+    /// single shared creation path for both the `show_template_picker` flow
+    /// (`confirm_template_choice`) and the `@`-dropdown fast path
+    /// (`apply_quick_template`), so the two can't drift into creating notes
+    /// differently from each other.
+    fn create_note_with_template(&mut self, title: String, template_choice: Option<String>) {
         let body = match &template_choice {
             Some(name) => Config::default_templates_dir()
                 .ok()
@@ -1143,6 +1239,16 @@ impl App {
             );
             editor.textarea.set_cursor_line_style(
                 ratatui::style::Style::default().fg(hex_to_color(&self.theme.fg)),
+            );
+            // Only ever rendered while the note is completely empty (see
+            // `InlineEditor::render`'s placeholder branch) — the `/`-menu
+            // has no other in-app hint pointing at it, so this is its one
+            // discoverability surface, gone the instant you type anything.
+            editor.textarea.set_placeholder_text(
+                "Type '/' for quick blocks (headers, code, tables, tags, frontmatter...)",
+            );
+            editor.textarea.set_placeholder_style(
+                ratatui::style::Style::default().fg(hex_to_color(&self.theme.muted)),
             );
             self.editor = Some(editor);
             self.mode = Mode::Edit;
@@ -1600,6 +1706,55 @@ impl App {
         }
     }
     fn handle_insert_key(&mut self, key: KeyEvent) {
+        // The `@`-quick-template dropdown only ever applies to the `NewNote`
+        // prompt, and only once an `@` has actually been typed — checked
+        // first so it can intercept `Up`/`Down`/`Enter` before they'd
+        // otherwise do nothing (`Up`/`Down` aren't bound at all below) or
+        // the wrong thing (a plain `Enter` would open `show_template_picker`
+        // instead of running the already-highlighted quick command).
+        if self.quick_template_query().is_some() {
+            let filtered = self.quick_template_filtered();
+            match key.code {
+                // First `Esc` only dismisses the dropdown (drops the typed
+                // `@word`) so the user can keep editing the title; a second
+                // `Esc` (now with no `@` left) falls through to cancelling
+                // the whole prompt, same as before this feature existed.
+                KeyCode::Esc => {
+                    if let Some(pos) = self.input.value.rfind('@') {
+                        self.input.value.truncate(pos);
+                    }
+                    self.quick_template_selected = 0;
+                    return;
+                }
+                KeyCode::Enter => {
+                    if let Some(cmd) = filtered.get(self.quick_template_selected).cloned() {
+                        self.apply_quick_template(cmd);
+                    }
+                    return;
+                }
+                KeyCode::Down => {
+                    if self.quick_template_selected + 1 < filtered.len() {
+                        self.quick_template_selected += 1;
+                    }
+                    return;
+                }
+                KeyCode::Up => {
+                    self.quick_template_selected = self.quick_template_selected.saturating_sub(1);
+                    return;
+                }
+                KeyCode::Backspace => {
+                    self.input.backspace();
+                    self.quick_template_selected = 0;
+                    return;
+                }
+                KeyCode::Char(c) => {
+                    self.input.push(c);
+                    self.quick_template_selected = 0;
+                    return;
+                }
+                _ => return,
+            }
+        }
         match key.code {
             KeyCode::Esc => {
                 self.pending_input = None;
@@ -1614,13 +1769,146 @@ impl App {
         }
     }
     fn handle_edit_key(&mut self, key: KeyEvent) {
+        if self.show_slash_menu {
+            self.handle_slash_menu_key(key);
+            return;
+        }
         match key.code {
             KeyCode::Esc => self.save_and_exit_edit(),
             _ => {
                 if let Some(editor) = &mut self.editor {
                     editor.textarea.input(key);
                 }
+                // `/` only opens the menu when it lands as the very first
+                // character of the line (cursor was at column 0, so it's
+                // at column 1 right after) — typing it anywhere else (a
+                // fraction, a URL, mid-sentence) is just a literal slash.
+                if key.code == KeyCode::Char('/') {
+                    let at_line_start = self
+                        .editor
+                        .as_ref()
+                        .is_some_and(|e| e.textarea.cursor().1 == 1);
+                    if at_line_start {
+                        self.slash_menu_selected = 0;
+                        self.show_slash_menu = true;
+                    }
+                }
             }
+        }
+    }
+    /// The typed filter for the `/`-menu: everything after the leading `/`
+    /// up to the cursor, read live off the editor's own buffer rather than
+    /// tracked in a separate field — the same reasoning `App.show_slash_menu`'s
+    /// doc comment gives, just for the query text instead of the open/closed
+    /// state. `None` means the menu should close (the query no longer starts
+    /// with `/`, e.g. it was backspaced away).
+    pub(crate) fn slash_query(&self) -> Option<String> {
+        if !self.show_slash_menu {
+            return None;
+        }
+        let editor = self.editor.as_ref()?;
+        let (row, col) = editor.textarea.cursor();
+        if col == 0 {
+            return None;
+        }
+        let line = editor.textarea.lines().get(row)?;
+        let chars: Vec<char> = line.chars().collect();
+        if chars.first() != Some(&'/') {
+            return None;
+        }
+        Some(chars[1..col.min(chars.len())].iter().collect())
+    }
+    /// `slash_menu::all_commands` narrowed to whatever's typed after the
+    /// `/` — same case-insensitive substring match the `@` quick-template
+    /// dropdown and which-key modal both already use for their own typed
+    /// filters.
+    pub(crate) fn slash_menu_filtered(&self) -> Vec<slash_menu::SlashCommand> {
+        let Some(query) = self.slash_query() else {
+            return Vec::new();
+        };
+        let query = query.to_lowercase();
+        slash_menu::all_commands(&self.config)
+            .into_iter()
+            .filter(|cmd| {
+                cmd.trigger.to_lowercase().contains(&query)
+                    || cmd.label.to_lowercase().contains(&query)
+            })
+            .collect()
+    }
+    fn handle_slash_menu_key(&mut self, key: KeyEvent) {
+        match key.code {
+            KeyCode::Esc => self.show_slash_menu = false,
+            KeyCode::Up => self.slash_menu_selected = self.slash_menu_selected.saturating_sub(1),
+            KeyCode::Down => {
+                let len = self.slash_menu_filtered().len();
+                if self.slash_menu_selected + 1 < len {
+                    self.slash_menu_selected += 1;
+                }
+            }
+            KeyCode::Enter => {
+                if let Some(cmd) = self
+                    .slash_menu_filtered()
+                    .get(self.slash_menu_selected)
+                    .cloned()
+                {
+                    self.show_slash_menu = false;
+                    self.apply_slash_command(&cmd);
+                }
+            }
+            KeyCode::Char(_) | KeyCode::Backspace => {
+                if let Some(editor) = &mut self.editor {
+                    editor.textarea.input(key);
+                }
+                match self.slash_query() {
+                    Some(_) => self.slash_menu_selected = 0,
+                    None => self.show_slash_menu = false,
+                }
+            }
+            _ => {}
+        }
+    }
+    /// Runs the chosen `/`-menu entry: deletes the typed `/query` (the
+    /// same range `slash_query` reads, from the start of the line up to
+    /// the cursor — `delete_line_by_head` is exactly that operation) and
+    /// inserts the command's body in its place, after substituting
+    /// `{{title}}`/`{{date}}` the same way note templates are rendered.
+    /// A `{{cursor}}` marker in the body is resolved to an absolute
+    /// `CursorMove::Jump` afterward instead of being inserted literally.
+    fn apply_slash_command(&mut self, cmd: &slash_menu::SlashCommand) {
+        let title = self
+            .selected_note()
+            .map(|n| n.frontmatter.title.clone())
+            .unwrap_or_default();
+        let mut vars = std::collections::HashMap::new();
+        vars.insert("title", title);
+        vars.insert("date", chrono::Local::now().format("%Y-%m-%d").to_string());
+        let rendered = shiki_core::Template {
+            name: String::new(),
+            contents: cmd.body.clone(),
+        }
+        .render(&vars);
+
+        let (before, cursor_marker) = match rendered.split_once("{{cursor}}") {
+            Some((before, after)) => (before.to_string(), Some(after.to_string())),
+            None => (rendered, None),
+        };
+
+        let Some(editor) = &mut self.editor else {
+            return;
+        };
+        let (insert_row, _) = editor.textarea.cursor();
+        editor.textarea.delete_line_by_head();
+        match &cursor_marker {
+            Some(after) => editor.textarea.insert_str(format!("{before}{after}")),
+            None => editor.textarea.insert_str(&before),
+        };
+        if cursor_marker.is_some() {
+            let target_row = insert_row + before.matches('\n').count();
+            let target_col = before.rsplit('\n').next().unwrap_or("").chars().count();
+            editor.textarea.move_cursor(tui_textarea::CursorMove::Jump(
+                target_row as u16,
+                target_col as u16,
+            ));
         }
     }
     fn handle_normal_key(&mut self, key: KeyEvent) {

--- a/shiki-tui/src/lib.rs
+++ b/shiki-tui/src/lib.rs
@@ -16,6 +16,7 @@ pub mod panel_notes;
 pub mod panel_preview;
 pub mod panel_tags;
 pub mod render;
+pub mod slash_menu;
 pub mod status_bar;
 pub(crate) mod sync;
 pub mod tree;

--- a/shiki-tui/src/slash_menu.rs
+++ b/shiki-tui/src/slash_menu.rs
@@ -1,0 +1,118 @@
+use shiki_config::Config;
+
+/// One entry in the inline editor's `/`-menu — either one of `builtins()`
+/// or a `[[snippets]]` entry from `config.toml` (`Config::snippets`, see
+/// `shiki_config::config::SnippetConfig` for the on-disk shape).
+#[derive(Debug, Clone)]
+pub struct SlashCommand {
+    pub trigger: String,
+    pub label: String,
+    /// `{{title}}`/`{{date}}` are substituted the same way note templates
+    /// are (`shiki_core::Template::render` — `App::apply_slash_command`
+    /// reuses it directly). A literal `{{cursor}}` marks where the cursor
+    /// should land after insertion; it's resolved separately and never
+    /// ends up in the actually-inserted text. Omit it to leave the cursor
+    /// at the end of the snippet, which is already correct for anything
+    /// that's just one line with nothing to fill in (`h1`, `divider`).
+    pub body: String,
+}
+
+fn builtin(trigger: &str, label: &str, body: &str) -> SlashCommand {
+    SlashCommand {
+        trigger: trigger.to_string(),
+        label: label.to_string(),
+        body: body.to_string(),
+    }
+}
+
+/// The commands every install starts with — deliberately not persisted to
+/// `config.toml` (unlike templates, which `ensure_defaults` writes to
+/// disk): there's nothing to customize by hand-editing a file here unless
+/// a user actually wants to, so nothing is written until they add their
+/// own `[[snippets]]` entry.
+pub fn builtins() -> Vec<SlashCommand> {
+    vec![
+        builtin("h1", "Heading 1", "# {{cursor}}"),
+        builtin("h2", "Heading 2", "## {{cursor}}"),
+        builtin("h3", "Heading 3", "### {{cursor}}"),
+        builtin("code", "Code block", "```\n{{cursor}}\n```"),
+        builtin("math", "Math block", "$$\n{{cursor}}\n$$"),
+        builtin(
+            "table",
+            "Table",
+            "| Column | Column |\n| --- | --- |\n| {{cursor}} |  |\n",
+        ),
+        builtin("check", "Checklist item", "- [ ] {{cursor}}"),
+        builtin("quote", "Quote", "> {{cursor}}"),
+        builtin("divider", "Divider", "---\n"),
+        builtin("date", "Today's date", "{{date}}"),
+        builtin("tags", "Tags line", "Tags: {{cursor}}"),
+        builtin(
+            "frontmatter",
+            "YAML frontmatter block",
+            "---\ntitle: {{title}}\ndate: {{date}}\ntags: []\n---\n{{cursor}}",
+        ),
+    ]
+}
+
+/// The full `/`-menu list: built-ins, with any `config.toml`
+/// `[snippets.<trigger>]` entry of the same trigger (case-insensitive)
+/// overriding it in place — so a user can redefine `code` or `h1` just as
+/// easily as add a brand new command — otherwise appended after the
+/// built-ins.
+pub fn all_commands(config: &Config) -> Vec<SlashCommand> {
+    let mut commands = builtins();
+    for (trigger, custom) in &config.snippets {
+        let entry = SlashCommand {
+            trigger: trigger.clone(),
+            label: custom.label.clone().unwrap_or_else(|| trigger.clone()),
+            body: custom.body.clone(),
+        };
+        match commands
+            .iter_mut()
+            .find(|c| c.trigger.eq_ignore_ascii_case(&entry.trigger))
+        {
+            Some(existing) => *existing = entry,
+            None => commands.push(entry),
+        }
+    }
+    commands
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use shiki_config::config::SnippetConfig;
+
+    #[test]
+    fn custom_snippet_is_appended() {
+        let mut config = Config::default();
+        config.snippets.insert(
+            "note".to_string(),
+            SnippetConfig {
+                label: Some("Callout".to_string()),
+                body: "> {{cursor}}".to_string(),
+            },
+        );
+        let commands = all_commands(&config);
+        assert_eq!(commands.len(), builtins().len() + 1);
+        assert!(commands.iter().any(|c| c.trigger == "note"));
+    }
+
+    #[test]
+    fn custom_snippet_overrides_a_builtin_case_insensitively() {
+        let mut config = Config::default();
+        config.snippets.insert(
+            "H1".to_string(),
+            SnippetConfig {
+                label: None,
+                body: "# custom {{cursor}}".to_string(),
+            },
+        );
+        let commands = all_commands(&config);
+        assert_eq!(commands.len(), builtins().len());
+        let h1 = commands.iter().find(|c| c.trigger == "H1").unwrap();
+        assert_eq!(h1.body, "# custom {{cursor}}");
+        assert_eq!(h1.label, "H1");
+    }
+}


### PR DESCRIPTION
## Summary

- Inline editor now word-wraps long lines instead of scrolling them off-screen horizontally (`tui-textarea` has no wrap support in any published version, so rendering is now done by hand, reusing the same wrap math for cursor placement).
- New `/`-menu in the inline editor: typing `/` at the start of a line opens a searchable palette of ready-to-insert blocks (headers, code, math, table, checklist, quote, divider, date, tags, frontmatter), fully customizable/overridable via `[snippets.<trigger>]` in `config.toml`.
- New `@` quick-command dropdown in the "New note" title prompt: `today`/`yesterday`/`tomorrow` plus any template, fuzzy-filtered, skipping the normal title → Enter → pick-a-template flow.
- 9 new note templates (`bug`, `spec`, `review`, `postmortem`, `standup`, `retro`, `1on1`, `weekly`, `brainstorm`) alongside the existing `default`/`daily`/`meeting`.
- A dim placeholder in the empty inline editor and an updated "New note" prompt title point at the two new entry points so they're discoverable without reading the docs.
- `IDEA.md`, `docs/documentation.html`, and `docs/index.html`'s JSON-LD version updated to match.
- Version bumped to `0.8.3` (patch), `CHANGELOG.md` updated.
- Also carries this branch's earlier scratch commits validating a draft nixpkgs `package.nix` (`.github/workflows/nix-package-check.yml`, `nix/shiki-package-*.nix`) — already green on this branch, and the workflow only triggers on `workflow_dispatch` or pushes to a branch literally named `nix-package-check`, so it's inert once on `main`.

## Notes for merging

- Merging this **will** redeploy the docs site (`pages.yml` triggers on any push to `main` touching `docs/**`), so the new `/`-menu and `@`-dropdown docs go live immediately.
- Merging this will **not** trigger a release — no commit here contains `[PUBLISH]`, which `auto-tag.yml` requires before it tags/publishes anything. Say the word separately if/when you want this version actually released to crates.io/AUR/Scoop.

## Test plan

- [x] `cargo fmt --all`, `cargo clippy --workspace --all-targets` clean
- [x] `cargo test --workspace` passing (27 tests)
- [x] Verified live in tmux: text wrap + cursor + scroll in the editor, `/`-menu (built-ins, config override, `{{cursor}}`/`{{title}}` substitution, Esc-once-vs-twice), `@` dropdown (today/yesterday/tomorrow + templates), all 12 templates generated and selectable, empty-editor placeholder
- [x] `Nix package check` CI green on this branch (both the local-src and fetchFromGitHub draft builds)

🤖 Generated with [Claude Code](https://claude.com/claude-code)