### PR TITLE
feat: add general.show_hints for input-prompt hint lines

### DIFF
--- a/IDEA.md
+++ b/IDEA.md
@@ -427,6 +427,9 @@ mouse_drag_selection = true
 # vault) to use it as the notebooks root instead of the platform default
 # (~/.local/share/shiki/). Notebooks are subdirectories of this path.
 # data_dir = "/Users/me/my-obsidian-vault"
+# When true, text-input prompts that have one (e.g. new notebook) show a
+# small hint line explaining non-obvious input, like pasting a git URL.
+show_hints = true
 
 [keybindings]
 leader = "space"

--- a/shiki-config/src/config.rs
+++ b/shiki-config/src/config.rs
@@ -48,6 +48,16 @@ pub struct General {
     /// at an existing Obsidian vault or any other directory of markdown notes.
     #[serde(default)]
     pub data_dir: Option<String>,
+    /// When true, text-input prompts that have one (currently just
+    /// `NewNotebook` — see `PendingInput::hint`) show a small muted line
+    /// under the input box explaining non-obvious input (e.g. that pasting a
+    /// git URL clones instead of creating a plain notebook). Defaults to
+    /// `true` since the whole point is surfacing a feature that isn't
+    /// otherwise discoverable; existing configs missing this key still parse
+    /// via `default_true`, same as every other bool added after this file's
+    /// initial fields.
+    #[serde(default = "default_true")]
+    pub show_hints: bool,
 }
 
 impl Default for General {
@@ -59,6 +69,7 @@ impl Default for General {
             use_favorite_editor: false,
             mouse_drag_selection: true,
             data_dir: None,
+            show_hints: true,
         }
     }
 }
@@ -1002,7 +1013,9 @@ fn section_comment(line: &str) -> Option<&'static str> {
 #   PREVIEW selects text and copies it to the clipboard on release.
 # - data_dir: optional path override for the notebooks directory. Point this
 #   at an existing Obsidian vault or any markdown folder to use it as the
-#   notebooks root. Unset defaults to the platform data directory."
+#   notebooks root. Unset defaults to the platform data directory.
+# - show_hints: when true, text-input prompts that have one (e.g. new
+#   notebook) show a small hint line explaining non-obvious input."
         }
         "[keybindings]" => {
             "\

--- a/shiki-tui/src/app.rs
+++ b/shiki-tui/src/app.rs
@@ -168,6 +168,21 @@ impl PendingInput {
             PendingInput::MoveOrCopy => " Move/copy to ",
         }
     }
+
+    /// Small muted line rendered under the input box, `None` for every
+    /// variant except the ones whose valid input isn't obvious from the
+    /// title alone — e.g. `NewNotebook` silently accepts a git URL instead
+    /// of a plain name (see `App::confirm_input`'s `looks_like_git_url`
+    /// branch), which nothing else in the modal hints at.
+    pub(crate) fn hint(self) -> Option<&'static str> {
+        match self {
+            PendingInput::NewNotebook => Some(
+                "A name creates a new local notebook. Paste a repo URL (https://, git@, ssh://) \
+                 to clone it instead — make sure you're logged in first if it's private.",
+            ),
+            _ => None,
+        }
+    }
 }
 
 /// A quick `@`-triggered shortcut typed into the `NewNote` title prompt —

--- a/shiki-tui/src/draw.rs
+++ b/shiki-tui/src/draw.rs
@@ -12,7 +12,7 @@ use ratatui::layout::{Constraint, Layout, Rect};
 use ratatui::style::{Modifier, Style};
 use ratatui::text::Line;
 use ratatui::text::Span;
-use ratatui::widgets::{Clear, List, ListItem, ListState};
+use ratatui::widgets::{Clear, List, ListItem, ListState, Paragraph, Wrap};
 use ratatui::Frame;
 use shiki_core::TagIndex;
 
@@ -84,6 +84,30 @@ pub fn draw(frame: &mut Frame, app: &App) {
                 state.select(Some(app.quick_template_selected));
             }
             frame.render_stateful_widget(list, list_area, &mut state);
