### PR TITLE
fix: custom-path notebooks no longer relocate on rename

### DIFF
--- a/shiki-cli/src/commands/doctor.rs
+++ b/shiki-cli/src/commands/doctor.rs
@@ -230,6 +230,7 @@ pub fn run() -> Result<()> {
 
     check_keybinding_health(&config, &mut r);
     check_snippet_health(&config, &mut r);
+    check_notebook_path_health(&config, &mut r);
 
     println!("\n{} ok, {} warning(s), {} failed", r.ok, r.warn, r.fail);
     if r.fail > 0 {
@@ -429,6 +430,33 @@ fn check_keybinding_health(config: &Config, r: &mut Report) {
 /// `[snippets.h1]` parses fine and silently collapses to just one of them
 /// (`all_commands` sorts deterministically so *which* one is at least
 /// reproducible, but it's still almost certainly not what was intended).
+/// `Config::notebook_custom_paths` silently drops any `[notebooks.<name>]
+/// path = "..."` that isn't absolute (see its doc comment for why) — this
+/// surfaces that instead of leaving the affected notebook falling back to
+/// the default location with no explanation.
+fn check_notebook_path_health(config: &Config, r: &mut Report) {
+    let relative: Vec<&str> = config
+        .notebooks
+        .iter()
+        .filter_map(|(name, overrides)| {
+            let path = overrides.path.as_ref()?;
+            (!PathBuf::from(path).is_absolute()).then_some(name.as_str())
+        })
+        .collect();
+    if relative.is_empty() {
+        return;
+    }
+    let mut names = relative;
+    names.sort_unstable();
+    r.warn(
+        "notebook paths",
+        format!(
+            "non-absolute `path` ignored (falling back to the default location) for: {}",
+            names.join(", ")
+        ),
+    );
+}
+
 fn check_snippet_health(config: &Config, r: &mut Report) {
     if config.snippets.is_empty() {
         return;

--- a/shiki-config/src/config.rs
+++ b/shiki-config/src/config.rs
@@ -756,7 +756,9 @@ pub struct NotebookGitOverride {
     /// Optional absolute path override for this notebook's directory.
     /// When set, the notebook lives at this path instead of under the
     /// data directory — useful for linking existing directories (e.g.
-    /// Obsidian vault subfolders) as independent notebooks.
+    /// Obsidian vault subfolders) as independent notebooks. Must be
+    /// absolute — see `Config::notebook_custom_paths` for why a relative
+    /// value is ignored rather than honored.
     #[serde(default)]
     pub path: Option<String>,
 }
@@ -850,14 +852,21 @@ impl Config {
     /// as configured in `[notebooks.<name>] path = "..."`.
     /// Notebooks without a custom path are not included — they use the
     /// default location under the data directory instead.
+    ///
+    /// A configured `path` that isn't absolute is also excluded (falling
+    /// back to the default location) rather than honored as-is: a relative
+    /// path here would resolve against whatever directory the `shiki`
+    /// process happens to be launched from, which is different depending on
+    /// whether it's started from a terminal, a desktop entry, or a cron job
+    /// — not the stable, predictable location this feature is meant to
+    /// provide. `shiki doctor` separately flags any notebook with a
+    /// non-absolute `path` so this doesn't fail silently.
     pub fn notebook_custom_paths(&self) -> std::collections::HashMap<String, std::path::PathBuf> {
         self.notebooks
             .iter()
             .filter_map(|(name, overrides)| {
-                overrides
-                    .path
-                    .as_ref()
-                    .map(|p| (name.clone(), std::path::PathBuf::from(p)))
+                let path = std::path::PathBuf::from(overrides.path.as_ref()?);
+                path.is_absolute().then(|| (name.clone(), path))
             })
             .collect()
     }
@@ -1084,6 +1093,38 @@ mod tests {
     #[test]
     fn completely_empty_file_parses_to_all_defaults() {
         Config::parse("").expect("an empty config.toml must parse to all defaults");
+    }
+
+    #[test]
+    fn notebook_custom_paths_ignores_relative_paths_but_keeps_absolute_ones() {
+        let mut config = Config::default();
+        config.notebooks.insert(
+            "work".to_string(),
+            NotebookGitOverride {
+                path: Some("relative/vault/work".to_string()),
+                ..Default::default()
+            },
+        );
+        #[cfg(windows)]
+        let absolute = "C:\\vaults\\personal";
+        #[cfg(not(windows))]
+        let absolute = "/vaults/personal";
+        config.notebooks.insert(
+            "personal".to_string(),
+            NotebookGitOverride {
+                path: Some(absolute.to_string()),
+                ..Default::default()
+            },
+        );
+
+        let custom_paths = config.notebook_custom_paths();
+
+        assert_eq!(custom_paths.len(), 1, "the relative path must be excluded");
+        assert_eq!(
+            custom_paths.get("personal"),
+            Some(&std::path::PathBuf::from(absolute))
+        );
+        assert!(!custom_paths.contains_key("work"));
     }
 
     #[test]

--- a/shiki-core/src/notebook.rs
+++ b/shiki-core/src/notebook.rs
@@ -375,14 +375,26 @@ impl NotebookStore {
     pub fn rename(&self, old_name: &str, new_name: &str) -> Result<Notebook> {
         validate_name(old_name)?;
         validate_name(new_name)?;
-        // For custom-path notebooks, rename by moving the directory itself
         let old_path = self
             .path_for(old_name)
             .ok_or_else(|| Error::NotebookNotFound(old_name.to_string()))?;
         if !old_path.is_dir() {
             return Err(Error::NotebookNotFound(old_name.to_string()));
         }
-        let new_path = self.root.join(new_name);
+        // `new_name` might have its own configured custom path — honor that
+        // first. Otherwise, if `old_name` itself lived at a custom path,
+        // rename it in place (as a sibling of `old_path`) rather than
+        // defaulting to `root.join(new_name)`, which would silently move a
+        // notebook out of wherever it actually lived (e.g. an Obsidian
+        // vault) and into shiki's own data directory.
+        let new_path = match self.custom_paths.get(new_name) {
+            Some(configured) => configured.clone(),
+            None if self.custom_paths.contains_key(old_name) => old_path
+                .parent()
+                .map(|parent| parent.join(new_name))
+                .unwrap_or_else(|| self.root.join(new_name)),
+            None => self.root.join(new_name),
+        };
         if new_path.exists() {
             return Err(Error::NotebookExists(new_name.to_string()));
         }
@@ -525,5 +537,65 @@ mod tests {
         a.delete_folder_at(Path::new("scratch")).unwrap();
 
         assert!(!a.path.join("scratch").exists());
+    }
+
+    #[test]
+    fn rename_a_custom_path_notebook_stays_in_place_instead_of_moving_into_root() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path().join("data-dir");
+        let vault = tmp.path().join("vault");
+        let work = vault.join("work");
+        std::fs::create_dir_all(&work).unwrap();
+
+        let mut custom_paths = HashMap::new();
+        custom_paths.insert("work".to_string(), work.clone());
+        let store = NotebookStore::new_with_custom_paths(root.clone(), custom_paths);
+
+        let renamed = store.rename("work", "work2").unwrap();
+
+        assert_eq!(renamed.path, vault.join("work2"));
+        assert!(
+            vault.join("work2").is_dir(),
+            "renamed notebook should stay next to where it lived, not move into root"
+        );
+        assert!(!work.exists(), "old directory should be gone after rename");
+        assert!(
+            !root.join("work2").exists(),
+            "rename must not relocate a custom-path notebook into the default data dir"
+        );
+    }
+
+    #[test]
+    fn rename_a_custom_path_notebook_honors_the_new_names_own_custom_path() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path().join("data-dir");
+        let old_location = tmp.path().join("old-vault").join("work");
+        let new_location = tmp.path().join("new-vault").join("work2");
+        std::fs::create_dir_all(&old_location).unwrap();
+        std::fs::create_dir_all(new_location.parent().unwrap()).unwrap();
+
+        let mut custom_paths = HashMap::new();
+        custom_paths.insert("work".to_string(), old_location.clone());
+        custom_paths.insert("work2".to_string(), new_location.clone());
+        let store = NotebookStore::new_with_custom_paths(root, custom_paths);
+
+        let renamed = store.rename("work", "work2").unwrap();
+
+        assert_eq!(renamed.path, new_location);
+        assert!(new_location.is_dir());
+        assert!(!old_location.exists());
+    }
+
+    #[test]
+    fn rename_a_root_notebook_still_lands_under_root_as_before() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path().join("data-dir");
+        let store = NotebookStore::new(root.clone());
+        store.create("work").unwrap();
+
+        let renamed = store.rename("work", "work2").unwrap();
+
+        assert_eq!(renamed.path, root.join("work2"));
+        assert!(root.join("work2").is_dir());
     }
 }


### PR DESCRIPTION
## Summary

Follow-up to #17 (configurable notebooks root directory & per-notebook custom paths), fixing a data-safety bug found during review after that PR was merged.

- **`NotebookStore::rename()`** resolved the old path through `path_for()` (custom-path-aware) but hardcoded the new path to `root.join(new_name)`. In practice, renaming any notebook with a configured custom `path` — e.g. a subfolder inside a user's Obsidian vault — silently moved its directory (and every note inside it) out of wherever it actually lived and into shiki's internal data directory. Reproduced live before this fix: created a custom-path notebook, renamed it, and watched its contents relocate into `~/.local/share/shiki/`, leaving the `[notebooks.<old_name>] path` config entry pointing at a directory that no longer existed.

  Fixed so that renaming a custom-path notebook keeps it in place (as a sibling of its original directory) unless the new name has its own configured `path`, in which case that's honored instead.

- **`Config::notebook_custom_paths()`** now only accepts absolute `path` values. A relative one used to resolve against whatever directory the `shiki` process happened to be launched from (terminal vs. desktop entry vs. cron), which is unpredictable — confirmed live by creating a notebook with a relative `path` from two different working directories and getting two different results. Non-absolute paths are now excluded (falling back to the default location) instead of silently accepted.

- **`shiki doctor`** gained a check that warns when a notebook's configured `path` isn't absolute, so the exclusion above isn't silent.

## Testing

- `cargo test --workspace` — all tests pass, including 4 new ones covering: rename staying in place for a custom-path notebook, rename honoring the new name's own configured path, the unaffected root-notebook rename case, and `notebook_custom_paths` filtering relative paths.
- `cargo clippy --workspace --all-targets` — clean.
- Manually reproduced the original bug end-to-end (pre-fix) and re-verified the fixed behavior end-to-end (post-fix) via the CLI, plus the new `doctor` warning.

## Backwards compatibility

No config schema change. Notebooks without a custom `path` are unaffected. Existing custom-path notebooks are unaffected unless renamed.