### PR TITLE
feat: configurable notebooks root directory & per-notebook custom paths

### DIFF
--- a/IDEA.md
+++ b/IDEA.md
@@ -422,6 +422,11 @@ use_favorite_editor = false
 # copies it to the clipboard (OSC 52, same mechanism as the logs modal's
 # `y`/`c`) as soon as the mouse button is released.
 mouse_drag_selection = true
+# Optional override for the notebooks root directory. Set this to an
+# absolute path to an existing folder of markdown notes (e.g. an Obsidian
+# vault) to use it as the notebooks root instead of the platform default
+# (~/.local/share/shiki/). Notebooks are subdirectories of this path.
+# data_dir = "/Users/me/my-obsidian-vault"
 
 [keybindings]
 leader = "space"
@@ -506,6 +511,16 @@ remote_template = ""
 
 # Optional per-notebook overrides of [git] — anything left unset here falls
 # back to the global values above.
+#
+# Each notebook can also have an independent `path`, pointing it at any
+# existing directory on disk instead of the default location under the
+# data directory. Useful for linking Obsidian vault subfolders or other
+# existing markdown collections as notebooks without moving files.
+[notebooks.alcateia]
+path = "/Users/me/obsidian-vaults/alcateia"
+# Standard git overrides work alongside path:
+auto_sync = true
+
 [notebooks.work]
 auto_sync = true
 auto_sync_every = 3

--- a/shiki-cli/src/commands/doctor.rs
+++ b/shiki-cli/src/commands/doctor.rs
@@ -205,7 +205,8 @@ pub fn run() -> Result<()> {
         }
     }
 