+        } else if let Some(hint) = kind.hint().filter(|_| app.config.general.show_hints) {
+            // Stacked under the input box's own fixed 3 rows, same idea as
+            // the quick-template dropdown above — the hint is informational
+            // only, so it never affects input handling, just what's drawn.
+            let hint_height = hint_line_count(hint, width.saturating_sub(2));
+            let popup_area = centered_rect(frame.area(), width, 3 + 1 + hint_height);
+            frame.render_widget(Clear, popup_area);
+            let [input_area, _spacer, hint_area] = Layout::vertical([
+                Constraint::Length(3),
+                Constraint::Length(1),
+                Constraint::Length(hint_height),
+            ])
+            .areas(popup_area);
+            app.input
+                .render(frame, input_area, title, hex_to_color(&app.theme.accent));
+            let hint_paragraph = Paragraph::new(hint)
+                .style(
+                    Style::default()
+                        .fg(hex_to_color(&app.theme.muted))
+                        .add_modifier(Modifier::ITALIC),
+                )
+                .alignment(ratatui::layout::Alignment::Center)
+                .wrap(Wrap { trim: true });
+            frame.render_widget(hint_paragraph, hint_area);
         } else {
             let popup_area = centered_rect(frame.area(), width, 3);
             frame.render_widget(Clear, popup_area);
@@ -158,6 +182,26 @@ pub fn draw(frame: &mut Frame, app: &App) {
         frame.render_widget(Clear, popup_area);
         dialog.render(frame, popup_area, hex_to_color(&app.theme.warning));
     }
+}
+
+/// Greedy word-wrap line count for a `PendingInput` hint, so the popup can
+/// be sized to fit it exactly before `Paragraph`'s own `Wrap` does the real
+/// wrapping at render time.
+fn hint_line_count(text: &str, width: u16) -> u16 {
+    let width = width.max(1) as usize;
+    let mut lines: u16 = 1;
+    let mut current = 0usize;
+    for word in text.split_whitespace() {
+        let word_len = word.chars().count();
+        let sep = if current == 0 { 0 } else { 1 };
+        if current + sep + word_len > width {
+            lines += 1;
+            current = word_len;
+        } else {
+            current += sep + word_len;
+        }
+    }
+    lines
 }
 
 fn render_theme_picker(frame: &mut Frame, frame_area: Rect, app: &App) {

--- a/shiki-tui/src/key_handlers.rs
+++ b/shiki-tui/src/key_handlers.rs
@@ -260,8 +260,8 @@ impl App {
             _ => {}
         }
     }
-    /// GENERAL — `use_favorite_editor`/`mouse_drag_selection` toggle in
-    /// place; the three text fields open a single-line prompt
+    /// GENERAL — `use_favorite_editor`/`mouse_drag_selection`/`show_hints`
+    /// toggle in place; the three text fields open a single-line prompt
     /// (`PendingInput::SettingsGeneralText`, resolved back to a field via
     /// `GeneralField::ALL[settings_selected]` once it's confirmed).
     fn handle_general_field_enter(&mut self) {
@@ -285,6 +285,12 @@ impl App {
             ));
             return;
         }
+        if field == GeneralField::ShowHints {
+            self.config.general.show_hints = !self.config.general.show_hints;
+            self.save_config();
+            self.set_status(format!("show_hints -> {}", self.config.general.show_hints));
+            return;
+        }
         let (label, prefill) = match field {
             GeneralField::DefaultNotebook => (
                 "default_notebook",
@@ -294,7 +300,9 @@ impl App {
             GeneralField::DailyTemplate => {
                 ("daily_template", self.config.general.daily_template.clone())
             }
-            GeneralField::UseFavoriteEditor | GeneralField::MouseDragSelection => unreachable!(),
+            GeneralField::UseFavoriteEditor
+            | GeneralField::MouseDragSelection
+            | GeneralField::ShowHints => unreachable!(),
         };
         self.show_settings = false;
         self.pending_input_title = Some(format!(" {label} "));
@@ -2219,6 +2227,7 @@ impl App {
                         }
                         GeneralField::UseFavoriteEditor => "use_favorite_editor",
                         GeneralField::MouseDragSelection => "mouse_drag_selection",
+                        GeneralField::ShowHints => "show_hints",
                     };
                     self.save_config();
                     self.set_status(format!("{label} -> '{value}'"));

--- a/shiki-tui/src/panel_settings.rs
+++ b/shiki-tui/src/panel_settings.rs
@@ -63,15 +63,17 @@ pub enum GeneralField {
     DailyTemplate,
     UseFavoriteEditor,
     MouseDragSelection,
+    ShowHints,
 }
 
 impl GeneralField {
-    pub const ALL: [GeneralField; 5] = [
+    pub const ALL: [GeneralField; 6] = [
         GeneralField::DefaultNotebook,
         GeneralField::Editor,
         GeneralField::DailyTemplate,
         GeneralField::UseFavoriteEditor,
         GeneralField::MouseDragSelection,
+        GeneralField::ShowHints,
     ];
 }
 
@@ -200,6 +202,7 @@ fn general_rows(app: &App) -> Vec<Line<'static>> {
             "mouse_drag_selection",
             cfg.general.mouse_drag_selection.to_string(),
         ),
+        row_line(app, "show_hints", cfg.general.show_hints.to_string()),
     ]
 }
 


### PR DESCRIPTION
## Summary
- Adds `general.show_hints` (default `true`), togglable in Settings' GENERAL tab or `config.toml`.
- When on, prompts that opt in via a new `PendingInput::hint()` show a small muted/italic line under the input box explaining non-obvious input.
- First (only) prompt wired up: New notebook — clarifies that pasting a git URL clones instead of creating a plain notebook.

## Test plan
- [x] `cargo check --workspace`
- [x] `cargo clippy --workspace --all-targets` (clean)
- [x] `cargo fmt --all` (no diff)
- [x] `cargo test --workspace` (48 passed)
- [x] Verified live via tmux: hint renders under the New notebook prompt with `show_hints = true`, disappears with `false`; toggling from Settings' GENERAL tab persists to `config.toml` and updates the footer status message.