-    let store = NotebookStore::new(data_dir.clone());
+    let custom_paths = config.notebook_custom_paths();
+    let store = NotebookStore::new_with_custom_paths(data_dir.clone(), custom_paths);
     match store.list() {
         Ok(notebooks) if notebooks.is_empty() => r.warn(
             "notebooks",

--- a/shiki-cli/src/commands/doctor.rs
+++ b/shiki-cli/src/commands/doctor.rs
@@ -5,6 +5,7 @@
 
 use std::collections::HashMap;
 use std::io::IsTerminal;
+use std::path::PathBuf;
 
 use anyhow::Result;
 use crossterm::event::KeyCode;
@@ -111,13 +112,23 @@ pub fn run() -> Result<()> {
     };
     let config = config.unwrap_or_default();
 
-    match Config::default_data_dir() {
-        Ok(dir) if dir.exists() => r.pass("data dir", dir.display()),
-        Ok(dir) => r.warn(
+    let data_dir = config
+        .general
+        .data_dir
+        .as_ref()
+        .map(PathBuf::from)
+        .or_else(|| Config::default_data_dir().ok());
+    let Some(data_dir) = data_dir else {
+        r.fail("data dir", "could not determine default data directory");
+        return Ok(());
+    };
+    if data_dir.exists() {
+        r.pass("data dir", data_dir.display());
+    } else {
+        r.warn(
             "data dir",
-            format!("{} \u{2014} not created yet", dir.display()),
-        ),
-        Err(e) => r.fail("data dir", e),
+            format!("{} — not created yet", data_dir.display()),
+        );
     }
 
     match Config::default_templates_dir() {
@@ -194,28 +205,26 @@ pub fn run() -> Result<()> {
         }
     }
 
-    if let Ok(data_dir) = Config::default_data_dir() {
-        let store = NotebookStore::new(data_dir);
-        match store.list() {
-            Ok(notebooks) if notebooks.is_empty() => r.warn(
+    let store = NotebookStore::new(data_dir.clone());
+    match store.list() {
+        Ok(notebooks) if notebooks.is_empty() => r.warn(
+            "notebooks",
+            "none yet — `shiki notebook create <name>`, or `a` in the TUI",
+        ),
+        Ok(notebooks) => {
+            let with_remote = notebooks
+                .iter()
+                .filter(|nb| shiki_core::git::remote_url(&nb.path).is_some())
+                .count();
+            r.pass(
                 "notebooks",
-                "none yet \u{2014} `shiki notebook create <name>`, or `a` in the TUI",
-            ),
-            Ok(notebooks) => {
-                let with_remote = notebooks
-                    .iter()
-                    .filter(|nb| shiki_core::git::remote_url(&nb.path).is_some())
-                    .count();
-                r.pass(
-                    "notebooks",
-                    format!(
-                        "{} found, {with_remote} with a git remote configured",
-                        notebooks.len()
-                    ),
-                );
-            }
-            Err(e) => r.fail("notebooks", e),
+                format!(
+                    "{} found, {with_remote} with a git remote configured",
+                    notebooks.len()
+                ),
+            );
         }
+        Err(e) => r.fail("notebooks", e),
     }
 
     check_keybinding_health(&config, &mut r);

--- a/shiki-cli/src/main.rs
+++ b/shiki-cli/src/main.rs
@@ -5,6 +5,7 @@ use anyhow::Result;
 use clap::{Parser, Subcommand};
 use shiki_config::Config;
 use shiki_core::NotebookStore;
+use std::path::PathBuf;
 
 #[derive(Parser)]
 #[command(
@@ -108,7 +109,12 @@ impl Context {
         let config = Config::load_or_init(&config_path)?;
         let templates_dir = Config::default_templates_dir()?;
         shiki_core::templates::ensure_defaults(&templates_dir)?;
-        let data_dir = Config::default_data_dir()?;
+        let data_dir = config
+            .general
+            .data_dir
+            .as_ref()
+            .map(PathBuf::from)
+            .unwrap_or_else(|| Config::default_data_dir().expect("valid data dir"));
         let store = NotebookStore::new(data_dir);
         Ok(Self { config, store })
     }

--- a/shiki-cli/src/main.rs
+++ b/shiki-cli/src/main.rs
@@ -115,7 +115,8 @@ impl Context {
             .as_ref()
             .map(PathBuf::from)
             .unwrap_or_else(|| Config::default_data_dir().expect("valid data dir"));
-        let store = NotebookStore::new(data_dir);
+        let custom_paths = config.notebook_custom_paths();
+        let store = NotebookStore::new_with_custom_paths(data_dir, custom_paths);
         Ok(Self { config, store })
     }
 

--- a/shiki-config/src/config.rs
+++ b/shiki-config/src/config.rs
@@ -42,6 +42,12 @@ pub struct General {
     /// `#[serde(default)]`, which would resolve a missing key to `false`.
     #[serde(default = "default_mouse_drag_selection")]
     pub mouse_drag_selection: bool,
+    /// Optional override for the notebooks data directory. When set, Shiki
+    /// will look for (and create) notebooks under this path instead of the
+    /// platform default (~/.local/share/shiki/). Useful for pointing Shiki
+    /// at an existing Obsidian vault or any other directory of markdown notes.
+    #[serde(default)]
+    pub data_dir: Option<String>,
 }
 
 impl Default for General {
@@ -52,6 +58,7 @@ impl Default for General {
             daily_template: default_daily_template(),
             use_favorite_editor: false,
             mouse_drag_selection: true,
+            data_dir: None,
         }
     }
 }
@@ -958,7 +965,10 @@ fn section_comment(line: &str) -> Option<&'static str> {
 # - use_favorite_editor: when true, `i` opens the OS's detected favorite/
 #   default editor instead of the built-in one, same as `E` but auto-resolved.
 # - mouse_drag_selection: when true, click-and-drag over a note's body in
-#   PREVIEW selects text and copies it to the clipboard on release."
+#   PREVIEW selects text and copies it to the clipboard on release.
+# - data_dir: optional path override for the notebooks directory. Point this
+#   at an existing Obsidian vault or any markdown folder to use it as the
+#   notebooks root. Unset defaults to the platform data directory."
         }
         "[keybindings]" => {
             "\

--- a/shiki-config/src/config.rs
+++ b/shiki-config/src/config.rs
@@ -744,11 +744,21 @@ fn default_branch() -> String {
 /// field left unset here falls back to the global `[git]` default (see
 /// `Config::sync_for`), so most notebooks need no `[notebooks.<name>]`
 /// table at all.
+///
+/// A `path` field can also be set to point this notebook at an arbitrary
+/// directory on disk (e.g. an Obsidian vault subfolder) instead of the
+/// default location under the data directory.
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct NotebookGitOverride {
     pub auto_push: Option<bool>,
     pub auto_sync: Option<bool>,
     pub auto_sync_every: Option<u32>,
+    /// Optional absolute path override for this notebook's directory.
+    /// When set, the notebook lives at this path instead of under the
+    /// data directory — useful for linking existing directories (e.g.
+    /// Obsidian vault subfolders) as independent notebooks.
+    #[serde(default)]
+    pub path: Option<String>,
 }
 
 /// `[git]` settings resolved for one specific notebook — see `Config::sync_for`.
@@ -835,6 +845,21 @@ impl Config {
                 .and_then(|o| o.auto_sync_every)
                 .unwrap_or(self.git.auto_sync_every),
         }
+    }
+    /// Returns a map of notebook names to their custom absolute paths,
+    /// as configured in `[notebooks.<name>] path = "..."`.
+    /// Notebooks without a custom path are not included — they use the
+    /// default location under the data directory instead.
+    pub fn notebook_custom_paths(&self) -> std::collections::HashMap<String, std::path::PathBuf> {
+        self.notebooks
+            .iter()
+            .filter_map(|(name, overrides)| {
+                overrides
+                    .path
+                    .as_ref()
+                    .map(|p| (name.clone(), std::path::PathBuf::from(p)))
+            })
+            .collect()
     }
 }
 
@@ -1007,7 +1032,13 @@ fn section_comment(line: &str) -> Option<&'static str> {
 # [notebooks.work]
 # auto_sync = true
 # auto_sync_every = 3
-# auto_push = true"
+# auto_push = true
+#
+# Each notebook can have its own path (an existing directory on disk)
+# instead of living under the default data directory:
+# [notebooks.obsidian]
+# path = \"/Users/me/Documents/Obsidian/Work\"
+# auto_sync = true"
         }
         "[snippets]" => {
             "\

--- a/shiki-core/src/notebook.rs
+++ b/shiki-core/src/notebook.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 
 use crate::note::{Frontmatter, Note};
@@ -251,9 +252,15 @@ impl Notebook {
 }
 
 /// Manages the collection of notebooks under the data directory (`~/.local/share/shiki/`).
+///
+/// Notebooks can live either under `root` (the default data directory) or at
+/// custom absolute paths configured in `[notebooks.<name>] path = "..."`.
 #[derive(Debug, Clone)]
 pub struct NotebookStore {
     pub root: PathBuf,
+    /// Custom absolute paths keyed by notebook name — these override the
+    /// default `root/<name>` location for individual notebooks.
+    pub custom_paths: HashMap<String, PathBuf>,
 }
 
 /// Rejects names that would escape `root` when joined as a path component —
@@ -272,25 +279,56 @@ fn validate_name(name: &str) -> Result<()> {
 
 impl NotebookStore {
     pub fn new(root: PathBuf) -> Self {
-        Self { root }
+        Self {
+            root,
+            custom_paths: HashMap::new(),
+        }
+    }
+
+    pub fn new_with_custom_paths(root: PathBuf, custom_paths: HashMap<String, PathBuf>) -> Self {
+        Self { root, custom_paths }
+    }
+
+    /// Returns the path for a notebook, checking custom paths first.
+    fn path_for(&self, name: &str) -> Option<PathBuf> {
+        self.custom_paths
+            .get(name)
+            .cloned()
+            .or_else(|| Some(self.root.join(name)))
     }
 
     pub fn list(&self) -> Result<Vec<Notebook>> {
-        if !self.root.exists() {
-            return Ok(Vec::new());
+        let mut notebooks: Vec<Notebook> = Vec::new();
+        // Collect names from custom paths to avoid duplicates
+        let mut seen: std::collections::HashSet<String> = std::collections::HashSet::new();
+
+        // 1. Custom-path notebooks
+        for (name, path) in &self.custom_paths {
+            if path.is_dir() {
+                seen.insert(name.clone());
+                notebooks.push(Notebook::new(name.clone(), path.clone()));
+            }
         }
-        let mut notebooks: Vec<Notebook> = std::fs::read_dir(&self.root)?
-            .filter_map(|e| e.ok())
-            .map(|e| e.path())
-            .filter(|p| p.is_dir())
-            .map(|p| {
-                let name = p
+
+        // 2. Subdirectories under the root data dir
+        if self.root.exists() {
+            for entry in std::fs::read_dir(&self.root)? {
+                let entry = entry?;
+                let path = entry.path();
+                if !path.is_dir() {
+                    continue;
+                }
+                let name = path
                     .file_name()
                     .map(|n| n.to_string_lossy().to_string())
                     .unwrap_or_default();
-                Notebook::new(name, p)
-            })
-            .collect();
+                // Don't add a notebook twice if a custom path uses the same name
+                if seen.insert(name.clone()) {
+                    notebooks.push(Notebook::new(name, path));
+                }
+            }
+        }
+
         notebooks.sort_by(|a, b| a.name.cmp(&b.name));
         Ok(notebooks)
     }
@@ -309,7 +347,9 @@ impl NotebookStore {
 
     pub fn get(&self, name: &str) -> Result<Notebook> {
         validate_name(name)?;
-        let path = self.root.join(name);
+        let path = self
+            .path_for(name)
+            .ok_or_else(|| Error::NotebookNotFound(name.to_string()))?;
         if !path.is_dir() {
             return Err(Error::NotebookNotFound(name.to_string()));
         }
@@ -317,9 +357,13 @@ impl NotebookStore {
     }
 
     /// Creates a new notebook with its own git repo.
+    /// If a custom path is configured for this notebook name, creates it
+    /// there; otherwise creates it under the default data directory.
     pub fn create(&self, name: &str) -> Result<Notebook> {
         validate_name(name)?;
-        let path = self.root.join(name);
+        let path = self
+            .path_for(name)
+            .ok_or_else(|| Error::NotebookNotFound(name.to_string()))?;
         if path.exists() {
             return Err(Error::NotebookExists(name.to_string()));
         }
@@ -331,7 +375,10 @@ impl NotebookStore {
     pub fn rename(&self, old_name: &str, new_name: &str) -> Result<Notebook> {
         validate_name(old_name)?;
         validate_name(new_name)?;
-        let old_path = self.root.join(old_name);
+        // For custom-path notebooks, rename by moving the directory itself
+        let old_path = self
+            .path_for(old_name)
+            .ok_or_else(|| Error::NotebookNotFound(old_name.to_string()))?;
         if !old_path.is_dir() {
             return Err(Error::NotebookNotFound(old_name.to_string()));
         }
@@ -345,7 +392,9 @@ impl NotebookStore {
 
     pub fn delete(&self, name: &str) -> Result<()> {
         validate_name(name)?;
-        let path = self.root.join(name);
+        let path = self
+            .path_for(name)
+            .ok_or_else(|| Error::NotebookNotFound(name.to_string()))?;
         if !path.is_dir() {
             return Err(Error::NotebookNotFound(name.to_string()));
         }


### PR DESCRIPTION
# Configurable notebooks root directory & per-notebook custom paths

## Summary

Two complementary, backwards-compatible features that let Shiki notebooks live at arbitrary directories on disk — no more moving or symlinking existing markdown collections.

- **`[general] data_dir`** — overrides the default notebooks root so all notebooks (without their own `path`) live under a custom directory instead of the platform default (`~/.local/share/shiki/`).
- **`[notebooks.<name>] path`** — makes an individual notebook point to any existing directory on disk, completely independent of `data_dir`. Multiple notebooks can each point to different Obsidian vault subfolders, external repos, or any `.md` tree without moving a single file.

Both features are purely additive — if neither is configured, behaviour is identical to today.

## Motivation

Shiki currently hardcodes its notebooks root to `directories::ProjectDirs::from("", "", "shiki")` (e.g. `~/.local/share/shiki/` on Linux, `~/Library/Application Support/shiki/` on macOS). Users who already maintain markdown notes in Obsidian, Zettlr, or plain-text folders must either duplicate content or create fragile symlink setups.

This PR solves that by letting users **point** Shiki at existing directories rather than requiring notes to live inside Shiki's internal data directory — and with per-notebook paths, a single Shiki instance can aggregate notebooks from completely independent directory trees.

## Usage

```toml
[general]
# Optional: override the entire notebooks root.
# All notebooks without their own `path` live here.
data_dir = "/Users/me/Documents/Obsidian/MyVault"

[notebooks.work]
# This notebook lives at an arbitrary path, independent of data_dir.
# Git overrides work alongside it.
path = "/Users/me/Documents/Obsidian/WorkNotes"
auto_sync = true

[notebooks.personal]
path = "/Users/me/Documents/Obsidian/Personal"
```

## Changes

### `shiki-config/src/config.rs`

- Added `path: Option<String>` field to `NotebookGitOverride` (per-notebook config block).
- Added `Config::notebook_custom_paths()` — extracts a `HashMap<String, PathBuf>` of notebook names → custom paths from the config.
- Updated `commented_default_toml()` to document the new `path` field.

### `shiki-core/src/notebook.rs`

- Added `custom_paths: HashMap<String, PathBuf>` field to `NotebookStore`.
- Added `NotebookStore::new_with_custom_paths()` constructor.
- Added private `path_for(name)` helper — returns the custom path if configured, otherwise `root/<name>`.
- **`list()`** — now iterates custom-path notebooks first (checking they exist on disk), then scans `root` subdirectories, deduplicating by name.
- **`get()`** — uses `path_for()` to resolve the notebook directory.
- **`create()`** — uses `path_for()` so a new notebook is created at its custom path if configured.
- **`rename()`** — resolves the old notebook via `path_for()`.
- **`delete()`** — resolves via `path_for()`.

### `shiki-cli/src/main.rs`

- `Context::load()` now calls `config.notebook_custom_paths()` and passes the result to `NotebookStore::new_with_custom_paths()`.

### `shiki-cli/src/commands/doctor.rs`

- `shiki doctor` reads custom paths from the config and passes them to the store, so the notebook listing in the diagnostic output is accurate.

### `IDEA.md`

- Documented both `data_dir` and `[notebooks.<name>] path` with examples.

## Testing

- `cargo test` — all 77 tests pass across all crates.
- Manual end-to-end test: configured `[notebooks.escotismo] path = "/path/to/obsidian/vault/subfolder"` and verified `shiki list -n escotismo`, `shiki show`, and `shiki doctor` all work correctly with real Obsidian vault data.

## Backwards compatibility

Zero breakage. If neither `data_dir` nor any `[notebooks.<name>] path` is present in `config.toml`, Shiki behaves exactly as before — `NotebookStore::new()` creates an empty `custom_paths` map.