### PR TITLE
Native editor mouse/keyboard UX overhaul (mouse selection, find/replace, OS clipboard, multi-cursor)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,63 @@ All notable changes to shiki are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this project doesn't follow strict
 semver yet (pre-1.0), but version bumps are still meaningful and tracked here.
 
+## [Unreleased]
+
+### Added
+
+- New `[editor]` config section (EDITOR tab in Settings, leader+`s`) — six independently toggleable
+  behaviors for the native note editor's mouse/keyboard UX: `mouse_selection`, `find_replace`,
+  `os_clipboard`, `select_all_ctrl_a`, `line_numbers`, `multi_cursor`.
+- `editor.mouse_selection` (on by default): click to position the cursor inside the note editor,
+  click-and-drag to select, double-click to select a word, triple-click to select a line — the
+  editor had no mouse support at all before this.
+- `editor.line_numbers` (off by default): a line-number gutter in the editor.
+- `editor.find_replace` (on by default): Ctrl+F opens a find/replace bar inside the editor —
+  live search-as-you-type, Enter/Shift+Enter for next/previous match, Ctrl+Enter to replace the
+  current match and advance, Ctrl+Alt+Enter to replace every occurrence.
+- `editor.os_clipboard` (off by default): Ctrl+C/X/V in the editor use the real OS clipboard
+  (via `arboard`), falling back automatically to the existing OSC 52 mechanism when there's no
+  display server to reach (e.g. headless SSH). Bracketed-paste is now enabled unconditionally so
+  a terminal paste anywhere in the app lands as one atomic insert instead of a burst of keystrokes.
+- `editor.select_all_ctrl_a` (off by default): Ctrl+A selects the whole buffer instead of
+  tui-textarea's default Emacs-style "move to start of line".
+- `editor.multi_cursor` (off by default): full multi-cursor editing. Alt+Click adds a cursor
+  (dedups against existing ones); Ctrl+D selects the word under the primary cursor and, on each
+  further press, adds the next occurrence as its own independently-selecting cursor, wrapping
+  around the buffer and reporting "no more occurrences" once every match already has a cursor.
+  Every keystroke (typing, Backspace/Delete, Enter, navigation) replays across the primary and
+  every secondary cursor via a new `multicursor` module built specifically because tui-textarea
+  itself has no multi-cursor concept at all — see the Fixed section below for the two real bugs
+  this uncovered along the way. Ctrl+U/Ctrl+R undo/redo a multi-cursor edit as one action (however
+  many cursors it actually mutated), not one step per cursor. Esc collapses back to a single
+  cursor first (VS Code's own convention); a second Esc then saves and exits as usual.
+
+### Fixed
+
+- Multi-cursor's own replay algorithm initially processed cursors bottom-to-top on the assumption
+  that this alone avoids invalidating other cursors' positions — caught by a failing unit test
+  before it ever reached a person: an edit that changes row count (Enter, or backspace-merging two
+  rows) *does* still invalidate an already-processed cursor's recorded result once a later
+  (higher, "more top") edit shifts rows below it. Replaced with the standard top-to-bottom
+  algorithm that tracks a running row/column delta instead, derived from `lines().len()`/cursor
+  position before and after each per-cursor edit rather than reimplementing tui-textarea's own
+  insert/delete arithmetic by hand.
+- A single `tui_textarea::TextArea::input()` call can silently push *two* separate undo-history
+  entries, not always one — verified directly against the vendored crate: typing a character over
+  an active selection is "delete the selection, then insert the character" (2 entries), while
+  Backspace over that same selection is just "delete" (1 entry). Assuming a flat count per
+  keystroke (as an earlier version of this work did) left Ctrl+U undoing only half of a
+  multi-cursor edit that replaced a selection, e.g. after Ctrl+D-selecting three occurrences and
+  typing a replacement. Fixed by measuring the real count directly — undo repeatedly until the
+  pre-edit content reappears, then redo back to the post-edit state — instead of guessing per key.
+
+- `arboard`'s clipboard handle is now kept alive for the process's lifetime instead of being
+  constructed and dropped on every copy/paste — the previous per-call pattern hit arboard's own
+  X11 "clipboard was dropped very quickly" guard, which `eprintln!`s a warning straight to the
+  real terminal underneath ratatui's alternate screen, visibly corrupting the TUI on every
+  Ctrl+C/Ctrl+V. Caught live by checking the real system clipboard (`wl-copy`/`wl-paste`) around
+  a Ctrl+C, not just by reasoning about the code.
+
 ## [0.8.7] - 2026-07-28
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,18 +25,38 @@ semver yet (pre-1.0), but version bumps are still meaningful and tracked here.
 - `editor.select_all_ctrl_a` (off by default): Ctrl+A selects the whole buffer instead of
   tui-textarea's default Emacs-style "move to start of line".
 - `editor.multi_cursor` (off by default): full multi-cursor editing. Alt+Click adds a cursor
-  (dedups against existing ones); Ctrl+D selects the word under the primary cursor and, on each
-  further press, adds the next occurrence as its own independently-selecting cursor, wrapping
-  around the buffer and reporting "no more occurrences" once every match already has a cursor.
-  Every keystroke (typing, Backspace/Delete, Enter, navigation) replays across the primary and
-  every secondary cursor via a new `multicursor` module built specifically because tui-textarea
-  itself has no multi-cursor concept at all — see the Fixed section below for the two real bugs
-  this uncovered along the way. Ctrl+U/Ctrl+R undo/redo a multi-cursor edit as one action (however
-  many cursors it actually mutated), not one step per cursor. Esc collapses back to a single
-  cursor first (VS Code's own convention); a second Esc then saves and exits as usual.
+  (dedups against existing ones); Ctrl+Alt+Up/Down adds one at the same column one row up/down
+  from whichever cursor sits furthest in that direction (VS Code's own "Add Cursor Above/Below",
+  a keyboard-only alternative added after Alt+Click alone felt uncomfortable in practice); Ctrl+D
+  selects the word under the primary cursor and, on each further press, adds the next occurrence
+  as its own independently-selecting cursor, wrapping around the buffer and reporting "no more
+  occurrences" once every match already has a cursor. Every keystroke (typing, Backspace/Delete,
+  Enter, navigation) replays across the primary and every secondary cursor via a new
+  `multicursor` module built specifically because tui-textarea itself has no multi-cursor concept
+  at all — see the Fixed section below for the real bugs this uncovered along the way. Ctrl+U/
+  Ctrl+R undo/redo a multi-cursor edit as one action (however many cursors it actually mutated),
+  not one step per cursor. Esc collapses back to a single cursor first (VS Code's own
+  convention); a second Esc then saves and exits as usual. Secondary cursors render as a solid
+  accent-colored block, distinct from the primary's plain reverse-video.
 
 ### Fixed
 
+- Mouse wheel scroll was never handled anywhere at all — reported live: scrolling over PREVIEW or
+  the editor did nothing. Now scrolls the editor's cursor (`Mode::Edit`, which in turn scrolls the
+  view — see the next entry) or reuses `move_selection`'s existing delta logic (`Mode::Normal`/
+  `Visual`, covers NOTEBOOKS/NOTES/PREVIEW the same way `j`/`k` already do), gated behind the same
+  "no modal is open" guard mouse clicks already use.
+- `PageUp`/`PageDown` did nothing at all inside the note editor (`Mode::Edit`) — reported live
+  alongside the mouse-scroll gap. Root cause: forwarding them to `tui-textarea` reaches
+  `Scrolling::PageUp/PageDown`, which scrolls its *internal* `Viewport` — but that viewport is
+  only ever populated by `tui-textarea`'s own `Widget` impl, and `InlineEditor::render`
+  deliberately bypasses that entirely (word-wrap support, see the struct's own doc comment), so
+  the viewport being scrolled is permanently zero-sized and the cursor never actually moves.
+  Fixed by moving the cursor directly instead, which `InlineEditor`'s own scroll-follow (driven
+  purely by cursor position) then scrolls the view to match.
+- Added Ctrl+Home/Ctrl+End to jump to the very start/end of the note — plain Home/End already
+  worked correctly (`tui-textarea`'s own start/end-of-*current-line*, no viewport dependency
+  involved), but there was no way to jump to the start/end of the whole document at all.
 - Multi-cursor's own replay algorithm initially processed cursors bottom-to-top on the assumption
   that this alone avoids invalidating other cursors' positions — caught by a failing unit test
   before it ever reached a person: an edit that changes row count (Enter, or backspace-merging two
@@ -53,6 +73,14 @@ semver yet (pre-1.0), but version bumps are still meaningful and tracked here.
   multi-cursor edit that replaced a selection, e.g. after Ctrl+D-selecting three occurrences and
   typing a replacement. Fixed by measuring the real count directly — undo repeatedly until the
   pre-edit content reappears, then redo back to the post-edit state — instead of guessing per key.
+- Secondary cursors reused `cursor_style()` (tui-textarea's default `Modifier::REVERSED`, the same
+  style the primary cursor uses) and had no fallback for sitting past the last character of a
+  line — reported live: "solo hay 1 visualmente, no parpadean varios cursores." A terminal can
+  only ever blink one real caret, so secondary cursors were never going to blink like the primary
+  regardless of styling, but reusing the *exact same* subtle reverse-video look made them easy to
+  miss entirely, and a cursor landing at end-of-line (the common case right after typing) had
+  nothing to render at all. Fixed with a distinct solid accent-colored block style plus the
+  missing end-of-line fallback.
 
 - `arboard`'s clipboard handle is now kept alive for the process's lifetime instead of being
   constructed and dropped on every copy/paste — the previous per-call pattern hit arboard's own

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -89,6 +89,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
 
 [[package]]
+name = "arboard"
+version = "3.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0348a1c054491f4bfe6ab86a7b6ab1e44e45d899005de92f58b3df180b36ddaf"
+dependencies = [
+ "clipboard-win",
+ "log",
+ "objc2",
+ "objc2-app-kit",
+ "objc2-foundation",
+ "parking_lot",
+ "percent-encoding",
+ "windows-sys 0.59.0",
+ "x11rb",
+]
+
+[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -314,6 +331,15 @@ name = "clap_lex"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+
+[[package]]
+name = "clipboard-win"
+version = "5.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bde03770d3df201d4fb868f2c9c59e66a3e4e2bd06692a0fe701e7103c7e84d4"
+dependencies = [
+ "error-code",
+]
 
 [[package]]
 name = "cmake"
@@ -695,6 +721,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "dispatch2"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
+dependencies = [
+ "bitflags",
+ "objc2",
+]
+
+[[package]]
 name = "displaydoc"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -781,6 +817,12 @@ dependencies = [
  "libc",
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "error-code"
+version = "3.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dea2df4cf52843e0452895c455a1a2cfbb842a1e7329671acf418fdc53ed4c59"
 
 [[package]]
 name = "fancy-regex"
@@ -916,6 +958,16 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
+]
+
+[[package]]
+name = "gethostname"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bd49230192a3797a9a4d6abe9b3eed6f7fa4c8a8a4947977c6f80025f92cbd8"
+dependencies = [
+ "rustix 1.1.4",
+ "windows-link",
 ]
 
 [[package]]
@@ -1561,6 +1613,79 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "objc2"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a12a8ed07aefc768292f076dc3ac8c48f3781c8f2d5851dd3d98950e8c5a89f"
+dependencies = [
+ "objc2-encode",
+]
+
+[[package]]
+name = "objc2-app-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d49e936b501e5c5bf01fda3a9452ff86dc3ea98ad5f283e1455153142d97518c"
+dependencies = [
+ "bitflags",
+ "objc2",
+ "objc2-core-graphics",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-core-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
+dependencies = [
+ "bitflags",
+ "dispatch2",
+ "objc2",
+]
+
+[[package]]
+name = "objc2-core-graphics"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e022c9d066895efa1345f8e33e584b9f958da2fd4cd116792e15e07e4720a807"
+dependencies = [
+ "bitflags",
+ "dispatch2",
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-io-surface",
+]
+
+[[package]]
+name = "objc2-encode"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
+
+[[package]]
+name = "objc2-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
+dependencies = [
+ "bitflags",
+ "objc2",
+ "objc2-core-foundation",
+]
+
+[[package]]
+name = "objc2-io-surface"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "180788110936d59bab6bd83b6060ffdfffb3b922ba1396b312ae795e1de9d81d"
+dependencies = [
+ "bitflags",
+ "objc2",
+ "objc2-core-foundation",
 ]
 
 [[package]]
@@ -2342,6 +2467,7 @@ name = "shiki-tui"
 version = "0.8.7"
 dependencies = [
  "anyhow",
+ "arboard",
  "base64",
  "chrono",
  "comrak",
@@ -3492,6 +3618,23 @@ name = "writeable"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
+
+[[package]]
+name = "x11rb"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9993aa5be5a26815fe2c3eacfc1fde061fc1a1f094bf1ad2a18bf9c495dd7414"
+dependencies = [
+ "gethostname",
+ "rustix 1.1.4",
+ "x11rb-protocol",
+]
+
+[[package]]
+name = "x11rb-protocol"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea6fc2961e4ef194dcbfe56bb845534d0dc8098940c7e5c012a258bfec6701bd"
 
 [[package]]
 name = "xattr"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,6 +57,10 @@ self_update = { version = "1.0.0-rc.6", default-features = false, features = [
     "checksums",
 ] }
 tempfile = "3"
+# `default-features = false` drops the default `image-data` feature (and its
+# `image`/`objc2-core-graphics`/etc. transitive deps) — shiki only ever
+# copies/pastes plain text through this, never images.
+arboard = { version = "3", default-features = false }
 
 [profile.release]
 lto = true

--- a/IDEA.md
+++ b/IDEA.md
@@ -300,13 +300,25 @@ The rest of the editor's mouse/keyboard UX is opt-in via `[editor]` (Settings' E
 - `select_all_ctrl_a` (off by default): `Ctrl+A` selects the whole buffer instead of moving to
   the start of the line.
 - `multi_cursor` (off by default): full multi-cursor editing. `Alt`+click adds a cursor at the
-  clicked position; `Ctrl+D` selects the word under the cursor, and every further press adds the
-  next occurrence as its own cursor (wraps around the buffer, reports "no more occurrences" once
-  everything's already selected). Typing, `Backspace`/`Delete`, `Enter`, and navigation all
+  clicked position; `Ctrl+Alt+↑`/`Ctrl+Alt+↓` (VS Code's own "Add Cursor Above/Below") adds one
+  at the same column one row up/down from whichever cursor already sits furthest in that
+  direction — a keyboard-only alternative to Alt+click, extending the same contiguous block on
+  each repeated press. `Ctrl+D` selects the word under the cursor, and every further press adds
+  the next occurrence as its own cursor (wraps around the buffer, reports "no more occurrences"
+  once everything's already selected). Typing, `Backspace`/`Delete`, `Enter`, and navigation all
   replay across every cursor at once — typing over a Ctrl+D-selected occurrence replaces it, same
   as a single cursor would. `Ctrl+U`/`Ctrl+R` undo/redo a multi-cursor edit as one action, however
   many cursors it touched. `Esc` first collapses back to a single cursor (a second `Esc` then
-  saves and exits, as usual).
+  saves and exits, as usual). Secondary cursors render as a solid accent-colored block (bold,
+  distinct from the primary's plain reverse-video) — a terminal can only blink one real caret, so
+  this is the compensating visual signal rather than an attempt to actually blink more than one.
+
+Navigation inside the editor is always on, not gated by `[editor]`: `PageUp`/`PageDown` move the
+cursor a page at a time, `Home`/`End` go to the start/end of the current line, `Ctrl+Home`/
+`Ctrl+End` jump to the very start/end of the note, and the mouse wheel scrolls too. `PageUp`/
+`PageDown`/mouse-wheel scrolling move the cursor itself (there's no independent scroll offset —
+the editor's word-wrap support means it bypasses `tui-textarea`'s own rendering, and with it,
+`tui-textarea`'s own viewport-based `PageUp`/`PageDown`, which otherwise does nothing here).
 
 ---
 

--- a/IDEA.md
+++ b/IDEA.md
@@ -207,7 +207,7 @@ search, tree view) using the same list/selection they already navigate with `j`/
 | `e` | Toggle `general.use_favorite_editor` on/off and persist it immediately — no need to hand-edit config.toml. The footer always shows which mode is active: the resolved editor name (e.g. `nvim`) when on, `native` (the built-in inline editor) when off |
 | `U` | Check for updates — modal; checks GitHub Releases in the background (never blocks the UI), shows "update available" if there's a newer version, and `Enter` downloads, verifies (against GitHub's own per-asset checksum), installs, and automatically relaunches into it |
 | `u` | Undo the last delete — restores the most recently deleted note/folder (or whole batch, from a Visual-mode delete) from the trash (`~/.config/shiki/trash/`) back to exactly where it came from. A single level of undo, not a full history: only the *most recent* delete is restorable this way; an older one is still on disk in the trash, just no longer reachable from here. With nothing to undo, reports that instead of doing anything |
-| `s` | Settings — near-full-screen, paged by tab (`←`/`→` switches GENERAL/THEME/GIT/NOTEBOOKS/SNIPPETS, `j`/`k` moves within one). Doesn't repeat the keybindings tables — `?` (which-key) already covers those live. Every tab is editable with `Enter`: GENERAL/GIT booleans (`use_favorite_editor`, `auto_commit`/`auto_push`/`sign_commits`/`auto_sync`) toggle in place and save immediately; every other GENERAL/GIT field opens a prompt prefilled with its current value; THEME's `name` opens the theme picker (live preview, same as leader+`c`) and `overrides` stays informational; NOTEBOOKS lists every notebook's actual git remote (redacted) and drills into one to edit its remote plus its `auto_push`/`auto_sync`/`auto_sync_every` overrides (booleans cycle inherit → true → false → inherit); SNIPPETS supports `a` (new snippet) and `d` (delete, with confirmation), and drilling into one edits its `label` and its full multi-line `body` through the same inline editor a note's own body uses. `i`/`E` still jump straight to editing `config.toml` itself for anything not covered above (inline or externally, same convention as editing a note); on save, the config is re-read, re-applied, and takes effect immediately (no restart) — an invalid edit is reported and neither written nor applied, keeping the previous config running. `h`/`Esc`/`Backspace` backs out of a drilled-into notebook/snippet a level; `Esc`/`q` at the top level closes |
+| `s` | Settings — near-full-screen, paged by tab (`←`/`→` switches GENERAL/THEME/GIT/EDITOR/NOTEBOOKS/SNIPPETS, `j`/`k` moves within one). Doesn't repeat the keybindings tables — `?` (which-key) already covers those live. Every tab is editable with `Enter`: GENERAL/GIT booleans (`use_favorite_editor`, `auto_commit`/`auto_push`/`sign_commits`/`auto_sync`) toggle in place and save immediately; every other GENERAL/GIT field opens a prompt prefilled with its current value; THEME's `name` opens the theme picker (live preview, same as leader+`c`) and `overrides` stays informational; EDITOR is six plain boolean toggles for the native note editor's UX (see `[editor]` below); NOTEBOOKS lists every notebook's actual git remote (redacted) and drills into one to edit its remote plus its `auto_push`/`auto_sync`/`auto_sync_every` overrides (booleans cycle inherit → true → false → inherit); SNIPPETS supports `a` (new snippet) and `d` (delete, with confirmation), and drilling into one edits its `label` and its full multi-line `body` through the same inline editor a note's own body uses. `i`/`E` still jump straight to editing `config.toml` itself for anything not covered above (inline or externally, same convention as editing a note); on save, the config is re-read, re-applied, and takes effect immediately (no restart) — an invalid edit is reported and neither written nor applied, keeping the previous config running. `h`/`Esc`/`Backspace` backs out of a drilled-into notebook/snippet a level; `Esc`/`q` at the top level closes |
 
 #### `[keybindings.notebooks]` — active while NOTEBOOKS is focused
 
@@ -283,6 +283,30 @@ bullet/numbered list item, a link, an image, a note/warning callout, and a colla
 Every command is customizable from `config.toml` under `[snippets.<trigger>]` — see the
 Configuration section below. A custom entry with the same trigger as a built-in (case-insensitive)
 replaces it instead of adding a duplicate, so nothing here is off-limits to redefine.
+
+The rest of the editor's mouse/keyboard UX is opt-in via `[editor]` (Settings' EDITOR tab, or
+`config.toml` directly — see the Configuration section):
+
+- `mouse_selection` (on by default): click to position the cursor, click-and-drag to select,
+  double-click to select a word, triple-click to select the whole line.
+- `line_numbers` (off by default): a line-number gutter.
+- `find_replace` (on by default): `Ctrl+F` opens a find/replace bar — typing live-jumps to the
+  nearest match, `Enter`/`Shift+Enter` step to the next/previous match, `Ctrl+Enter` replaces the
+  current match and advances, `Ctrl+Alt+Enter` replaces every occurrence, `Tab` switches between
+  the find and replace fields, `Esc` closes the bar (a second `Esc` then saves and exits, as usual).
+- `os_clipboard` (off by default): `Ctrl+C`/`Ctrl+X`/`Ctrl+V` use the real OS clipboard, falling
+  back automatically to the existing OSC 52 mechanism when there's no display server to reach
+  (e.g. a headless SSH session).
+- `select_all_ctrl_a` (off by default): `Ctrl+A` selects the whole buffer instead of moving to
+  the start of the line.
+- `multi_cursor` (off by default): full multi-cursor editing. `Alt`+click adds a cursor at the
+  clicked position; `Ctrl+D` selects the word under the cursor, and every further press adds the
+  next occurrence as its own cursor (wraps around the buffer, reports "no more occurrences" once
+  everything's already selected). Typing, `Backspace`/`Delete`, `Enter`, and navigation all
+  replay across every cursor at once — typing over a Ctrl+D-selected occurrence replaces it, same
+  as a single cursor would. `Ctrl+U`/`Ctrl+R` undo/redo a multi-cursor edit as one action, however
+  many cursors it touched. `Esc` first collapses back to a single cursor (a second `Esc` then
+  saves and exits, as usual).
 
 ---
 
@@ -511,6 +535,18 @@ auto_sync_every = 5
 # anything.
 remote_template = ""
 # remote_template = "git@git.example.com:notes/{notebook}.git"
+
+# Native note editor (Mode::Edit) UX — every key here is independently
+# toggleable from the EDITOR tab in Settings (leader+`s`); nothing changes
+# until you opt in, except the two purely-additive ones below which default
+# to true.
+[editor]
+mouse_selection = true   # click to position, drag/double/triple-click to select
+find_replace = true      # Ctrl+F opens a find/replace bar in the editor
+os_clipboard = false     # Ctrl+C/X/V use the real OS clipboard (falls back to OSC 52)
+select_all_ctrl_a = false  # Ctrl+A selects everything instead of "start of line"
+line_numbers = false     # shows a line-number gutter
+multi_cursor = false     # Alt+Click adds a cursor, Ctrl+D adds the next occurrence
 
 # Optional per-notebook overrides of [git] — anything left unset here falls
 # back to the global values above.

--- a/docs/documentation.html
+++ b/docs/documentation.html
@@ -726,6 +726,31 @@ bg = "#1e1e2e"</pre>
         </tbody>
       </table>
 
+      <h3 id="config-editor"><code>[editor]</code> — native note editor UX</h3>
+      <p style="max-width:70ch;">
+        Every key here is off unless noted — nothing about how the note editor (<code>Mode::Edit</code>)
+        behaves changes until you opt in, e.g. from the EDITOR tab in Settings (<code>leader</code>
+        then <code>s</code>).
+      </p>
+      <table class="ref-table config-ref-table">
+        <thead><tr><th>Key</th><th>Default</th><th>What it does</th></tr></thead>
+        <tbody>
+          <tr><td><code>mouse_selection</code></td><td><code>true</code></td><td>Click to position the cursor, click-and-drag to select, double-click for a word, triple-click for a line — inside the editor itself (distinct from <code>general.mouse_drag_selection</code>, which is PREVIEW's read-only line selection)</td></tr>
+          <tr><td><code>find_replace</code></td><td><code>true</code></td><td><code>Ctrl+F</code> opens a find/replace bar inside the editor</td></tr>
+          <tr><td><code>os_clipboard</code></td><td><code>false</code></td><td><code>Ctrl+C</code>/<code>Ctrl+X</code>/<code>Ctrl+V</code> use the real OS clipboard instead of the internal yank register, falling back automatically to the existing OSC 52 mechanism when there's no display server to reach (e.g. a headless SSH session)</td></tr>
+          <tr><td><code>select_all_ctrl_a</code></td><td><code>false</code></td><td><code>Ctrl+A</code> selects the whole buffer instead of moving to the start of the line</td></tr>
+          <tr><td><code>line_numbers</code></td><td><code>false</code></td><td>Shows a line-number gutter in the editor</td></tr>
+          <tr><td><code>multi_cursor</code></td><td><code>false</code></td><td><code>Alt+Click</code> adds a cursor, <code>Ctrl+D</code> adds the next occurrence of the current word/selection — full multi-cursor editing</td></tr>
+        </tbody>
+      </table>
+      <pre class="code">[editor]
+mouse_selection = true
+find_replace = true
+os_clipboard = false
+select_all_ctrl_a = false
+line_numbers = false
+multi_cursor = false</pre>
+
       <h3 id="config-notebooks"><code>[notebooks.&lt;name&gt;]</code> — per-notebook overrides</h3>
       <p style="max-width:70ch;">
         Every field above in <code>[git]</code> is a <em>global default</em>. Any individual
@@ -790,8 +815,8 @@ body = "# [{{title}}] {{cursor}}"</pre>
         <figcaption><code>leader</code> then <code>s</code> — every option above, editable in place.</figcaption>
       </figure>
       <p style="max-width:70ch;">
-        <code>←</code>/<code>→</code> switches between five tabs — GENERAL, THEME, GIT, NOTEBOOKS,
-        SNIPPETS — mirroring the sections above one for one. <code>j</code>/<code>k</code> moves
+        <code>←</code>/<code>→</code> switches between six tabs — GENERAL, THEME, GIT, EDITOR,
+        NOTEBOOKS, SNIPPETS — mirroring the sections above one for one. <code>j</code>/<code>k</code> moves
         within a tab, <code>Enter</code> edits or toggles the highlighted row (a true/false field
         flips immediately and saves; anything else opens a one-line prompt prefilled with its
         current value), and <code>Esc</code>/<code>q</code> closes. NOTEBOOKS and SNIPPETS are two
@@ -908,6 +933,17 @@ auto_sync_every = 5
 # anything.
 remote_template = ""
 # remote_template = "git@git.example.com:notes/{notebook}.git"
+
+# Native note editor (Mode::Edit) UX — every key is independently toggleable
+# from the EDITOR tab in Settings; nothing changes until you opt in, except
+# the two purely-additive ones below which default to true.
+[editor]
+mouse_selection = true
+find_replace = true
+os_clipboard = false
+select_all_ctrl_a = false
+line_numbers = false
+multi_cursor = false
 
 # Optional per-notebook overrides of [git] — anything left unset here falls
 # back to the global values above.

--- a/scripts/demo-gif.sh
+++ b/scripts/demo-gif.sh
@@ -9,9 +9,11 @@
 # inline editor's `/`-menu (v0.8.3+) for headings/bullets/checklist items
 # instead of hand-typed markdown, a git commit, a full tour of the now
 # fully-interactive Settings screen (v0.8.5 — every tab, including creating
-# a brand-new `/`-menu snippet from inside it), and live-cycling into the
-# 3 newest built-in themes (Dracula/One Dark/Monokai, v0.8.4) — not just
-# read-only navigation. Runs automatically on every release now
+# a brand-new `/`-menu snippet from inside it), the native editor's mouse/
+# keyboard UX overhaul (multi-cursor via repeated Ctrl+D, live find/
+# replace), and live-cycling into the 3 newest built-in themes (Dracula/
+# One Dark/Monokai, v0.8.4) — not just read-only navigation. Runs
+# automatically on every release now
 # (release.yml's update-screenshots job calls this right alongside
 # scripts/screenshots.sh, committing docs/assets/demo.gif back to `main`
 # the same way it already did for the per-theme screenshots), so the demo
@@ -571,7 +573,30 @@ write_note work "docs/deployment-guide.md" "Deployment guide" "2026-07-08" "[wor
 Previous version stays deployable for 48 hours after any release
 specifically so a rollback is always a known-good, already-tested target."
 
-# === research/ — 5 root notes, no folders (a flat notebook for variety) ===
+# === research/ — 6 root notes, no folders (a flat notebook for variety) ===
+
+# Three lines starting with the exact same word, deliberately — Phase 13
+# below drives this with repeated Ctrl+D presses (select word under
+# cursor, then keep adding the next occurrence), which only needs the
+# cursor to start at (0, 0) — the default position on entering edit mode —
+# and never needs pixel-precise mouse coordinates the way an Alt+Click
+# multi-cursor demo would. Placed in research/, not personal/, on purpose:
+# a real bug caught live building this phase — an earlier version added it
+# to personal/'s root, and since notes sort alphabetically, "Errands this
+# week" landed *before* "Gift ideas" there, shifting every later note's
+# index by one. Phase 7 (much earlier in this same recording, written long
+# before this note existed) batch-deletes by a hardcoded index that
+# assumed "Gift ideas" specifically, so it silently deleted this note
+# instead once the index shifted — by Phase 13 the note was simply gone
+# ("no match" from the notes-scope search that first replaced global
+# search here, before the actual root cause was found). research/ is
+# never touched by index-dependent navigation anywhere in this recording,
+# so a new note there can't collide with any earlier phase's assumptions
+# the way personal/'s root can.
+write_note research "errands-this-week.md" "Errands this week" "2026-07-21" "[personal, todo]" \
+"TODO: buy milk
+TODO: call the dentist
+TODO: finish the quarterly report"
 
 write_note research "rust-async-patterns.md" "Rust async patterns" "2026-07-02" "[rust, research]" \
 "## When NOT to reach for async
@@ -700,6 +725,14 @@ name = "gruvbox-dark"
 [git]
 auto_commit = false
 auto_push = false
+
+# line_numbers/multi_cursor default off (see [editor] in shiki-config) —
+# flipped on here so Phase 13's editor screenshots show these features
+# active rather than recording the (invisible-by-design) off state.
+# mouse_selection/find_replace already default to true.
+[editor]
+line_numbers = true
+multi_cursor = true
 EOF
 
 # --- Commit everything so the footer shows a clean synced state instead of
@@ -724,7 +757,22 @@ Set TypingSpeed 30ms
 Set WaitTimeout 5s
 
 Hide
-Type "XDG_CONFIG_HOME='$CFG' XDG_DATA_HOME='$WORK/data' '$BIN'"
+# `directories::ProjectDirs::from("", "", "shiki")` (shiki-config) appends
+# its own "shiki" segment onto whatever `$XDG_CONFIG_HOME`/`$XDG_DATA_HOME`
+# is given — so these must be the *parent* of `$CFG`/`$DATA` (which
+# already end in "/shiki" themselves), not `$CFG`/`$DATA` directly. A real
+# bug caught live while adding Phase 13 below: an earlier version of this
+# line passed `$CFG` as-is, so the app was actually reading/writing
+# `$WORK/config/shiki/shiki/config.toml` — one level too deep, and thus
+# never the hand-written config this script generates at all. It went
+# unnoticed for a while because `Config::default()`'s own values
+# (gruvbox-dark theme, "personal" as the default notebook, auto_push
+# false) happen to coincidentally match what the hand-written config also
+# specifies — until `[editor] line_numbers`/`multi_cursor = true` was
+# added and *didn't* match its own (false) default, which is what actually
+# exposed this. `XDG_DATA_HOME` already did this correctly (`$WORK/data`,
+# not `$DATA`); only `$XDG_CONFIG_HOME` had the bug.
+Type "XDG_CONFIG_HOME='$WORK/config' XDG_DATA_HOME='$WORK/data' '$BIN'"
 Enter
 Sleep 1200ms
 Show
@@ -1003,9 +1051,12 @@ Sleep 1800ms
 # demonstrated below by jumping straight from NOTEBOOKS level 2 to SNIPPETS
 # without backing out first. Every toggle exercised here is flipped back to
 # its starting value before moving on (use_favorite_editor, auto_push, the
-# notebook's own auto_push override) so this phase leaves no side effect
-# behind except the one it's actually meant to: a real new `/`-menu
-# snippet, created from scratch entirely from within Settings.
+# notebook's own auto_push override, EDITOR's mouse_selection) so this
+# phase leaves no side effect behind except the one it's actually meant
+# to: a real new `/`-menu snippet, created from scratch entirely from
+# within Settings. Tab order is GENERAL -> THEME -> GIT -> EDITOR ->
+# NOTEBOOKS -> SNIPPETS — EDITOR sits between GIT and NOTEBOOKS, so every
+# tab-switch count below accounts for it.
 Space
 Type "s"
 Sleep 700ms
@@ -1056,6 +1107,24 @@ Sleep 500ms
 Enter
 Sleep 600ms
 Escape
+Sleep 600ms
+
+# EDITOR (new tab, sits between GIT and NOTEBOOKS — every tab count below
+# that used to jump straight from GIT to NOTEBOOKS with a single `Right`
+# has to know about this or it silently lands one section short: caught
+# for real by running this exact recording once before finalizing it —
+# the original single-`Right` GIT->NOTEBOOKS jump landed on EDITOR
+# instead, and the NOTEBOOKS-drill keystrokes that followed then
+# misfired straight into EDITOR's own flat toggle list, in one run
+# actually typing "PR review checklist" into personal's git remote text
+# prompt). mouse_selection toggles off then back on in place, same
+# boolean-flips-immediately-on-Enter behavior every other tab's booleans
+# already have.
+Right
+Sleep 600ms
+Enter
+Sleep 600ms
+Enter
 Sleep 600ms
 
 # NOTEBOOKS: level 1 lists every real notebook with its actual git remote
@@ -1111,7 +1180,96 @@ Sleep 700ms
 Escape
 Sleep 600ms
 
-# --- Phase 13: theme picker, standalone (leader+`c`) — live-cycle through
+# --- Phase 13: native editor mouse/keyboard UX overhaul (mouse selection,
+# find/replace, real OS clipboard, full multi-cursor, all opt-in via
+# [editor], flipped on above in the generated config). Jumped to by global
+# search (leader+`g`, the same cross-notebook mechanism Phase 5 already
+# uses for "Acme") rather than local navigation, so this phase doesn't
+# depend on tracking exactly which notebook/folder everything before it
+# left selected.
+#
+# A real bug caught live building this phase: Phase 12's own trailing two
+# `Escape`s (above) only back out of the SNIPPETS drill-down to its level-1
+# list — they don't close the Settings modal itself, which was still open
+# on SNIPPETS the whole time. `Space` and the first few letters of
+# "errands" landed on that still-open modal instead of the leader key:
+# `Space`/`g`/`e`/`r`/`r` are all no-ops at SNIPPETS level 1 (not bound to
+# anything there) *except* `a`, which is level 1's own "new snippet"
+# binding — it fired, opened the trigger prompt, and swallowed the
+# remaining letters of "errands" ("nds") as the typed trigger name,
+# creating a real (garbage) `/nds` snippet. One more `Escape` here — for
+# real this time at level 1, where `Esc`/`q` does close the whole modal —
+# fixes it.
+#
+# A second, sneakier bug caught the same way, unrelated to Settings: the
+# demo note originally lived at personal/'s root, sorted alphabetically —
+# which put it *before* "Gift ideas" there, shifting every later note's
+# index by one. Phase 7 (written long before this note existed)
+# batch-deletes by a hardcoded index that assumed "Gift ideas" specifically
+# lived at that position, so once the index shifted, it silently deleted
+# this note instead. By the time this phase ran, the note was simply gone
+# — global search's top-ranked result was some unrelated note purely by
+# coincidence, which looked at first like a *ranking* bug rather than a
+# *the-note-doesn't-exist-anymore* bug. Moved the note to research/
+# instead (see setup_sample_data) — never touched by index-dependent
+# navigation anywhere in this recording, so it can't collide with an
+# earlier phase's assumptions the way personal/'s root can.
+Escape
+Sleep 500ms
+Space
+Type "g"
+Sleep 400ms
+Type "errands"
+Sleep 700ms
+Enter
+Sleep 700ms
+Type "i"
+Sleep 500ms
+# Ctrl+D: 1st press selects the word under the cursor (no new cursor
+# yet), each press after that adds the next occurrence as its own cursor
+# — three identical "TODO"s means three presses select all of them, no
+# pixel-coordinate mouse math or counted arrow-key navigation needed at
+# all. Typing then replaces all three selections at once. Verified this
+# exact sequence against a real recording before scripting it here (not
+# assumed): it does replace all three, live, in one motion.
+Ctrl+D
+Sleep 500ms
+Ctrl+D
+Sleep 500ms
+Ctrl+D
+Sleep 600ms
+Type "DONE"
+Sleep 900ms
+# `Escape` first collapses the secondary cursors (this app's own
+# convention — verified directly: a second, distinct keystroke afterward
+# only ever lands at the primary's own position, proving the secondaries
+# were cleared rather than the editor having exited) before the find/
+# replace demo below, so it isn't left with stale cursor markers from the
+# multi-cursor edit. This edit is left in place rather than undone
+# afterward — a real, lasting change, the same "show it actually doing
+# something" preference every other phase in this recording already
+# follows (see Phase 7's own comment).
+Escape
+Sleep 500ms
+# Find/replace: Ctrl+F opens the bar, typing live-jumps to the match —
+# genuinely live, not scripted around. Replacing via Ctrl+Enter/
+# Ctrl+Alt+Enter is deliberately not demonstrated here: verified directly
+# that this terminal stack (ttyd, the same one VHS itself records
+# through) can't distinguish Ctrl+Enter from plain Enter without an
+# extended keyboard protocol neither ttyd nor most real terminals
+# implement, so scripting a "replace" demo around it would be recording
+# a keystroke that doesn't reliably do the same thing on a real viewer's
+# own terminal either.
+Ctrl+F
+Sleep 400ms
+Type "dentist"
+Sleep 900ms
+Escape
+Sleep 500ms
+Escape
+Sleep 600ms
+
+# --- Phase 14: theme picker, standalone (leader+`c`) — live-cycle through
 # the 3 newest built-in themes (Dracula, One Dark, Monokai — v0.8.4 grew
 # the set from 12 to 15) before cancelling back to the notebook's actual
 # gruvbox-dark. `available_themes` order comes straight from
@@ -1130,7 +1288,7 @@ Sleep 700ms
 Escape
 Sleep 500ms
 
-# --- Phase 14: which-key / command palette, quick glimpse.
+# --- Phase 15: which-key / command palette, quick glimpse.
 Type "?"
 Sleep 900ms
 Escape

--- a/scripts/screenshots.sh
+++ b/scripts/screenshots.sh
@@ -212,6 +212,18 @@ Product, Engineering, Design leads.
   # movement into the middle of a real note's content.
   write_note personal "quick-capture.md" "Quick capture" "2026-07-20" "[]" ""
 
+  # Three lines all starting with the exact same word, deliberately — the
+  # multi-cursor screenshots (below) drive this with repeated Ctrl+D
+  # presses (select word under cursor, then keep adding the next
+  # occurrence), which only needs the cursor to start at (0, 0) — the
+  # default position on entering edit mode — and never needs pixel-precise
+  # mouse coordinates or counted arrow-key navigation the way an Alt+Click
+  # or Ctrl+Alt+Down demo would.
+  write_note personal "errands-this-week.md" "Errands this week" "2026-07-21" "[personal, todo]" \
+"TODO: buy milk
+TODO: call the dentist
+TODO: finish the quarterly report"
+
   for nb in personal work; do
     git -C "$DATA/$nb" add -A
     git -C "$DATA/$nb" commit -q -m "shiki: initial notes"
@@ -223,6 +235,15 @@ setup_sample_data
 CONFIG_BASE="$WORK/config-base/shiki"
 mkdir -p "$CONFIG_BASE"
 XDG_CONFIG_HOME="$WORK/config-base" XDG_DATA_HOME="$DATA/.." timeout 2 "$BIN" config >/dev/null 2>&1 || true
+
+# `line_numbers`/`multi_cursor` default off (see `[editor]` in
+# shiki-config) — flipped on here, once, in the base config every theme's
+# own copy is `sed`'d from below, so the editor screenshots show these
+# features active rather than screenshotting the (invisible-by-design)
+# off state. `mouse_selection`/`find_replace` already default to `true`,
+# so nothing to flip for those.
+sed -i 's/^line_numbers = false/line_numbers = true/' "$CONFIG_BASE/config.toml"
+sed -i 's/^multi_cursor = false/multi_cursor = true/' "$CONFIG_BASE/config.toml"
 
 # --- One xterm session per (theme, size). xdotool sends keys/text directly
 # to the window by id (a plain windowfocus first, since Xvfb has no window
@@ -332,6 +353,53 @@ capture() {
     # only runs once and this same file is reused by every theme/tier capture
     # that follows.
     send_key "BackSpace"
+    send_key "Escape"
+    send_key "Escape"
+
+    # EDITOR settings tab — GENERAL is the section a fresh leader+s always
+    # opens on, so `Right` x3 (GENERAL -> THEME -> GIT -> EDITOR) reaches it
+    # the same way a real user would, rather than assuming its index.
+    send_text " s"
+    send_key "Right"
+    send_key "Right"
+    send_key "Right"
+    shot "16-settings-editor"
+    send_key "Escape"
+
+    # Multi-cursor + find/replace, on the dedicated errands-this-week note
+    # (see setup_sample_data) — jumped to by title, same pattern as the
+    # slash-menu note above.
+    send_text "hhhl"
+    send_text "/"
+    send_text "errands"
+    send_key "Return"
+    send_text "i"
+    shot "17-editor-line-numbers"
+    # Ctrl+D 3x: 1st press selects the word under the cursor (no new
+    # cursor yet), each press after that adds the next occurrence as its
+    # own cursor — three identical "TODO"s means three presses select all
+    # of them, with no pixel-coordinate mouse math or counted arrow-key
+    # navigation needed at all.
+    send_key "ctrl+d"
+    send_key "ctrl+d"
+    send_key "ctrl+d"
+    shot "18-editor-multicursor-select"
+    send_text "DONE"
+    shot "19-editor-multicursor-typed"
+    # `Escape` first collapses the secondary cursors (this app's own
+    # convention) rather than leaving their now-stale positions/selections
+    # around for the find/replace shot below. 4 Ctrl+U (one per typed
+    # character, each grouped atomically across all 3 cursors — see
+    # `editor_undo`'s own doc comment) restores "TODO" exactly, since this
+    # note is shared by every theme/tier capture that follows.
+    send_key "Escape"
+    send_key "ctrl+u"
+    send_key "ctrl+u"
+    send_key "ctrl+u"
+    send_key "ctrl+u"
+    send_key "ctrl+f"
+    send_text "milk"
+    shot "20-editor-find-replace"
     send_key "Escape"
     send_key "Escape"
   else

--- a/shiki-cli/src/tui.rs
+++ b/shiki-cli/src/tui.rs
@@ -1,5 +1,7 @@
 use anyhow::Result;
-use crossterm::event::{DisableMouseCapture, EnableMouseCapture};
+use crossterm::event::{
+    DisableBracketedPaste, DisableMouseCapture, EnableBracketedPaste, EnableMouseCapture,
+};
 use crossterm::execute;
 use crossterm::terminal::{
     disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen,
@@ -13,7 +15,12 @@ use shiki_tui::App;
 pub fn launch(config: Config, store: NotebookStore) -> Result<()> {
     enable_raw_mode()?;
     let mut stdout = std::io::stdout();
-    execute!(stdout, EnterAlternateScreen, EnableMouseCapture)?;
+    execute!(
+        stdout,
+        EnterAlternateScreen,
+        EnableMouseCapture,
+        EnableBracketedPaste
+    )?;
     let backend = CrosstermBackend::new(stdout);
     let mut terminal = Terminal::new(backend)?;
 
@@ -23,6 +30,7 @@ pub fn launch(config: Config, store: NotebookStore) -> Result<()> {
     disable_raw_mode()?;
     execute!(
         terminal.backend_mut(),
+        DisableBracketedPaste,
         DisableMouseCapture,
         LeaveAlternateScreen
     )?;

--- a/shiki-config/src/config.rs
+++ b/shiki-config/src/config.rs
@@ -749,6 +749,64 @@ fn default_branch() -> String {
     "main".into()
 }
 
+/// Settings for the inline note editor's mouse/keyboard UX (`Mode::Edit`,
+/// `shiki-tui/src/editor.rs`) — every field here gates one independently
+/// toggleable behavior, off by default unless it's purely additive and safe
+/// (`mouse_selection`, `find_replace`), so nothing about how the editor
+/// behaves today changes for anyone who doesn't visit the EDITOR Settings
+/// tab (leader+`s`) and turn something on.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct EditorConfig {
+    /// Click-to-position, click-and-drag to select, double-click to select
+    /// a word, triple-click to select a line — all inside the editor itself
+    /// (distinct from `General::mouse_drag_selection`, which is PREVIEW's
+    /// read-only line-selection). Defaults to `true`: purely additive, no
+    /// existing keyboard behavior changes.
+    #[serde(default = "default_true")]
+    pub mouse_selection: bool,
+    /// Ctrl+F opens a find/replace bar inside the editor. Defaults to
+    /// `true`: purely additive, doesn't touch any existing binding.
+    #[serde(default = "default_true")]
+    pub find_replace: bool,
+    /// When true, Ctrl+C/X/V inside the editor use the real OS clipboard
+    /// (falling back automatically to the existing OSC 52 mechanism when
+    /// the OS clipboard can't be reached, e.g. a headless SSH session with
+    /// no `$DISPLAY`/`$WAYLAND_DISPLAY`) instead of tui-textarea's internal
+    /// yank register. Off by default since it's an environment-dependent
+    /// behavior change, not a pure addition.
+    #[serde(default)]
+    pub os_clipboard: bool,
+    /// When true, Ctrl+A selects the whole buffer instead of tui-textarea's
+    /// default Emacs-style "move to start of line". Off by default — this
+    /// changes existing muscle-memory behavior rather than adding to it.
+    #[serde(default)]
+    pub select_all_ctrl_a: bool,
+    /// Shows a line-number gutter in the editor. Off by default (cosmetic
+    /// opt-in).
+    #[serde(default)]
+    pub line_numbers: bool,
+    /// Enables Alt+Click (add a cursor) and Ctrl+D (add the next occurrence
+    /// of the current word/selection) for multi-cursor editing. Off by
+    /// default: it's the most involved of these behaviors, built as a replay
+    /// layer on top of tui-textarea's single-cursor model rather than
+    /// something the library supports natively.
+    #[serde(default)]
+    pub multi_cursor: bool,
+}
+
+impl Default for EditorConfig {
+    fn default() -> Self {
+        Self {
+            mouse_selection: true,
+            find_replace: true,
+            os_clipboard: false,
+            select_all_ctrl_a: false,
+            line_numbers: false,
+            multi_cursor: false,
+        }
+    }
+}
+
 /// Per-notebook override of the `[git]` sync policy — a notebook connected
 /// to a private work repo might want `auto_push`, while a scratch notebook
 /// with no remote at all shouldn't be forced into the same policy. Any
@@ -834,6 +892,8 @@ pub struct Config {
     pub theme: ThemeConfig,
     #[serde(default)]
     pub git: GitConfig,
+    #[serde(default)]
+    pub editor: EditorConfig,
     /// Per-notebook overrides of `[git]`, keyed by notebook name — e.g.
     /// `[notebooks.work]` with `auto_push = true`. See `NotebookGitOverride`.
     #[serde(default)]
@@ -1048,6 +1108,22 @@ fn section_comment(line: &str) -> Option<&'static str> {
 #   replaced with the new notebook's name. Empty (the default) means don't
 #   auto-configure anything; the remote still has to already exist."
         }
+        "[editor]" => {
+            "\
+# Inline note editor UX (Mode::Edit) — every key here is off unless noted,
+# so nothing about how the editor behaves changes until you opt in, e.g.
+# from the EDITOR tab in Settings (leader+`s`).
+# - mouse_selection: click to position the cursor, drag to select,
+#   double-click for a word, triple-click for a line. Defaults to true.
+# - find_replace: Ctrl+F opens a find/replace bar. Defaults to true.
+# - os_clipboard: Ctrl+C/X/V use the real OS clipboard, falling back to the
+#   existing OSC 52 mechanism when there's no display server (e.g. SSH).
+# - select_all_ctrl_a: Ctrl+A selects everything instead of moving to the
+#   start of the line.
+# - line_numbers: shows a line-number gutter.
+# - multi_cursor: Alt+Click adds a cursor, Ctrl+D adds the next occurrence
+#   of the current word/selection."
+        }
         "[notebooks]" => {
             "\
 # Optional per-notebook overrides of [git] above, e.g.:
@@ -1098,6 +1174,7 @@ mod tests {
             "[keybindings.preview]\nedit_inline = \"z\"\n",
             "[theme]\nname = \"nord\"\n",
             "[git]\nauto_push = true\n",
+            "[editor]\nline_numbers = true\n",
         ] {
             Config::parse(partial).unwrap_or_else(|e| panic!("{partial:?} failed to parse: {e}"));
         }
@@ -1191,7 +1268,7 @@ mod tests {
     fn commented_default_toml_comments_every_known_section() {
         let commented = commented_default_toml();
         let lines: Vec<&str> = commented.lines().collect();
-        for section in ["[general]", "[keybindings]", "[theme]", "[git]"] {
+        for section in ["[general]", "[keybindings]", "[theme]", "[git]", "[editor]"] {
             let idx = lines
                 .iter()
                 .position(|l| *l == section)

--- a/shiki-tui/Cargo.toml
+++ b/shiki-tui/Cargo.toml
@@ -26,3 +26,4 @@ chrono.workspace = true
 base64.workspace = true
 unicode-width.workspace = true
 directories.workspace = true
+arboard.workspace = true

--- a/shiki-tui/src/app.rs
+++ b/shiki-tui/src/app.rs
@@ -287,6 +287,28 @@ pub(crate) enum DeleteTarget {
     Notebook,
 }
 
+/// Which of the find/replace bar's two fields is currently typed into —
+/// `Tab` switches between them.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum FindField {
+    Query,
+    Replace,
+}
+
+/// Ctrl+F's find/replace bar (`config.editor.find_replace`), open only
+/// inside `Mode::Edit` — `None` means the bar is closed. Reuses `InputBox`
+/// for both fields, same as the global-search bar (`global_search_input`),
+/// rather than inventing new text-input handling.
+pub(crate) struct EditorFindState {
+    pub(crate) query: InputBox,
+    pub(crate) replace: InputBox,
+    pub(crate) focus: FindField,
+    /// The cursor position when the bar was opened — where a fresh search
+    /// (no existing selection yet, e.g. right after opening or right after
+    /// closing) starts scanning from.
+    pub(crate) anchor: (usize, usize),
+}
+
 pub struct App {
     pub config: Config,
     pub theme: Theme,
@@ -350,6 +372,51 @@ pub struct App {
     pub input: InputBox,
     pub confirm: Option<confirm::ConfirmDialog>,
     pub editor: Option<InlineEditor<'static>>,
+    /// Click-count tracking for `config.editor.mouse_selection` (single vs.
+    /// double vs. triple click) inside the editor — `(when, column, row)` of
+    /// the last `Down` event, compared against a short time+position window
+    /// on the next one; `None` once the window lapses or focus moves away
+    /// from the editor.
+    pub(crate) editor_last_click: Option<(std::time::Instant, u16, u16)>,
+    /// How many consecutive clicks landed on the same cell within the
+    /// double/triple-click window — capped at 3 (single/word/line).
+    pub(crate) editor_click_count: u8,
+    /// Whether `tui_textarea::TextArea::start_selection` has already been
+    /// called for the drag gesture currently in progress — a single-click
+    /// `Down` doesn't start a selection by itself (it might just be a plain
+    /// click-to-position), so the *first* `Drag` event after it is what
+    /// actually begins one.
+    pub(crate) editor_drag_active: bool,
+    /// Ctrl+F's find/replace bar — see `EditorFindState`'s own doc comment.
+    pub(crate) editor_find: Option<EditorFindState>,
+    /// `config.editor.multi_cursor`'s extra cursors — empty means ordinary
+    /// single-cursor editing (the common case, same "absent means normal"
+    /// pattern as `preview_selection`). The *primary* cursor is always
+    /// `editor`'s own live `TextArea` cursor/selection; these are purely
+    /// virtual, tracked only here — see `multicursor::replay_keystroke`.
+    pub(crate) editor_secondary_cursors: Vec<crate::multicursor::CursorState>,
+    /// One entry per historical edit action, most recent last — how many
+    /// `textarea.undo()` calls it takes to fully reverse that one action
+    /// (1 for an ordinary single-cursor edit, N for a multi-cursor edit
+    /// that mutated N cursors). Every code path that mutates the buffer
+    /// directly (the plain forward path, multi-cursor replay, find/
+    /// replace, OS-clipboard cut/paste, bracketed-paste) pushes its own
+    /// entry here and clears `editor_redo_groups`, so Ctrl+U popping the
+    /// last entry always undoes exactly one *user-perceived* action,
+    /// however many cursors it touched — verified live: typing a
+    /// multi-character word across 3 Alt+Click cursors and pressing
+    /// Ctrl+U three times correctly peels off one whole keystroke's worth
+    /// (all 3 cursors) per press, restoring the original text exactly.
+    /// A single `usize` (rather than this stack) was tried first and was
+    /// wrong: it only remembered the *most recent* keystroke's group size,
+    /// so undoing a 3-letter word typed across 3 cursors correctly undid
+    /// the last letter as one action but then fell back to single-cursor
+    /// steps for the other two letters.
+    pub(crate) editor_undo_groups: Vec<usize>,
+    /// Mirrors `editor_undo_groups` for Ctrl+R — an undo pushes however
+    /// many steps it actually undid here, so redoing it restores all of
+    /// them as one action too.
+    pub(crate) editor_redo_groups: Vec<usize>,
     /// The inline editor's `/`-menu (see `slash_menu.rs`) — open only
     /// while `Mode::Edit`'s current line reads exactly `/` up to the
     /// cursor (checked live off `editor.textarea` itself in
@@ -752,6 +819,13 @@ impl App {
             input: InputBox::default(),
             confirm: None,
             editor: None,
+            editor_last_click: None,
+            editor_click_count: 0,
+            editor_drag_active: false,
+            editor_find: None,
+            editor_secondary_cursors: Vec::new(),
+            editor_undo_groups: Vec::new(),
+            editor_redo_groups: Vec::new(),
             show_slash_menu: false,
             slash_menu_selected: 0,
             want_external_edit: None,
@@ -1780,6 +1854,7 @@ pub fn run<B: Backend>(terminal: &mut Terminal<B>, app: &mut App) -> io::Result<
                     }
                 }
                 Event::Mouse(mouse) => app.on_mouse(mouse),
+                Event::Paste(text) => app.on_paste(text),
                 _ => {}
             }
         }
@@ -1796,6 +1871,7 @@ fn relaunch_into_updated_binary(exe_path: &std::path::Path) -> io::Result<()> {
     crossterm::terminal::disable_raw_mode()?;
     crossterm::execute!(
         io::stdout(),
+        crossterm::event::DisableBracketedPaste,
         crossterm::event::DisableMouseCapture,
         crossterm::terminal::LeaveAlternateScreen
     )?;
@@ -1813,6 +1889,7 @@ fn suspend_and_edit<B: Backend>(
     crossterm::terminal::disable_raw_mode()?;
     crossterm::execute!(
         io::stdout(),
+        crossterm::event::DisableBracketedPaste,
         crossterm::event::DisableMouseCapture,
         crossterm::terminal::LeaveAlternateScreen
     )?;
@@ -1820,7 +1897,8 @@ fn suspend_and_edit<B: Backend>(
     crossterm::execute!(
         io::stdout(),
         crossterm::terminal::EnterAlternateScreen,
-        crossterm::event::EnableMouseCapture
+        crossterm::event::EnableMouseCapture,
+        crossterm::event::EnableBracketedPaste
     )?;
     crossterm::terminal::enable_raw_mode()?;
     terminal.clear()

--- a/shiki-tui/src/clipboard.rs
+++ b/shiki-tui/src/clipboard.rs
@@ -9,10 +9,47 @@
 
 use base64::Engine;
 use std::io::Write;
+use std::sync::{Mutex, OnceLock};
 
 pub fn copy(text: &str) {
     let encoded = base64::engine::general_purpose::STANDARD.encode(text);
     let mut stdout = std::io::stdout();
     let _ = write!(stdout, "\x1b]52;c;{encoded}\x07");
     let _ = stdout.flush();
+}
+
+/// A single, process-lifetime `arboard::Clipboard`, not a fresh one per
+/// call — verified live (via `wl-copy`/`wl-paste` against the real Wayland
+/// clipboard) that constructing-then-immediately-dropping one, as every
+/// earlier version of `copy_os`/`paste_os` did, hits arboard's own X11
+/// backend's "dropped very quickly after writing" guard: on Linux it
+/// checks `stderr().is_terminal()` and, if true, `eprintln!`s a multi-line
+/// warning straight to the real terminal underneath — bypassing ratatui
+/// entirely and visibly corrupting the alternate-screen TUI on *every*
+/// Ctrl+C/Ctrl+V. Keeping one instance alive for the app's whole lifetime
+/// (arboard's own documented recommendation for exactly this situation)
+/// means it's never dropped until the process exits, long past the ~100ms
+/// window that guard checks for.
+fn os_clipboard() -> Option<&'static Mutex<arboard::Clipboard>> {
+    static CELL: OnceLock<Option<Mutex<arboard::Clipboard>>> = OnceLock::new();
+    CELL.get_or_init(|| arboard::Clipboard::new().ok().map(Mutex::new))
+        .as_ref()
+}
+
+/// Writes `text` to the real OS clipboard (`config.editor.os_clipboard`).
+/// Returns `false` on any failure — most commonly there being no display
+/// server to reach at all (a headless SSH session with no `$DISPLAY`/
+/// `$WAYLAND_DISPLAY`) — so the caller can fall back to `copy` (OSC 52,
+/// which works fine over SSH) instead.
+pub fn copy_os(text: &str) -> bool {
+    let Some(cb) = os_clipboard() else {
+        return false;
+    };
+    cb.lock().is_ok_and(|mut cb| cb.set_text(text).is_ok())
+}
+
+/// Reads the real OS clipboard, or `None` if it can't be reached (no
+/// display server) or holds something other than plain text.
+pub fn paste_os() -> Option<String> {
+    os_clipboard()?.lock().ok()?.get_text().ok()
 }

--- a/shiki-tui/src/draw.rs
+++ b/shiki-tui/src/draw.rs
@@ -27,11 +27,16 @@ pub fn draw(frame: &mut Frame, app: &App) {
     if app.mode == Mode::Edit {
         if let Some(editor) = &app.editor {
             let gutter_style = Style::default().fg(hex_to_color(&app.theme.muted));
+            let secondary_cursor_style = Style::default()
+                .bg(hex_to_color(&app.theme.accent))
+                .fg(hex_to_color(&app.theme.bg))
+                .add_modifier(Modifier::BOLD);
             editor.render(
                 frame,
                 areas.preview,
                 app.config.editor.line_numbers,
                 gutter_style,
+                secondary_cursor_style,
                 &app.editor_secondary_cursors,
             );
             if app.show_slash_menu {

--- a/shiki-tui/src/draw.rs
+++ b/shiki-tui/src/draw.rs
@@ -26,9 +26,19 @@ pub fn draw(frame: &mut Frame, app: &App) {
     panel_notes::render(frame, areas.notes, app);
     if app.mode == Mode::Edit {
         if let Some(editor) = &app.editor {
-            editor.render(frame, areas.preview);
+            let gutter_style = Style::default().fg(hex_to_color(&app.theme.muted));
+            editor.render(
+                frame,
+                areas.preview,
+                app.config.editor.line_numbers,
+                gutter_style,
+                &app.editor_secondary_cursors,
+            );
             if app.show_slash_menu {
                 render_slash_menu(frame, areas.preview, editor, app);
+            }
+            if app.editor_find.is_some() {
+                render_editor_find(frame, areas.preview, editor, app);
             }
         }
     } else {
@@ -565,10 +575,7 @@ fn render_slash_menu(
     editor: &crate::editor::InlineEditor,
     app: &App,
 ) {
-    let inner = match editor.textarea.block() {
-        Some(block) => block.inner(area),
-        None => area,
-    };
+    let inner = editor.inner_area(area);
     if inner.width < 10 || inner.height < 3 {
         return;
     }
@@ -613,4 +620,73 @@ fn render_slash_menu(
         state.select(Some(app.slash_menu_selected));
     }
     frame.render_stateful_widget(list, popup_area, &mut state);
+}
+
+/// Ctrl+F's find/replace bar — two stacked single-line `InputBox`es pinned
+/// to the top of the editor's own inner area, the focused one bordered in
+/// the accent color so it's clear which field typing goes to. No dedicated
+/// "match highlight" style exists here: a match becomes the editor's own
+/// selection (`App::editor_find_step`), so it's already visible through
+/// the same selection-highlight rendering `InlineEditor::render` always
+/// does.
+fn render_editor_find(
+    frame: &mut Frame,
+    area: Rect,
+    editor: &crate::editor::InlineEditor,
+    app: &App,
+) {
+    use crate::app::FindField;
+    let Some(state) = &app.editor_find else {
+        return;
+    };
+    let inner = editor.inner_area(area);
+    if inner.width < 20 || inner.height < 6 {
+        return;
+    }
+    let accent = hex_to_color(&app.theme.accent);
+    let muted = hex_to_color(&app.theme.muted);
+    // Anchored top-*right*, not the full inner width from the left edge —
+    // same placement VS Code's own find widget uses, specifically so a
+    // short note's lines (which start at the left edge) aren't completely
+    // hidden underneath it the way a full-width bar would.
+    let width = inner.width.min(44);
+    let x = inner.x + inner.width - width;
+    let clear_area = Rect {
+        x,
+        y: inner.y,
+        width,
+        height: 6,
+    };
+    frame.render_widget(Clear, clear_area);
+    let query_area = Rect {
+        x,
+        y: inner.y,
+        width,
+        height: 3,
+    };
+    let replace_area = Rect {
+        x,
+        y: inner.y + 3,
+        width,
+        height: 3,
+    };
+    let query_color = if state.focus == FindField::Query {
+        accent
+    } else {
+        muted
+    };
+    let replace_color = if state.focus == FindField::Replace {
+        accent
+    } else {
+        muted
+    };
+    state
+        .query
+        .render(frame, query_area, " Find (enter/shift+enter) ", query_color);
+    state.replace.render(
+        frame,
+        replace_area,
+        " Replace (ctrl+enter/ctrl+alt+enter) ",
+        replace_color,
+    );
 }

--- a/shiki-tui/src/editor.rs
+++ b/shiki-tui/src/editor.rs
@@ -175,6 +175,7 @@ impl<'a> InlineEditor<'a> {
         area: Rect,
         line_numbers: bool,
         gutter_style: Style,
+        secondary_cursor_style: Style,
         secondary_cursors: &[crate::multicursor::CursorState],
     ) {
         if let Some(block) = self.textarea.block() {
@@ -245,6 +246,7 @@ impl<'a> InlineEditor<'a> {
             // shiki never calls `set_selection_style`, so this is the same
             // value `TextArea::default()` already uses internally.
             select: Style::default().bg(Color::LightBlue),
+            secondary_cursor: secondary_cursor_style,
         };
         let selection = self.textarea.selection_range();
 
@@ -291,6 +293,16 @@ struct RowStyles {
     cursor: Style,
     cursor_line: Style,
     select: Style,
+    /// A solid, theme-accent-colored block — deliberately *not* the same
+    /// style as `cursor` (a bare `Modifier::REVERSED`, tui-textarea's
+    /// default). A terminal can only ever blink *one* real caret, so
+    /// secondary cursors can't blink like the primary does regardless of
+    /// styling — but reusing the exact same subtle reverse-video look for
+    /// both made every secondary cursor easy to miss entirely at a glance
+    /// (reported live: "solo hay 1 visualmente, no parpadean varios
+    /// cursores"). A distinct solid color is the compensating signal real
+    /// multi-cursor TUIs (e.g. Helix) use for the same hard constraint.
+    secondary_cursor: Style,
 }
 
 struct SegmentCtx<'a> {
@@ -372,14 +384,18 @@ fn build_segment_line(
     let mut plain = String::new();
 
     for (col, &ch) in chars.iter().enumerate().take(end).skip(start) {
-        let is_cursor =
-            (ctx.is_cursor_segment && ctx.row == ctx.cursor_row && col == ctx.cursor_col)
-                || ctx.is_secondary_cursor(col);
-        if is_cursor {
+        let is_primary_cursor =
+            ctx.is_cursor_segment && ctx.row == ctx.cursor_row && col == ctx.cursor_col;
+        if is_primary_cursor {
             if !plain.is_empty() {
                 spans.push(Span::styled(std::mem::take(&mut plain), line_style));
             }
             spans.push(Span::styled(ch.to_string(), styles.cursor));
+        } else if ctx.is_secondary_cursor(col) {
+            if !plain.is_empty() {
+                spans.push(Span::styled(std::mem::take(&mut plain), line_style));
+            }
+            spans.push(Span::styled(ch.to_string(), styles.secondary_cursor));
         } else if ctx.is_selected(col) {
             if !plain.is_empty() {
                 spans.push(Span::styled(std::mem::take(&mut plain), line_style));
@@ -394,6 +410,13 @@ fn build_segment_line(
     }
     if ctx.is_cursor_segment && ctx.row == ctx.cursor_row && ctx.cursor_col == end {
         spans.push(Span::styled(" ", styles.cursor));
+    } else if ctx.is_secondary_cursor(end) {
+        // A secondary cursor sitting past the last character of the line
+        // (very common — it's exactly where a cursor lands right after
+        // typing) has no character of its own to attach a style to,
+        // same fallback the primary cursor's own end-of-line case above
+        // already needed.
+        spans.push(Span::styled(" ", styles.secondary_cursor));
     }
 
     Line::from(spans)
@@ -726,7 +749,9 @@ mod tests {
         let mut terminal = ratatui::Terminal::new(ratatui::backend::TestBackend::new(20, 5))
             .expect("test backend");
         terminal
-            .draw(|frame| editor.render(frame, area, false, Style::default(), &[]))
+            .draw(|frame| {
+                editor.render(frame, area, false, Style::default(), Style::default(), &[])
+            })
             .unwrap();
 
         // Row 0 is "hello", clicking column 3 lands on the 'l' at index 3.
@@ -749,7 +774,7 @@ mod tests {
         let mut terminal = ratatui::Terminal::new(ratatui::backend::TestBackend::new(20, 5))
             .expect("test backend");
         terminal
-            .draw(|frame| editor.render(frame, area, true, Style::default(), &[]))
+            .draw(|frame| editor.render(frame, area, true, Style::default(), Style::default(), &[]))
             .unwrap();
         // Gutter for a 1-line file is "1 " (2 columns) — a click landing
         // in the gutter itself clamps to column 0 of the actual text.

--- a/shiki-tui/src/editor.rs
+++ b/shiki-tui/src/editor.rs
@@ -7,6 +7,11 @@ use ratatui::widgets::Paragraph;
 use ratatui::Frame;
 use tui_textarea::TextArea;
 
+/// One source line's `wrap_line` break points — `(start, end)` char-index
+/// ranges, one per visual (post-wrap) segment. A plain type alias purely to
+/// keep signatures like `char_rows_and_wraps`'s readable.
+type WrapRanges = Vec<(usize, usize)>;
+
 /// Thin wrapper over `tui-textarea` for the inline editor (key `e`/`i`).
 ///
 /// `tui-textarea` 0.7 has no soft line-wrap at all — confirmed against its
@@ -73,21 +78,116 @@ impl<'a> InlineEditor<'a> {
         self.cursor_screen_row.get()
     }
 
+    /// `area` minus whatever block/border `tui-textarea` has configured —
+    /// the one place this match lives, reused by `render`, `position_at`,
+    /// and `draw.rs`'s slash-menu anchoring (which used to duplicate this
+    /// same match independently).
+    pub fn inner_area(&self, area: Rect) -> Rect {
+        match self.textarea.block() {
+            Some(block) => block.inner(area),
+            None => area,
+        }
+    }
+
+    /// Columns reserved for the line-number gutter when `line_numbers` is
+    /// on — digit count of the last line number, plus one padding column —
+    /// or `0` when the feature is off, so callers can subtract it from the
+    /// available width unconditionally without an extra branch.
+    fn gutter_width(&self, line_numbers: bool) -> u16 {
+        if !line_numbers {
+            return 0;
+        }
+        (self.textarea.lines().len().to_string().len() + 1) as u16
+    }
+
+    /// Computes each source line's characters plus its `wrap_line` break
+    /// points, at `width` columns — the one place both `render` and
+    /// `position_at` derive this, so a hit-test can never disagree with
+    /// what was actually painted (see the struct doc comment's own
+    /// reasoning for why `render` bypasses `tui-textarea`'s `Widget` impl
+    /// in the first place).
+    fn char_rows_and_wraps(&self, width: usize) -> (Vec<Vec<char>>, Vec<WrapRanges>) {
+        let char_rows: Vec<Vec<char>> = self
+            .textarea
+            .lines()
+            .iter()
+            .map(|l| l.chars().collect())
+            .collect();
+        let wraps: Vec<WrapRanges> = char_rows
+            .iter()
+            .map(|chars| wrap_line(chars, width))
+            .collect();
+        (char_rows, wraps)
+    }
+
+    /// Inverse of `render`'s own painting loop: maps a screen coordinate
+    /// (already known to be a mouse event's `column`/`row`) back onto a
+    /// logical `(row, col)` in the buffer, or `None` if it falls outside
+    /// the editor's inner area. Relies on `scroll_top` as of the *last*
+    /// `render` call, same assumption `cursor_screen_row()` already makes.
+    pub fn position_at(
+        &self,
+        area: Rect,
+        line_numbers: bool,
+        column: u16,
+        row: u16,
+    ) -> Option<(usize, usize)> {
+        let inner = self.inner_area(area);
+        if inner.width == 0
+            || inner.height == 0
+            || column < inner.x
+            || column >= inner.x + inner.width
+            || row < inner.y
+            || row >= inner.y + inner.height
+        {
+            return None;
+        }
+        let gutter = self.gutter_width(line_numbers);
+        let width = (inner.width as usize)
+            .saturating_sub(gutter as usize)
+            .max(1);
+        let (char_rows, wraps) = self.char_rows_and_wraps(width);
+        let target_visual_row = self.scroll_top.get() as usize + (row - inner.y) as usize;
+        let col_in_row = (column - inner.x).saturating_sub(gutter) as usize;
+
+        let mut visual_row = 0usize;
+        for (logical_row, _) in char_rows.iter().enumerate() {
+            for &(start, end) in &wraps[logical_row] {
+                if visual_row == target_visual_row {
+                    return Some((logical_row, (start + col_in_row).min(end)));
+                }
+                visual_row += 1;
+            }
+        }
+        // Clicked below the last rendered line — clamp to the end of the
+        // buffer rather than returning `None`, so a click just past the
+        // last line of a short note still lands somewhere sensible.
+        let last_row = char_rows.len().saturating_sub(1);
+        Some((last_row, char_rows.get(last_row).map(Vec::len).unwrap_or(0)))
+    }
+
     /// Renders the buffer word-wrapped to `area`'s width, instead of
     /// `tui-textarea`'s own unwrapped-with-horizontal-scroll rendering —
     /// see the struct doc comment for why this exists at all.
-    pub fn render(&self, frame: &mut Frame, area: Rect) {
-        let inner = match self.textarea.block() {
-            Some(block) => {
-                frame.render_widget(block.clone(), area);
-                block.inner(area)
-            }
-            None => area,
-        };
+    pub(crate) fn render(
+        &self,
+        frame: &mut Frame,
+        area: Rect,
+        line_numbers: bool,
+        gutter_style: Style,
+        secondary_cursors: &[crate::multicursor::CursorState],
+    ) {
+        if let Some(block) = self.textarea.block() {
+            frame.render_widget(block.clone(), area);
+        }
+        let inner = self.inner_area(area);
         if inner.width == 0 || inner.height == 0 {
             return;
         }
-        let width = inner.width as usize;
+        let gutter = self.gutter_width(line_numbers);
+        let width = (inner.width as usize)
+            .saturating_sub(gutter as usize)
+            .max(1);
         let height = inner.height as usize;
 
         // Bypassing `tui-textarea`'s own `Widget` impl (see the struct doc
@@ -101,10 +201,14 @@ impl<'a> InlineEditor<'a> {
             self.cursor_screen_row.set(0);
             let chars: Vec<char> = self.textarea.placeholder_text().chars().collect();
             let style = self.textarea.placeholder_style().unwrap_or_default();
+            let gutter_pad = " ".repeat(gutter as usize);
             let lines: Vec<Line<'static>> = wrap_line(&chars, width)
                 .into_iter()
                 .map(|(s, e)| {
-                    Line::from(Span::styled(chars[s..e].iter().collect::<String>(), style))
+                    Line::from(vec![
+                        Span::raw(gutter_pad.clone()),
+                        Span::styled(chars[s..e].iter().collect::<String>(), style),
+                    ])
                 })
                 .collect();
             let paragraph = Paragraph::new(lines).style(self.textarea.style());
@@ -112,12 +216,7 @@ impl<'a> InlineEditor<'a> {
             return;
         }
 
-        let source_lines = self.textarea.lines();
-        let char_rows: Vec<Vec<char>> = source_lines.iter().map(|l| l.chars().collect()).collect();
-        let wraps: Vec<Vec<(usize, usize)>> = char_rows
-            .iter()
-            .map(|chars| wrap_line(chars, width))
-            .collect();
+        let (char_rows, wraps) = self.char_rows_and_wraps(width);
 
         let (cursor_row, cursor_col) = self.textarea.cursor();
         let (cursor_local_row, _) = locate_in_wrap(&wraps[cursor_row], cursor_col);
@@ -163,8 +262,18 @@ impl<'a> InlineEditor<'a> {
                         cursor_col,
                         is_cursor_segment: row == cursor_row && local_idx == cursor_local_row,
                         selection,
+                        secondary: secondary_cursors,
                     };
-                    rendered.push(build_segment_line(chars, seg, &ctx, &styles));
+                    let mut line = build_segment_line(chars, seg, &ctx, &styles);
+                    if gutter > 0 {
+                        let prefix = if local_idx == 0 {
+                            format!("{:>w$} ", row + 1, w = (gutter as usize).saturating_sub(1))
+                        } else {
+                            " ".repeat(gutter as usize)
+                        };
+                        line.spans.insert(0, Span::styled(prefix, gutter_style));
+                    }
+                    rendered.push(line);
                 }
                 visual_row += 1;
             }
@@ -184,7 +293,7 @@ struct RowStyles {
     select: Style,
 }
 
-struct SegmentCtx {
+struct SegmentCtx<'a> {
     row: usize,
     cursor_row: usize,
     cursor_col: usize,
@@ -194,24 +303,51 @@ struct SegmentCtx {
     /// one of them, never zero or more than one.
     is_cursor_segment: bool,
     selection: Option<((usize, usize), (usize, usize))>,
+    /// `config.editor.multi_cursor`'s extra cursors, each with its own
+    /// independent selection — painted the same way the primary
+    /// cursor/selection already is, just looped over instead of singular.
+    secondary: &'a [crate::multicursor::CursorState],
 }
 
-impl SegmentCtx {
+/// Whether `(row, col)` falls within `[start, end)` (inclusive of every
+/// row strictly between them) — the one range-check both the primary
+/// selection and every secondary cursor's own selection use, so they can't
+/// disagree on what "inside the selection" means at a row boundary.
+fn pos_in_range(row: usize, col: usize, start: (usize, usize), end: (usize, usize)) -> bool {
+    let (sr, sc) = start;
+    let (er, ec) = end;
+    if row < sr || row > er {
+        false
+    } else if sr == er {
+        col >= sc && col < ec
+    } else if row == sr {
+        col >= sc
+    } else if row == er {
+        col < ec
+    } else {
+        true
+    }
+}
+
+impl SegmentCtx<'_> {
     fn is_selected(&self, col: usize) -> bool {
-        let Some(((sr, sc), (er, ec))) = self.selection else {
-            return false;
-        };
-        if self.row < sr || self.row > er {
-            false
-        } else if sr == er {
-            col >= sc && col < ec
-        } else if self.row == sr {
-            col >= sc
-        } else if self.row == er {
-            col < ec
-        } else {
-            true
+        if let Some((start, end)) = self.selection {
+            if pos_in_range(self.row, col, start, end) {
+                return true;
+            }
         }
+        self.secondary.iter().any(|c| {
+            c.anchor.is_some_and(|anchor| {
+                pos_in_range(self.row, col, anchor.min(c.pos), anchor.max(c.pos))
+            })
+        })
+    }
+
+    /// Whether `(self.row, col)` is exactly one of the secondary cursors'
+    /// own position — painted with the same `cursor` style the primary
+    /// cursor uses, distinguishing them from ordinary selected text.
+    fn is_secondary_cursor(&self, col: usize) -> bool {
+        self.secondary.iter().any(|c| c.pos == (self.row, col))
     }
 }
 
@@ -236,7 +372,9 @@ fn build_segment_line(
     let mut plain = String::new();
 
     for (col, &ch) in chars.iter().enumerate().take(end).skip(start) {
-        let is_cursor = ctx.is_cursor_segment && ctx.row == ctx.cursor_row && col == ctx.cursor_col;
+        let is_cursor =
+            (ctx.is_cursor_segment && ctx.row == ctx.cursor_row && col == ctx.cursor_col)
+                || ctx.is_secondary_cursor(col);
         if is_cursor {
             if !plain.is_empty() {
                 spans.push(Span::styled(std::mem::take(&mut plain), line_style));
@@ -327,6 +465,151 @@ fn locate_in_wrap(ranges: &[(usize, usize)], col: usize) -> (usize, usize) {
     (last, col - ranges[last].0)
 }
 
+/// Classifies a char the way a double-click "select the word under the
+/// cursor" needs to: whitespace never joins a word, and a run of
+/// word-characters (alphanumeric/`_`) is a different "word" than an
+/// adjacent run of punctuation — `"foo.bar"` double-clicked on `foo` should
+/// select just `foo`, not the whole dotted path. Mirrors the idea of
+/// `tui-textarea`'s own internal (non-`pub`, unreachable from shiki)
+/// `word.rs` classifier, reimplemented here since it can't be imported.
+#[derive(PartialEq, Eq)]
+enum CharKind {
+    Space,
+    Word,
+    Punct,
+}
+
+fn char_kind(c: char) -> CharKind {
+    if c.is_whitespace() {
+        CharKind::Space
+    } else if c.is_alphanumeric() || c == '_' {
+        CharKind::Word
+    } else {
+        CharKind::Punct
+    }
+}
+
+/// The char-range `[start, end)` of the "word" containing `col` within
+/// `chars` — used by double-click (select word) and, later, by Ctrl+D
+/// (select the word under the cursor as the initial multi-select query).
+/// `col == chars.len()` (cursor sitting past the last character) uses the
+/// *previous* character's kind, matching where a click there visually is.
+pub fn word_range(chars: &[char], col: usize) -> (usize, usize) {
+    if chars.is_empty() {
+        return (0, 0);
+    }
+    let at = col.min(chars.len() - 1);
+    let kind = char_kind(chars[at]);
+    if kind == CharKind::Space {
+        return (at, at + 1);
+    }
+    let mut start = at;
+    while start > 0 && char_kind(chars[start - 1]) == kind {
+        start -= 1;
+    }
+    let mut end = at + 1;
+    while end < chars.len() && char_kind(chars[end]) == kind {
+        end += 1;
+    }
+    (start, end)
+}
+
+/// Every occurrence of `query` across `lines`, case-insensitive, as
+/// `(row, start_col, end_col)` char-index triples in document order —
+/// plain literal substring matching (no regex), which is what Ctrl+F
+/// searches by default. A pure function of `&[String]` (not `&TextArea`)
+/// so it's independently testable, same reasoning as `word_range`.
+pub(crate) fn find_all_matches(lines: &[String], query: &str) -> Vec<(usize, usize, usize)> {
+    if query.is_empty() {
+        return Vec::new();
+    }
+    let query_lower: Vec<char> = query.to_lowercase().chars().collect();
+    let qlen = query_lower.len();
+    let mut matches = Vec::new();
+    for (row, line) in lines.iter().enumerate() {
+        let lower: Vec<char> = line.to_lowercase().chars().collect();
+        if lower.len() < qlen {
+            continue;
+        }
+        let mut col = 0;
+        while col + qlen <= lower.len() {
+            if lower[col..col + qlen] == query_lower[..] {
+                matches.push((row, col, col + qlen));
+                col += qlen;
+            } else {
+                col += 1;
+            }
+        }
+    }
+    matches
+}
+
+/// The next (or, if `backward`, previous) match strictly after/before
+/// `from` in document order, wrapping around the whole buffer when there
+/// is none — same "find next wraps to the top" behavior a real editor's
+/// find bar has. `from` is compared against each match's *start* position.
+pub(crate) fn next_match(
+    matches: &[(usize, usize, usize)],
+    from: (usize, usize),
+    backward: bool,
+) -> Option<(usize, usize, usize)> {
+    if backward {
+        matches
+            .iter()
+            .rev()
+            .find(|&&(r, s, _)| (r, s) < from)
+            .or_else(|| matches.last())
+            .copied()
+    } else {
+        matches
+            .iter()
+            .find(|&&(r, s, _)| (r, s) > from)
+            .or_else(|| matches.first())
+            .copied()
+    }
+}
+
+/// The literal text between two logical `(row, col)` positions (`start`
+/// assumed `<= end` in document order) — used to seed Ctrl+F's query from
+/// an existing selection, and to read out arbitrary selected text in
+/// general. A pure function of `&[String]`, not `&TextArea`, for the same
+/// testability reason as `find_all_matches`.
+pub(crate) fn selection_text(
+    lines: &[String],
+    start: (usize, usize),
+    end: (usize, usize),
+) -> String {
+    let (sr, sc) = start;
+    let (er, ec) = end;
+    if sr >= lines.len() {
+        return String::new();
+    }
+    if sr == er {
+        let chars: Vec<char> = lines[sr].chars().collect();
+        let sc = sc.min(chars.len());
+        let ec = ec.min(chars.len());
+        return chars[sc..ec].iter().collect();
+    }
+    let last_row = er.min(lines.len().saturating_sub(1));
+    let mut out = String::new();
+    for (row, line) in lines.iter().enumerate().take(last_row + 1).skip(sr) {
+        let chars: Vec<char> = line.chars().collect();
+        if row == sr {
+            let sc = sc.min(chars.len());
+            out.extend(&chars[sc..]);
+        } else if row == er {
+            let ec = ec.min(chars.len());
+            out.extend(&chars[..ec]);
+        } else {
+            out.push_str(line);
+        }
+        if row != er {
+            out.push('\n');
+        }
+    }
+    out
+}
+
 /// Smallest vertical scroll adjustment that keeps `cursor` inside a
 /// `height`-row-tall viewport currently topped at `prev_top` — scrolls up
 /// the instant the cursor moves above it, or down the instant it moves
@@ -394,5 +677,132 @@ mod tests {
         assert_eq!(next_scroll_top(0, 3, 5), 0); // cursor already visible
         assert_eq!(next_scroll_top(0, 7, 5), 3); // cursor below viewport
         assert_eq!(next_scroll_top(4, 1, 5), 1); // cursor above viewport
+    }
+
+    #[test]
+    fn word_range_selects_the_word_under_the_cursor() {
+        let line = chars("hello world");
+        assert_eq!(word_range(&line, 2), (0, 5)); // inside "hello"
+        assert_eq!(word_range(&line, 0), (0, 5)); // at its start
+        assert_eq!(word_range(&line, 6), (6, 11)); // inside "world"
+    }
+
+    #[test]
+    fn word_range_stops_at_punctuation() {
+        let line = chars("foo.bar");
+        assert_eq!(word_range(&line, 1), (0, 3)); // "foo"
+        assert_eq!(word_range(&line, 3), (3, 4)); // the "." itself
+        assert_eq!(word_range(&line, 5), (4, 7)); // "bar"
+    }
+
+    #[test]
+    fn word_range_on_whitespace_selects_just_that_cell() {
+        let line = chars("a b");
+        assert_eq!(word_range(&line, 1), (1, 2));
+    }
+
+    #[test]
+    fn word_range_clamps_past_the_last_character() {
+        let line = chars("hi");
+        assert_eq!(word_range(&line, 5), (0, 2));
+    }
+
+    #[test]
+    fn word_range_on_empty_line() {
+        assert_eq!(word_range(&[], 0), (0, 0));
+    }
+
+    #[test]
+    fn position_at_maps_a_click_back_to_the_clicked_character() {
+        let editor = InlineEditor::from_contents("hello\nworld foo");
+        let area = Rect {
+            x: 0,
+            y: 0,
+            width: 20,
+            height: 5,
+        };
+        // Render once so `scroll_top`/wrap state is established, same
+        // precondition `cursor_screen_row()` already documents.
+        let mut terminal = ratatui::Terminal::new(ratatui::backend::TestBackend::new(20, 5))
+            .expect("test backend");
+        terminal
+            .draw(|frame| editor.render(frame, area, false, Style::default(), &[]))
+            .unwrap();
+
+        // Row 0 is "hello", clicking column 3 lands on the 'l' at index 3.
+        assert_eq!(editor.position_at(area, false, 3, 0), Some((0, 3)));
+        // Row 1 is "world foo", clicking column 6 lands on 'f' at index 6.
+        assert_eq!(editor.position_at(area, false, 6, 1), Some((1, 6)));
+        // Outside the area entirely.
+        assert_eq!(editor.position_at(area, false, 30, 0), None);
+    }
+
+    #[test]
+    fn position_at_accounts_for_the_line_number_gutter() {
+        let editor = InlineEditor::from_contents("hello");
+        let area = Rect {
+            x: 0,
+            y: 0,
+            width: 20,
+            height: 5,
+        };
+        let mut terminal = ratatui::Terminal::new(ratatui::backend::TestBackend::new(20, 5))
+            .expect("test backend");
+        terminal
+            .draw(|frame| editor.render(frame, area, true, Style::default(), &[]))
+            .unwrap();
+        // Gutter for a 1-line file is "1 " (2 columns) — a click landing
+        // in the gutter itself clamps to column 0 of the actual text.
+        assert_eq!(editor.position_at(area, true, 0, 0), Some((0, 0)));
+        assert_eq!(editor.position_at(area, true, 2, 0), Some((0, 0)));
+    }
+
+    fn lines(s: &[&str]) -> Vec<String> {
+        s.iter().map(|l| l.to_string()).collect()
+    }
+
+    #[test]
+    fn find_all_matches_is_case_insensitive_and_non_overlapping() {
+        let doc = lines(&["Hello hello", "say HELLO again"]);
+        let matches = find_all_matches(&doc, "hello");
+        assert_eq!(matches, vec![(0, 0, 5), (0, 6, 11), (1, 4, 9)]);
+    }
+
+    #[test]
+    fn find_all_matches_returns_nothing_for_an_empty_query() {
+        assert_eq!(find_all_matches(&lines(&["anything"]), ""), Vec::new());
+    }
+
+    #[test]
+    fn next_match_wraps_around_in_both_directions() {
+        let matches = vec![(0, 0, 3), (1, 2, 5), (2, 0, 3)];
+        // Forward from the last match wraps to the first.
+        assert_eq!(next_match(&matches, (2, 0), false), Some((0, 0, 3)));
+        // Forward from before the first match lands on the first.
+        assert_eq!(next_match(&matches, (0, 0), false), Some((1, 2, 5)));
+        // Backward from the first match wraps to the last.
+        assert_eq!(next_match(&matches, (0, 0), true), Some((2, 0, 3)));
+        // Backward from after the last match lands on the last.
+        assert_eq!(next_match(&matches, (2, 3), true), Some((2, 0, 3)));
+    }
+
+    #[test]
+    fn next_match_none_when_there_are_no_matches() {
+        assert_eq!(next_match(&[], (0, 0), false), None);
+    }
+
+    #[test]
+    fn selection_text_extracts_a_single_line_range() {
+        let doc = lines(&["hello world"]);
+        assert_eq!(selection_text(&doc, (0, 6), (0, 11)), "world");
+    }
+
+    #[test]
+    fn selection_text_extracts_across_multiple_lines() {
+        let doc = lines(&["hello world", "second line", "third"]);
+        assert_eq!(
+            selection_text(&doc, (0, 6), (2, 3)),
+            "world\nsecond line\nthi"
+        );
     }
 }

--- a/shiki-tui/src/key_handlers.rs
+++ b/shiki-tui/src/key_handlers.rs
@@ -1,12 +1,12 @@
-use crossterm::event::{KeyCode, KeyEvent, MouseButton, MouseEvent, MouseEventKind};
+use crossterm::event::{KeyCode, KeyEvent, KeyModifiers, MouseButton, MouseEvent, MouseEventKind};
 use shiki_config::Config;
 use shiki_core::Notebook;
 
 use crate::app::{
     drawer_area, global_search_layout, global_search_popup_area, is_notebook_git_action,
-    looks_like_git_url, looks_like_path, relative_folder, shift, App, BatchOp, DeleteTarget, Focus,
-    Mode, PendingInput, PreviewSelection, QuickCommand, SelectedEntry, TrashedEntry, UpdateMsg,
-    UpdateState, PAGE_STEP,
+    looks_like_git_url, looks_like_path, relative_folder, shift, App, BatchOp, DeleteTarget,
+    EditorFindState, FindField, Focus, Mode, PendingInput, PreviewSelection, QuickCommand,
+    SelectedEntry, TrashedEntry, UpdateMsg, UpdateState, PAGE_STEP,
 };
 use crate::editor::InlineEditor;
 use crate::icons;
@@ -214,6 +214,7 @@ impl App {
                 SettingsSection::General => self.handle_general_field_enter(),
                 SettingsSection::Theme => self.handle_theme_field_enter(),
                 SettingsSection::Git => self.handle_git_field_enter(),
+                SettingsSection::Editor => self.handle_editor_field_enter(),
                 SettingsSection::Notebooks => {
                     let names = crate::panel_settings::sorted_notebook_names(self);
                     if let Some(name) = names.get(self.settings_selected) {
@@ -389,6 +390,43 @@ impl App {
                 ("auto_sync", self.config.git.auto_sync)
             }
             _ => return,
+        };
+        self.save_config();
+        self.set_status(format!("{label} -> {new_val}"));
+    }
+    /// EDITOR — every field is a plain bool toggle, no text/drill-down
+    /// fields at all, so `Enter` always just flips the selected row.
+    fn handle_editor_field_enter(&mut self) {
+        use crate::panel_settings::EditorField;
+        self.toggle_editor_bool(EditorField::ALL[self.settings_selected]);
+    }
+    fn toggle_editor_bool(&mut self, field: crate::panel_settings::EditorField) {
+        use crate::panel_settings::EditorField;
+        let (label, new_val) = match field {
+            EditorField::MouseSelection => {
+                self.config.editor.mouse_selection = !self.config.editor.mouse_selection;
+                ("mouse_selection", self.config.editor.mouse_selection)
+            }
+            EditorField::FindReplace => {
+                self.config.editor.find_replace = !self.config.editor.find_replace;
+                ("find_replace", self.config.editor.find_replace)
+            }
+            EditorField::OsClipboard => {
+                self.config.editor.os_clipboard = !self.config.editor.os_clipboard;
+                ("os_clipboard", self.config.editor.os_clipboard)
+            }
+            EditorField::SelectAllCtrlA => {
+                self.config.editor.select_all_ctrl_a = !self.config.editor.select_all_ctrl_a;
+                ("select_all_ctrl_a", self.config.editor.select_all_ctrl_a)
+            }
+            EditorField::LineNumbers => {
+                self.config.editor.line_numbers = !self.config.editor.line_numbers;
+                ("line_numbers", self.config.editor.line_numbers)
+            }
+            EditorField::MultiCursor => {
+                self.config.editor.multi_cursor = !self.config.editor.multi_cursor;
+                ("multi_cursor", self.config.editor.multi_cursor)
+            }
         };
         self.save_config();
         self.set_status(format!("{label} -> {new_val}"));
@@ -1247,13 +1285,66 @@ impl App {
     pub fn on_mouse(&mut self, mouse: MouseEvent) {
         match mouse.kind {
             MouseEventKind::Down(MouseButton::Left) => {
-                self.on_mouse_down(mouse.column, mouse.row);
+                // Alt+Click adds a multi-cursor at the clicked position
+                // instead of moving the primary cursor there — crossterm
+                // doesn't report Alt-modified mouse events uniformly
+                // across every terminal emulator, so a terminal that
+                // doesn't forward the modifier just degrades gracefully
+                // to a plain single-cursor click, never a crash or a
+                // stuck state.
+                if self.mode == Mode::Edit
+                    && self.config.editor.mouse_selection
+                    && self.config.editor.multi_cursor
+                    && mouse.modifiers.contains(KeyModifiers::ALT)
+                {
+                    self.on_editor_alt_click(mouse.column, mouse.row);
+                } else {
+                    self.on_mouse_down(mouse.column, mouse.row);
+                }
             }
             MouseEventKind::Drag(MouseButton::Left) => {
                 self.on_mouse_drag(mouse.column, mouse.row);
             }
             MouseEventKind::Up(MouseButton::Left) => self.on_mouse_up(),
             _ => {}
+        }
+    }
+
+    /// Handles a terminal bracketed-paste event (`Event::Paste`, enabled
+    /// unconditionally at startup — see `shiki-cli/src/tui.rs`). This has
+    /// to be handled somewhere regardless of `config.editor.os_clipboard`:
+    /// once bracketed-paste mode is on, *every* terminal paste anywhere in
+    /// the app arrives this way instead of as a burst of individual
+    /// `Event::Key`s, so silently dropping it here would break pasting
+    /// into every text prompt in the app (new note, rename, global search,
+    /// ...), not just the note editor.
+    ///
+    /// Plain-text editing (`Mode::Edit`, no find bar or slash menu open)
+    /// gets the one genuine improvement: the whole paste lands as a single
+    /// `insert_str` — one undo step, and immune to the `/`-menu
+    /// mis-firing if the pasted text happens to start with `/` (see
+    /// `handle_edit_key`'s own `/`-detection comment). Every other context
+    /// (the find/replace bar, the slash menu, and any `InputBox`-driven
+    /// prompt — new note, rename, global search, settings text fields,
+    /// which-key's filter, ...) has no bulk-insert of its own, so it's
+    /// replayed as if each character had arrived as an ordinary keystroke
+    /// — exactly what it looked like before bracketed-paste mode existed.
+    pub fn on_paste(&mut self, text: String) {
+        if self.mode == Mode::Edit && self.editor_find.is_none() && !self.show_slash_menu {
+            if let Some(editor) = &mut self.editor {
+                editor.textarea.insert_str(&text);
+                self.editor_undo_groups.push(1);
+                self.editor_redo_groups.clear();
+            }
+            return;
+        }
+        for c in text.chars() {
+            let code = if c == '\n' {
+                KeyCode::Enter
+            } else {
+                KeyCode::Char(c)
+            };
+            self.on_key(KeyEvent::new(code, KeyModifiers::NONE));
         }
     }
 
@@ -1285,6 +1376,11 @@ impl App {
             return;
         }
 
+        if self.mode == Mode::Edit && self.config.editor.mouse_selection {
+            self.on_editor_mouse_down(column, row);
+            return;
+        }
+
         if self.can_start_preview_selection() {
             let preview = layout::split(self.last_frame_area, self.focus).preview;
             let row_count = self.note_preview_lines().map(|l| l.len()).unwrap_or(0);
@@ -1306,6 +1402,12 @@ impl App {
     }
 
     fn on_mouse_drag(&mut self, column: u16, row: u16) {
+        if self.mode == Mode::Edit && self.config.editor.mouse_selection {
+            if self.editor_click_count > 0 {
+                self.on_editor_mouse_drag(column, row);
+            }
+            return;
+        }
         if self.preview_selection.is_none() {
             return;
         }
@@ -1336,6 +1438,7 @@ impl App {
     }
 
     fn on_mouse_up(&mut self) {
+        self.editor_drag_active = false;
         let Some(selection) = self.preview_selection.take() else {
             return;
         };
@@ -1365,6 +1468,128 @@ impl App {
         ));
     }
 
+    /// Alt+Click (`config.editor.multi_cursor`): adds a plain cursor at
+    /// the clicked position — dedups against the primary and every
+    /// existing secondary (see `multicursor::add_cursor_at`), so clicking
+    /// an already-present cursor's exact cell is a harmless no-op rather
+    /// than a duplicate.
+    fn on_editor_alt_click(&mut self, column: u16, row: u16) {
+        let preview = layout::split(self.last_frame_area, self.focus).preview;
+        let line_numbers = self.config.editor.line_numbers;
+        let Some(editor) = &self.editor else {
+            return;
+        };
+        let Some(pos) = editor.position_at(preview, line_numbers, column, row) else {
+            return;
+        };
+        let primary = editor.textarea.cursor();
+        crate::multicursor::add_cursor_at(&mut self.editor_secondary_cursors, primary, pos);
+    }
+    /// `config.editor.mouse_selection`'s click handling: single click
+    /// positions the cursor, a second click within `MULTI_CLICK_WINDOW` on
+    /// the same cell selects the word under it, a third selects the whole
+    /// line — same click-counting idea as a real GUI text editor, since
+    /// crossterm itself has no concept of a "double click" event. Resets
+    /// `editor_drag_active` for the new gesture: `true` when the click
+    /// itself already established a selection (word/line), so the first
+    /// `Drag` event that follows extends *that* selection instead of
+    /// re-anchoring it at the drag's own start (which would discard the
+    /// word/line just selected); `false` for a plain single click, which
+    /// hasn't anchored anything yet.
+    fn on_editor_mouse_down(&mut self, column: u16, row: u16) {
+        let preview = layout::split(self.last_frame_area, self.focus).preview;
+        let line_numbers = self.config.editor.line_numbers;
+        let Some(editor) = &mut self.editor else {
+            return;
+        };
+        let Some((doc_row, doc_col)) = editor.position_at(preview, line_numbers, column, row)
+        else {
+            return;
+        };
+        let now = std::time::Instant::now();
+        const MULTI_CLICK_WINDOW: std::time::Duration = std::time::Duration::from_millis(400);
+        let same_cell = self.editor_last_click.is_some_and(|(t, c, r)| {
+            c == column && r == row && now.duration_since(t) < MULTI_CLICK_WINDOW
+        });
+        self.editor_click_count = if same_cell {
+            (self.editor_click_count + 1).min(3)
+        } else {
+            1
+        };
+        self.editor_last_click = Some((now, column, row));
+
+        match self.editor_click_count {
+            2 => {
+                let chars: Vec<char> = editor.textarea.lines()[doc_row].chars().collect();
+                let (start, end) = crate::editor::word_range(&chars, doc_col);
+                editor.textarea.cancel_selection();
+                editor
+                    .textarea
+                    .move_cursor(tui_textarea::CursorMove::Jump(doc_row as u16, start as u16));
+                editor.textarea.start_selection();
+                editor
+                    .textarea
+                    .move_cursor(tui_textarea::CursorMove::Jump(doc_row as u16, end as u16));
+            }
+            3 => {
+                editor.textarea.cancel_selection();
+                editor
+                    .textarea
+                    .move_cursor(tui_textarea::CursorMove::Jump(doc_row as u16, 0));
+                editor.textarea.start_selection();
+                editor
+                    .textarea
+                    .move_cursor(tui_textarea::CursorMove::Jump(doc_row as u16, u16::MAX));
+            }
+            _ => {
+                editor.textarea.cancel_selection();
+                editor.textarea.move_cursor(tui_textarea::CursorMove::Jump(
+                    doc_row as u16,
+                    doc_col as u16,
+                ));
+            }
+        }
+        self.editor_drag_active = self.editor_click_count > 1;
+    }
+    /// Extends the in-progress editor selection while dragging — clamps to
+    /// the editor's own inner area (no auto-scroll in v1, same reasoning
+    /// and convention as PREVIEW's own `on_mouse_drag` above). The first
+    /// drag event after a plain single click anchors the selection there
+    /// (`tui_textarea::TextArea::move_cursor` auto-extends from an anchor
+    /// set by `start_selection`, so no separate anchor bookkeeping is
+    /// needed in shiki itself); a drag following a double/triple click
+    /// skips re-anchoring since one already exists (see `editor_drag_active`'s
+    /// own doc comment).
+    fn on_editor_mouse_drag(&mut self, column: u16, row: u16) {
+        let preview = layout::split(self.last_frame_area, self.focus).preview;
+        let line_numbers = self.config.editor.line_numbers;
+        let Some(editor) = &mut self.editor else {
+            return;
+        };
+        let inner = editor.inner_area(preview);
+        if inner.width == 0 || inner.height == 0 {
+            return;
+        }
+        let left = inner.x;
+        let right = (inner.x + inner.width).saturating_sub(1).max(left);
+        let top = inner.y;
+        let bottom = (inner.y + inner.height).saturating_sub(1).max(top);
+        let clamped_column = column.clamp(left, right);
+        let clamped_row = row.clamp(top, bottom);
+        let Some((doc_row, doc_col)) =
+            editor.position_at(preview, line_numbers, clamped_column, clamped_row)
+        else {
+            return;
+        };
+        if !self.editor_drag_active {
+            editor.textarea.start_selection();
+            self.editor_drag_active = true;
+        }
+        editor.textarea.move_cursor(tui_textarea::CursorMove::Jump(
+            doc_row as u16,
+            doc_col as u16,
+        ));
+    }
     /// Guards `on_mouse_down`'s preview-selection branch: the feature is off
     /// in config, we're editing the note inline (the preview `Rect` belongs
     /// to the editor then, not `panel_preview::render`), or some modal is
@@ -2634,15 +2859,105 @@ impl App {
         }
     }
     fn handle_edit_key(&mut self, key: KeyEvent) {
+        if self.editor_find.is_some() {
+            self.handle_editor_find_key(key);
+            return;
+        }
         if self.show_slash_menu {
             self.handle_slash_menu_key(key);
             return;
         }
         match key.code {
-            KeyCode::Esc => self.save_and_exit_edit(),
+            // Esc first collapses multi-cursor editing back to just the
+            // primary (VS Code's own "Escape removes secondary cursors"
+            // convention) — only a *second* Esc, with no secondaries left,
+            // actually saves and exits.
+            KeyCode::Esc => {
+                if self.editor_secondary_cursors.is_empty() {
+                    self.save_and_exit_edit();
+                } else {
+                    self.editor_secondary_cursors.clear();
+                }
+            }
+            KeyCode::Char('f')
+                if key.modifiers.contains(KeyModifiers::CONTROL)
+                    && self.config.editor.find_replace =>
+            {
+                self.open_editor_find();
+            }
+            KeyCode::Char('c')
+                if key.modifiers.contains(KeyModifiers::CONTROL)
+                    && self.config.editor.os_clipboard =>
+            {
+                self.editor_copy_selection();
+            }
+            KeyCode::Char('x')
+                if key.modifiers.contains(KeyModifiers::CONTROL)
+                    && self.config.editor.os_clipboard =>
+            {
+                self.editor_cut_selection();
+            }
+            KeyCode::Char('v')
+                if key.modifiers.contains(KeyModifiers::CONTROL)
+                    && self.config.editor.os_clipboard =>
+            {
+                self.editor_paste_os();
+            }
+            // Off by default: tui-textarea's own Ctrl+A is Emacs-style
+            // "move to start of line," existing muscle memory this
+            // shouldn't change unless explicitly opted into. Also
+            // collapses any secondary cursors first — "select everything,
+            // replicated across N cursors" isn't a meaningful state.
+            KeyCode::Char('a')
+                if key.modifiers.contains(KeyModifiers::CONTROL)
+                    && self.config.editor.select_all_ctrl_a =>
+            {
+                self.editor_secondary_cursors.clear();
+                if let Some(editor) = &mut self.editor {
+                    editor.textarea.select_all();
+                }
+            }
+            // Off by default, and collides with tui-textarea's own Emacs
+            // Ctrl+D ("delete next character") the moment it's turned on —
+            // an accepted tradeoff, same category as `select_all_ctrl_a`'s
+            // own collision with Emacs Ctrl+A, since multi-cursor is opt-in.
+            KeyCode::Char('d')
+                if key.modifiers.contains(KeyModifiers::CONTROL)
+                    && self.config.editor.multi_cursor =>
+            {
+                self.editor_add_next_occurrence();
+            }
+            KeyCode::Char('u') if key.modifiers.contains(KeyModifiers::CONTROL) => {
+                self.editor_undo();
+            }
+            KeyCode::Char('r') if key.modifiers.contains(KeyModifiers::CONTROL) => {
+                self.editor_redo();
+            }
             _ => {
                 if let Some(editor) = &mut self.editor {
-                    editor.textarea.input(key);
+                    let edits = if self.editor_secondary_cursors.is_empty() {
+                        // A plain `input()` call can itself push *two*
+                        // history entries (typing over an active selection
+                        // is "delete selection, then insert" — see
+                        // `multicursor::undo_history_depth`'s own doc
+                        // comment for why this is measured, not assumed).
+                        let snapshot = editor.textarea.lines().to_vec();
+                        if editor.textarea.input(key) {
+                            crate::multicursor::undo_history_depth(&mut editor.textarea, &snapshot)
+                        } else {
+                            0
+                        }
+                    } else {
+                        crate::multicursor::replay_keystroke(
+                            &mut editor.textarea,
+                            key,
+                            &mut self.editor_secondary_cursors,
+                        )
+                    };
+                    if edits > 0 {
+                        self.editor_undo_groups.push(edits);
+                        self.editor_redo_groups.clear();
+                    }
                 }
                 // `/` only opens the menu when it lands as the very first
                 // character of the line (cursor was at column 0, so it's
@@ -2660,6 +2975,354 @@ impl App {
                 }
             }
         }
+    }
+    /// Ctrl+C (`config.editor.os_clipboard`): extracts the selected text
+    /// *before* mutating anything (`copy()` may collapse/alter the
+    /// selection as a side effect), writes it to the real OS clipboard —
+    /// falling back automatically to the existing OSC 52 mechanism when
+    /// arboard can't reach a display server (headless SSH) — and still
+    /// calls `copy()` too, so the internal yank register (and thus Ctrl+V
+    /// with `os_clipboard` off) stays in sync regardless.
+    fn editor_copy_selection(&mut self) {
+        let Some(editor) = &mut self.editor else {
+            return;
+        };
+        let Some((start, end)) = editor.textarea.selection_range() else {
+            return;
+        };
+        let text = crate::editor::selection_text(editor.textarea.lines(), start, end);
+        editor.textarea.copy();
+        if !crate::clipboard::copy_os(&text) {
+            crate::clipboard::copy(&text);
+        }
+    }
+    /// Ctrl+X — same as `editor_copy_selection` but deletes the selection
+    /// (`cut()`) instead of leaving it in place.
+    fn editor_cut_selection(&mut self) {
+        let Some(editor) = &mut self.editor else {
+            return;
+        };
+        let Some((start, end)) = editor.textarea.selection_range() else {
+            return;
+        };
+        let text = crate::editor::selection_text(editor.textarea.lines(), start, end);
+        let cut = editor.textarea.cut();
+        if !crate::clipboard::copy_os(&text) {
+            crate::clipboard::copy(&text);
+        }
+        if cut {
+            self.editor_undo_groups.push(1);
+            self.editor_redo_groups.clear();
+        }
+    }
+    /// Ctrl+V — tries the real OS clipboard first; if arboard can't reach
+    /// one (no display server), falls through to `tui-textarea`'s own
+    /// internal yank register (`paste()`), exactly what Ctrl+V already did
+    /// before `os_clipboard` existed, so nothing regresses in that case.
+    fn editor_paste_os(&mut self) {
+        let Some(editor) = &mut self.editor else {
+            return;
+        };
+        let pasted = match crate::clipboard::paste_os() {
+            Some(text) => editor.textarea.insert_str(&text),
+            None => editor.textarea.paste(),
+        };
+        if pasted {
+            self.editor_undo_groups.push(1);
+            self.editor_redo_groups.clear();
+        }
+    }
+    /// Ctrl+U — pops the most recent entry off `editor_undo_groups` and
+    /// undoes exactly that many steps as one action, stopping early if
+    /// `textarea.undo()` ever returns `false` (nothing left to undo — an
+    /// empty stack pops `1` as a harmless default, which just no-ops
+    /// against `undo()`'s own "nothing to undo" case). Pushes however many
+    /// steps were *actually* undone onto `editor_redo_groups`, so the next
+    /// Ctrl+R restores exactly that many, not the (possibly larger)
+    /// originally-requested count.
+    fn editor_undo(&mut self) {
+        let count = self.editor_undo_groups.pop().unwrap_or(1);
+        let Some(editor) = &mut self.editor else {
+            return;
+        };
+        let mut undone = 0;
+        for _ in 0..count {
+            if !editor.textarea.undo() {
+                break;
+            }
+            undone += 1;
+        }
+        if undone > 0 {
+            self.editor_redo_groups.push(undone);
+        }
+    }
+    /// Ctrl+R — mirrors `editor_undo` for redo.
+    fn editor_redo(&mut self) {
+        let count = self.editor_redo_groups.pop().unwrap_or(1);
+        let Some(editor) = &mut self.editor else {
+            return;
+        };
+        let mut redone = 0;
+        for _ in 0..count {
+            if !editor.textarea.redo() {
+                break;
+            }
+            redone += 1;
+        }
+        if redone > 0 {
+            self.editor_undo_groups.push(redone);
+        }
+    }
+    /// Ctrl+D (`config.editor.multi_cursor`): the first press (primary has
+    /// no selection yet) just selects the word under the cursor, matching
+    /// VS Code's own first-press behavior — no new cursor yet. Every press
+    /// after that adds a new selecting cursor at the next occurrence of
+    /// the current selection's text, searching forward from whichever
+    /// existing cursor (primary or secondary) sits furthest along in the
+    /// document, and wrapping around the whole buffer. Reports "no more
+    /// occurrences" instead of adding a duplicate once every occurrence
+    /// already has its own cursor.
+    fn editor_add_next_occurrence(&mut self) {
+        let Some(editor) = &mut self.editor else {
+            return;
+        };
+        if editor.textarea.selection_range().is_none() {
+            let (row, col) = editor.textarea.cursor();
+            let chars: Vec<char> = editor.textarea.lines()[row].chars().collect();
+            let (start, end) = crate::editor::word_range(&chars, col);
+            if start == end {
+                return;
+            }
+            editor
+                .textarea
+                .move_cursor(tui_textarea::CursorMove::Jump(row as u16, start as u16));
+            editor.textarea.start_selection();
+            editor
+                .textarea
+                .move_cursor(tui_textarea::CursorMove::Jump(row as u16, end as u16));
+            return;
+        }
+        let (start, end) = editor.textarea.selection_range().unwrap();
+        let query = crate::editor::selection_text(editor.textarea.lines(), start, end);
+        if query.is_empty() {
+            return;
+        }
+        let matches = crate::editor::find_all_matches(editor.textarea.lines(), &query);
+        let last_end = self
+            .editor_secondary_cursors
+            .iter()
+            .map(|c| c.pos)
+            .chain(std::iter::once(end))
+            .max()
+            .unwrap_or(end);
+        let Some((row, mstart, mend)) = crate::editor::next_match(&matches, last_end, false) else {
+            self.set_status("no more occurrences".into());
+            return;
+        };
+        if !crate::multicursor::add_occurrence(
+            &mut self.editor_secondary_cursors,
+            row,
+            mstart,
+            mend,
+        ) {
+            self.set_status("no more occurrences".into());
+        }
+    }
+    /// Opens Ctrl+F's find/replace bar, seeding the query from the current
+    /// selection's text when one exists (so selecting a word first and
+    /// pressing Ctrl+F searches for it immediately, same convenience a GUI
+    /// editor's find bar has) — otherwise empty. `anchor` (where a fresh
+    /// search starts scanning from) is the cursor position at the moment
+    /// the bar opens.
+    fn open_editor_find(&mut self) {
+        let Some(editor) = &self.editor else {
+            return;
+        };
+        let seed = editor
+            .textarea
+            .selection_range()
+            .map(|(start, end)| crate::editor::selection_text(editor.textarea.lines(), start, end))
+            .unwrap_or_default();
+        let anchor = editor.textarea.cursor();
+        self.editor_find = Some(EditorFindState {
+            query: InputBox { value: seed },
+            replace: InputBox::default(),
+            focus: FindField::Query,
+            anchor,
+        });
+    }
+    fn handle_editor_find_key(&mut self, key: KeyEvent) {
+        let Some(state) = &mut self.editor_find else {
+            return;
+        };
+        match key.code {
+            KeyCode::Esc => {
+                self.editor_find = None;
+                if let Some(editor) = &mut self.editor {
+                    editor.textarea.cancel_selection();
+                }
+            }
+            KeyCode::Tab => {
+                state.focus = match state.focus {
+                    FindField::Query => FindField::Replace,
+                    FindField::Replace => FindField::Query,
+                };
+            }
+            KeyCode::Backspace => {
+                match state.focus {
+                    FindField::Query => state.query.backspace(),
+                    FindField::Replace => state.replace.backspace(),
+                }
+                if state.focus == FindField::Query {
+                    self.editor_find_step(false);
+                }
+            }
+            KeyCode::Char(c) => {
+                match state.focus {
+                    FindField::Query => state.query.push(c),
+                    FindField::Replace => state.replace.push(c),
+                }
+                if state.focus == FindField::Query {
+                    self.editor_find_step(false);
+                }
+            }
+            KeyCode::Enter => {
+                let ctrl = key.modifiers.contains(KeyModifiers::CONTROL);
+                let alt = key.modifiers.contains(KeyModifiers::ALT);
+                if ctrl && alt {
+                    self.editor_replace_all();
+                } else if ctrl {
+                    self.editor_replace_current_and_advance();
+                } else if key.modifiers.contains(KeyModifiers::SHIFT) {
+                    self.editor_find_step(true);
+                } else {
+                    self.editor_find_step(false);
+                }
+            }
+            _ => {}
+        }
+    }
+    /// Jumps to the next (or, if `backward`, previous) match, selecting it
+    /// (`cancel_selection` + `start_selection` + `move_cursor(Jump(..))`,
+    /// the exact same pattern double/triple-click already established) so
+    /// it's visible via the editor's own selection-highlight rendering —
+    /// there's no separate "search highlight" style, the match just becomes
+    /// the current selection. Search continues from the current
+    /// selection's end (forward) or start (backward) once one exists, or
+    /// from the bar's `anchor` before any match has been jumped to yet.
+    fn editor_find_step(&mut self, backward: bool) {
+        let Some(state) = &self.editor_find else {
+            return;
+        };
+        let query = state.query.value.clone();
+        let anchor = state.anchor;
+        let Some(editor) = &mut self.editor else {
+            return;
+        };
+        let matches = crate::editor::find_all_matches(editor.textarea.lines(), &query);
+        if matches.is_empty() {
+            editor.textarea.cancel_selection();
+            return;
+        }
+        let from = editor
+            .textarea
+            .selection_range()
+            .map(|(start, end)| if backward { start } else { end })
+            .unwrap_or(anchor);
+        if let Some((row, start, end)) = crate::editor::next_match(&matches, from, backward) {
+            editor.textarea.cancel_selection();
+            editor
+                .textarea
+                .move_cursor(tui_textarea::CursorMove::Jump(row as u16, start as u16));
+            editor.textarea.start_selection();
+            editor
+                .textarea
+                .move_cursor(tui_textarea::CursorMove::Jump(row as u16, end as u16));
+        }
+    }
+    /// Ctrl+Enter: replaces the currently-selected match (if the selection
+    /// is in fact a match — it always is right after `editor_find_step`,
+    /// since a match becoming the selection is the only way one gets
+    /// created while the find bar is open) and advances to the next one.
+    /// `cut()` and `insert_str()` are two *separate* undo-history entries
+    /// (verified directly: undoing once after a cut+insert only reverts
+    /// the insert, leaving the cut text still missing) — pushing a flat
+    /// `1` here would leave Ctrl+U in a broken halfway state after every
+    /// single replacement, so the group size is the sum of their own
+    /// return values (each `true` means that call actually pushed an
+    /// entry) instead of an assumed constant.
+    fn editor_replace_current_and_advance(&mut self) {
+        let replacement = match &self.editor_find {
+            Some(state) => state.replace.value.clone(),
+            None => return,
+        };
+        let mut group = 0usize;
+        if let Some(editor) = &mut self.editor {
+            if editor.textarea.selection_range().is_some() {
+                group += usize::from(editor.textarea.cut());
+                group += usize::from(editor.textarea.insert_str(&replacement));
+            }
+        }
+        if group > 0 {
+            self.editor_undo_groups.push(group);
+            self.editor_redo_groups.clear();
+        }
+        self.editor_find_step(false);
+    }
+    /// Ctrl+Alt+Enter: replaces every occurrence. Always re-searches from
+    /// scratch each iteration (the buffer just changed) but only accepts a
+    /// match at or after `search_from` — which advances to the real cursor
+    /// position after each replacement — so a replacement that happens to
+    /// contain the query itself (e.g. "a" -> "aa") can never re-match its
+    /// own freshly-inserted text and loop forever. The *whole* replace-all
+    /// undoes as one Ctrl+U (one pushed group summing every individual
+    /// `cut`/`insert_str`'s own real return value — see
+    /// `editor_replace_current_and_advance`'s doc comment for why that sum
+    /// matters instead of an assumed constant), not one occurrence at a
+    /// time — cheap to get right now that `editor_undo_groups` is a real
+    /// stack instead of a single pending value.
+    fn editor_replace_all(&mut self) {
+        let (query, replacement) = match &self.editor_find {
+            Some(state) => (state.query.value.clone(), state.replace.value.clone()),
+            None => return,
+        };
+        if query.is_empty() {
+            return;
+        }
+        let Some(editor) = &mut self.editor else {
+            return;
+        };
+        let mut count = 0usize;
+        let mut group = 0usize;
+        let mut search_from = (0usize, 0usize);
+        loop {
+            let matches = crate::editor::find_all_matches(editor.textarea.lines(), &query);
+            let Some(&(row, start, end)) = matches.iter().find(|&&(r, s, _)| (r, s) >= search_from)
+            else {
+                break;
+            };
+            editor.textarea.cancel_selection();
+            editor
+                .textarea
+                .move_cursor(tui_textarea::CursorMove::Jump(row as u16, start as u16));
+            editor.textarea.start_selection();
+            editor
+                .textarea
+                .move_cursor(tui_textarea::CursorMove::Jump(row as u16, end as u16));
+            group += usize::from(editor.textarea.cut());
+            group += usize::from(editor.textarea.insert_str(&replacement));
+            search_from = editor.textarea.cursor();
+            count += 1;
+        }
+        editor.textarea.cancel_selection();
+        if group > 0 {
+            self.editor_undo_groups.push(group);
+            self.editor_redo_groups.clear();
+        }
+        self.set_status(format!(
+            "replaced {count} occurrence{}",
+            if count == 1 { "" } else { "s" }
+        ));
     }
     /// The typed filter for the `/`-menu: everything after the leading `/`
     /// up to the cursor, read live off the editor's own buffer rather than

--- a/shiki-tui/src/key_handlers.rs
+++ b/shiki-tui/src/key_handlers.rs
@@ -1306,7 +1306,30 @@ impl App {
                 self.on_mouse_drag(mouse.column, mouse.row);
             }
             MouseEventKind::Up(MouseButton::Left) => self.on_mouse_up(),
+            MouseEventKind::ScrollUp => self.on_mouse_scroll(-1),
+            MouseEventKind::ScrollDown => self.on_mouse_scroll(1),
             _ => {}
+        }
+    }
+
+    /// Mouse wheel scroll — never handled at all before this (verified
+    /// live: scrolling over PREVIEW or the editor did nothing whatsoever).
+    /// Moves the editor's cursor by a few rows (`Mode::Edit` — the only way
+    /// to scroll the view at all, since `InlineEditor`'s own scroll offset
+    /// is entirely cursor-driven, not an independent viewport state) or
+    /// reuses `move_selection`'s existing delta logic (`Mode::Normal`/
+    /// `Visual`, covers NOTEBOOKS/NOTES/PREVIEW identically to `j`/`k`) —
+    /// gated on `no_modal_open()` so scrolling over a popup can't reach the
+    /// layout underneath it.
+    fn on_mouse_scroll(&mut self, dir: isize) {
+        const SCROLL_STEP: isize = 3;
+        if !self.no_modal_open() {
+            return;
+        }
+        if self.mode == Mode::Edit {
+            self.editor_scroll_cursor(dir * SCROLL_STEP);
+        } else if self.mode == Mode::Normal || self.mode == Mode::Visual {
+            self.move_selection(dir * SCROLL_STEP);
         }
     }
 
@@ -1600,9 +1623,15 @@ impl App {
     /// a click reaching any of these shouldn't be reinterpreted as a
     /// PREVIEW text selection.
     fn can_start_preview_selection(&self) -> bool {
-        self.config.general.mouse_drag_selection
-            && self.mode != Mode::Edit
-            && !self.show_slash_menu
+        self.config.general.mouse_drag_selection && self.mode != Mode::Edit && self.no_modal_open()
+    }
+    /// Whether any overlay is currently covering the 3-pane layout — every
+    /// popup/modal flag this app has, in one place, so a click or scroll
+    /// reaching the layout underneath one of them can't be misinterpreted
+    /// as belonging to NOTEBOOKS/NOTES/PREVIEW. Shared by
+    /// `can_start_preview_selection` and mouse-wheel scrolling.
+    fn no_modal_open(&self) -> bool {
+        !self.show_slash_menu
             && self.pending_input.is_none()
             && !self.show_tags
             && !self.show_theme_picker
@@ -2933,6 +2962,52 @@ impl App {
             KeyCode::Char('r') if key.modifiers.contains(KeyModifiers::CONTROL) => {
                 self.editor_redo();
             }
+            // VS Code's own "Add Cursor Above/Below" binding — a keyboard
+            // alternative to Alt+Click that doesn't need the mouse at all,
+            // requested after Alt+Click felt uncomfortable in practice.
+            KeyCode::Up
+                if key.modifiers.contains(KeyModifiers::CONTROL)
+                    && key.modifiers.contains(KeyModifiers::ALT)
+                    && self.config.editor.multi_cursor =>
+            {
+                self.editor_add_cursor_vertical(-1);
+            }
+            KeyCode::Down
+                if key.modifiers.contains(KeyModifiers::CONTROL)
+                    && key.modifiers.contains(KeyModifiers::ALT)
+                    && self.config.editor.multi_cursor =>
+            {
+                self.editor_add_cursor_vertical(1);
+            }
+            // Always replaces the generic forward for these two — see
+            // `editor_scroll_cursor`'s own doc comment for why forwarding
+            // them to `tui-textarea` does nothing in this editor.
+            KeyCode::PageDown => self.editor_scroll_cursor(PAGE_STEP),
+            KeyCode::PageUp => self.editor_scroll_cursor(-PAGE_STEP),
+            // Plain Home/End already work via the generic forward
+            // (`tui-textarea`'s own `CursorMove::Head`/`End` — start/end of
+            // the *current* line, no viewport dependency). Ctrl+Home/
+            // Ctrl+End add the jump-to-document-start/end that plain
+            // Home/End don't cover, the common convention this was missing.
+            KeyCode::Home if key.modifiers.contains(KeyModifiers::CONTROL) => {
+                if let Some(editor) = &mut self.editor {
+                    editor.textarea.cancel_selection();
+                    editor
+                        .textarea
+                        .move_cursor(tui_textarea::CursorMove::Jump(0, 0));
+                }
+            }
+            KeyCode::End if key.modifiers.contains(KeyModifiers::CONTROL) => {
+                if let Some(editor) = &mut self.editor {
+                    let last_row = editor.textarea.lines().len().saturating_sub(1);
+                    let last_col = editor.textarea.lines()[last_row].chars().count();
+                    editor.textarea.cancel_selection();
+                    editor.textarea.move_cursor(tui_textarea::CursorMove::Jump(
+                        last_row as u16,
+                        last_col as u16,
+                    ));
+                }
+            }
             _ => {
                 if let Some(editor) = &mut self.editor {
                     let edits = if self.editor_secondary_cursors.is_empty() {
@@ -3072,6 +3147,79 @@ impl App {
         if redone > 0 {
             self.editor_undo_groups.push(redone);
         }
+    }
+    /// Moves the editor's cursor `delta` logical rows (clamped to the
+    /// buffer), preserving column as closely as the target row allows —
+    /// drives both `PageUp`/`PageDown` (`delta = ±PAGE_STEP`) and mouse
+    /// wheel scrolling. This exists because forwarding `PageUp`/`PageDown`
+    /// to `tui-textarea` (as the generic catch-all does for every other
+    /// key) does nothing at all in this editor: verified live.
+    /// `tui-textarea`'s own `Scrolling::PageUp/PageDown` scrolls its
+    /// *internal* `Viewport`, which is only ever populated by its own
+    /// `Widget` impl — and `InlineEditor::render` deliberately bypasses
+    /// that entirely (see the struct doc comment), so the viewport
+    /// `Scrolling` scrolls is permanently zero-sized and the cursor
+    /// (adjusted to "stay in viewport" afterward) never actually moves.
+    /// Moving the cursor directly sidesteps that viewport entirely, and
+    /// `InlineEditor`'s own scroll-follow (driven purely by cursor
+    /// position, not an independent scroll offset) then scrolls the view
+    /// to match on the next render — the only "scroll" this editor has.
+    fn editor_scroll_cursor(&mut self, delta: isize) {
+        let Some(editor) = &mut self.editor else {
+            return;
+        };
+        let (row, col) = editor.textarea.cursor();
+        let last_row = editor.textarea.lines().len().saturating_sub(1);
+        let new_row = (row as isize + delta).clamp(0, last_row as isize) as usize;
+        if new_row == row {
+            return;
+        }
+        let new_col = col.min(editor.textarea.lines()[new_row].chars().count());
+        editor.textarea.cancel_selection();
+        editor.textarea.move_cursor(tui_textarea::CursorMove::Jump(
+            new_row as u16,
+            new_col as u16,
+        ));
+    }
+    /// Ctrl+Alt+Up/Down (`config.editor.multi_cursor`): adds a cursor one
+    /// row above (`dir < 0`) or below (`dir > 0`) whichever existing
+    /// cursor (primary or secondary) already sits furthest in that
+    /// direction — so repeated presses keep extending the same contiguous
+    /// block of cursors upward/downward, matching VS Code's own behavior,
+    /// rather than always adding relative to the primary alone. The new
+    /// cursor's column is clamped to its target line's length, same as a
+    /// plain `Up`/`Down` keypress would clamp against a shorter line.
+    fn editor_add_cursor_vertical(&mut self, dir: isize) {
+        let Some(editor) = &self.editor else {
+            return;
+        };
+        let primary = editor.textarea.cursor();
+        let reference = self
+            .editor_secondary_cursors
+            .iter()
+            .map(|c| c.pos)
+            .chain(std::iter::once(primary))
+            .reduce(|a, b| if dir < 0 { a.min(b) } else { a.max(b) });
+        let Some((row, col)) = reference else {
+            return;
+        };
+        let target_row = if dir < 0 {
+            match row.checked_sub(1) {
+                Some(r) => r,
+                None => return,
+            }
+        } else {
+            row + 1
+        };
+        if target_row >= editor.textarea.lines().len() {
+            return;
+        }
+        let target_col = col.min(editor.textarea.lines()[target_row].chars().count());
+        crate::multicursor::add_cursor_at(
+            &mut self.editor_secondary_cursors,
+            primary,
+            (target_row, target_col),
+        );
     }
     /// Ctrl+D (`config.editor.multi_cursor`): the first press (primary has
     /// no selection yet) just selects the word under the cursor, matching

--- a/shiki-tui/src/lib.rs
+++ b/shiki-tui/src/lib.rs
@@ -10,6 +10,7 @@ pub(crate) mod key_handlers;
 pub mod keybindings;
 pub mod layout;
 pub mod links_panel;
+pub(crate) mod multicursor;
 pub mod panel_drawer;
 pub mod panel_notebooks;
 pub mod panel_notes;

--- a/shiki-tui/src/multicursor.rs
+++ b/shiki-tui/src/multicursor.rs
@@ -1,0 +1,421 @@
+//! Multi-cursor editing (`config.editor.multi_cursor`) — Alt+Click adds a
+//! cursor, Ctrl+D adds the next occurrence of the current word/selection.
+//!
+//! `tui-textarea` has no native multi-cursor concept at all: a `TextArea`
+//! owns exactly one `cursor: (usize, usize)` and one optional selection
+//! anchor. Rather than reimplementing insert/delete/newline-splitting
+//! ourselves, this module drives the *same* single-cursor `TextArea`
+//! through every extra cursor position in turn — for one keystroke, jump
+//! its real cursor to a stored position, replay the key (reusing every bit
+//! of `tui-textarea`'s own editing logic verbatim), read the result back,
+//! and move on to the next position — then restores the shared cursor to
+//! wherever the primary ended up.
+//!
+//! Processing order is the one genuinely tricky part, and the first version
+//! of this module got it backwards: processing **bottom-to-top** avoids
+//! invalidating cursors *not yet processed* (an edit never affects rows
+//! above it), but it does the opposite for cursors *already* processed —
+//! once a lower cursor's result is recorded, a later (higher, i.e. "more
+//! top") edit that inserts/removes rows shifts everything below it,
+//! silently invalidating that already-recorded result. Verified by a
+//! failing test before this comment existed: two cursors each pressing
+//! Enter landed one row off from where they should have.
+//!
+//! The correct algorithm processes **top-to-bottom, left-to-right**
+//! (ascending `(row, col)`) while tracking a running delta: after each
+//! cursor's turn, `lines().len()` before vs. after tells us exactly how
+//! many rows that edit inserted or removed (no need to special-case which
+//! keys change row count), and the resulting column position vs. the
+//! column we moved to tells us the column shift for any cursor still
+//! waiting on the *same original row*. Every subsequent cursor's stored
+//! position is adjusted by the accumulated delta before it's used, so it's
+//! always correct by the time its own turn comes — the same idea real
+//! multi-cursor editors use, just derived from `input`'s own before/after
+//! state instead of reimplementing insert/delete arithmetic by hand.
+
+use tui_textarea::{CursorMove, TextArea};
+
+/// One cursor's position plus its own optional selection anchor —
+/// `anchor.is_some()` means this cursor currently has an active selection
+/// from `anchor` to `pos`, independent of every other cursor's selection.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct CursorState {
+    pub(crate) pos: (usize, usize),
+    pub(crate) anchor: Option<(usize, usize)>,
+}
+
+/// Replays one keystroke at the primary cursor (`textarea`'s own live
+/// cursor/selection) and every secondary cursor, top-to-bottom (see the
+/// module doc comment), then restores `textarea`'s live cursor back to the
+/// primary's own final position — `secondary` is updated in place, in its
+/// original order, with each cursor's new position/selection. Returns how
+/// many of the cursors (primary included) actually mutated the buffer,
+/// i.e. how many real undo-history entries this one keystroke pushed —
+/// `tui_textarea::TextArea::input`'s own return value already means
+/// exactly this ("did this input modify the buffer"), so it's read
+/// straight off each per-cursor `input` call rather than inferred.
+pub(crate) fn replay_keystroke(
+    textarea: &mut TextArea,
+    key: crossterm::event::KeyEvent,
+    secondary: &mut Vec<CursorState>,
+) -> usize {
+    let primary = CursorState {
+        pos: textarea.cursor(),
+        anchor: textarea.selection_range().map(|(start, _)| start),
+    };
+    // `None` tags the primary; `Some(i)` tags `secondary[i]` — original
+    // (pre-edit) positions, kept alongside the tag so results can be
+    // written back in the *original* Vec order even though processing
+    // order (ascending position) is generally different from it.
+    let mut order: Vec<(Option<usize>, (usize, usize))> = secondary
+        .iter()
+        .enumerate()
+        .map(|(i, c)| (Some(i), c.pos))
+        .collect();
+    order.push((None, primary.pos));
+    order.sort_by_key(|&(_, pos)| pos);
+
+    let mut edits = 0usize;
+    let mut new_primary = primary;
+    let mut new_secondary = secondary.clone();
+    // Running shift applied to every not-yet-processed cursor's *stored*
+    // position: `row_delta` from any earlier row-count-changing edit,
+    // `col_delta` from an earlier edit on that exact same original row
+    // (reset the instant an edit changes row count, since column position
+    // on a since-split/merged row no longer means what it used to).
+    let mut row_delta: isize = 0;
+    let mut col_delta_row: Option<usize> = None;
+    let mut col_delta: isize = 0;
+
+    for (tag, orig_pos) in order {
+        let cursor = match tag {
+            Some(i) => secondary[i],
+            None => primary,
+        };
+        let adjusted = adjust(cursor, orig_pos.0, row_delta, col_delta_row, col_delta);
+
+        goto(textarea, adjusted);
+        let lines_before = textarea.lines().len();
+        let pre_col = textarea.cursor().1;
+        let snapshot = textarea.lines().to_vec();
+        if textarea.input(key) {
+            edits += undo_history_depth(textarea, &snapshot);
+        }
+        let lines_after = textarea.lines().len();
+        let (post_row, post_col) = textarea.cursor();
+
+        let this_row_delta = lines_after as isize - lines_before as isize;
+        if this_row_delta != 0 {
+            row_delta += this_row_delta;
+            col_delta_row = None;
+            col_delta = 0;
+        } else {
+            col_delta_row = Some(orig_pos.0);
+            col_delta += post_col as isize - pre_col as isize;
+        }
+
+        let updated = CursorState {
+            pos: (post_row, post_col),
+            anchor: textarea.selection_range().map(|(start, _)| start),
+        };
+        match tag {
+            Some(i) => new_secondary[i] = updated,
+            None => new_primary = updated,
+        }
+    }
+    goto(textarea, new_primary);
+    *secondary = new_secondary;
+    edits
+}
+
+/// How many real `textarea.undo()` calls it takes to fully reverse the
+/// edit that was *just* made — measured directly against `before` (the
+/// buffer's content immediately prior to that edit) rather than assumed,
+/// then immediately redone that many times to restore the just-made edit
+/// before returning, so the measurement is otherwise invisible to the
+/// caller.
+///
+/// This exists because a single `TextArea::input` call can silently push
+/// *two* separate history entries, not always one — verified directly
+/// against the vendored crate: typing a character while a selection is
+/// active is "delete the selection, then insert the character" (2
+/// entries; one `undo()` only un-inserts the character, leaving the
+/// deleted selection still missing), while Backspace over that same kind
+/// of selection is just "delete the selection" (1 entry, nothing to
+/// insert). Guessing a fixed count per key/selection combination would
+/// mean re-deriving `tui-textarea`'s own internal history-grouping rules
+/// by hand for every key this module might ever replay; measuring it
+/// directly is correct regardless of which key or selection shape was
+/// involved. Capped at 10 rounds as a safety valve against looping forever
+/// if `undo()` ever legitimately can't reach `before` (not expected in
+/// practice, but a silent infinite loop would be far worse than an
+/// occasionally-undercounted group).
+pub(crate) fn undo_history_depth(textarea: &mut TextArea, before: &[String]) -> usize {
+    let mut n = 0;
+    while textarea.lines() != before && n < 10 {
+        if !textarea.undo() {
+            break;
+        }
+        n += 1;
+    }
+    for _ in 0..n {
+        textarea.redo();
+    }
+    n
+}
+
+/// Applies the running row/column delta (see `replay_keystroke`) to one
+/// cursor's stored position and, if present, its selection anchor — both
+/// are positions in the same original-document coordinate space, so both
+/// need the same adjustment.
+fn adjust(
+    cursor: CursorState,
+    orig_row: usize,
+    row_delta: isize,
+    col_delta_row: Option<usize>,
+    col_delta: isize,
+) -> CursorState {
+    let shift = |(row, col): (usize, usize)| -> (usize, usize) {
+        let new_row = (row as isize + row_delta).max(0) as usize;
+        let new_col = if col_delta_row == Some(orig_row) {
+            (col as isize + col_delta).max(0) as usize
+        } else {
+            col
+        };
+        (new_row, new_col)
+    };
+    CursorState {
+        pos: shift(cursor.pos),
+        anchor: cursor.anchor.map(shift),
+    }
+}
+
+/// Moves `textarea`'s live cursor to `cursor.pos`, restoring its selection
+/// anchor first when it has one — shared by `replay_keystroke`'s per-cursor
+/// loop and its final restore-the-primary step, so the two can't disagree
+/// on how a `CursorState` becomes the textarea's actual live state.
+fn goto(textarea: &mut TextArea, cursor: CursorState) {
+    textarea.cancel_selection();
+    if let Some((ar, ac)) = cursor.anchor {
+        textarea.move_cursor(CursorMove::Jump(ar as u16, ac as u16));
+        textarea.start_selection();
+    }
+    textarea.move_cursor(CursorMove::Jump(cursor.pos.0 as u16, cursor.pos.1 as u16));
+}
+
+/// Alt+Click: adds a plain (no selection) cursor at `pos`, deduplicating
+/// against the primary's own position and every existing secondary.
+pub(crate) fn add_cursor_at(
+    secondary: &mut Vec<CursorState>,
+    primary_pos: (usize, usize),
+    pos: (usize, usize),
+) {
+    if pos == primary_pos || secondary.iter().any(|c| c.pos == pos) {
+        return;
+    }
+    secondary.push(CursorState { pos, anchor: None });
+}
+
+/// Ctrl+D's "add the next occurrence": pushes a new selecting cursor at
+/// `(row, start)..(row, end)` unless an identical one already exists (which
+/// only happens once every occurrence in the buffer already has a cursor —
+/// the caller reports that as "no more occurrences" rather than looping).
+/// Returns whether a new cursor was actually added.
+pub(crate) fn add_occurrence(
+    secondary: &mut Vec<CursorState>,
+    row: usize,
+    start: usize,
+    end: usize,
+) -> bool {
+    let cursor = CursorState {
+        pos: (row, end),
+        anchor: Some((row, start)),
+    };
+    if secondary.contains(&cursor) {
+        return false;
+    }
+    secondary.push(cursor);
+    true
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+
+    fn key(c: char) -> KeyEvent {
+        KeyEvent::new(KeyCode::Char(c), KeyModifiers::NONE)
+    }
+
+    fn textarea(lines: &[&str]) -> TextArea<'static> {
+        TextArea::new(lines.iter().map(|l| l.to_string()).collect())
+    }
+
+    #[test]
+    fn replays_a_plain_character_at_every_cursor() {
+        let mut ta = textarea(&["cat", "cat", "cat"]);
+        ta.move_cursor(CursorMove::Jump(0, 0));
+        let mut secondary = vec![
+            CursorState {
+                pos: (1, 0),
+                anchor: None,
+            },
+            CursorState {
+                pos: (2, 0),
+                anchor: None,
+            },
+        ];
+        let edits = replay_keystroke(&mut ta, key('X'), &mut secondary);
+        assert_eq!(edits, 3);
+        assert_eq!(ta.lines(), &["Xcat", "Xcat", "Xcat"]);
+        // Every cursor landed right after its own inserted 'X'.
+        assert_eq!(ta.cursor(), (0, 1));
+        assert_eq!(secondary[0].pos, (1, 1));
+        assert_eq!(secondary[1].pos, (2, 1));
+    }
+
+    #[test]
+    fn typing_over_a_selection_reports_two_edits_per_cursor_and_undoes_atomically() {
+        // Real bug caught live: `TextArea::input` pushes *two* history
+        // entries when it replaces an active selection (delete, then
+        // insert), not one — a naive `edits += 1` per cursor undercounts,
+        // and a single Ctrl+U then only half-reverses each cursor,
+        // leaving text neither "cat" nor "dog". Every cursor here has a
+        // full-word selection (Ctrl+D-style), so typing 'd' must report
+        // 2 edits per cursor (6 total) and a matching number of `undo()`
+        // calls must fully restore "cat" on every line.
+        let mut ta = textarea(&["cat", "cat", "cat"]);
+        ta.move_cursor(CursorMove::Jump(0, 0));
+        ta.start_selection();
+        ta.move_cursor(CursorMove::Jump(0, 3));
+        let mut secondary = vec![
+            CursorState {
+                pos: (1, 3),
+                anchor: Some((1, 0)),
+            },
+            CursorState {
+                pos: (2, 3),
+                anchor: Some((2, 0)),
+            },
+        ];
+        let edits = replay_keystroke(&mut ta, key('d'), &mut secondary);
+        assert_eq!(edits, 6, "2 history entries per cursor (delete + insert)");
+        assert_eq!(ta.lines(), &["d", "d", "d"]);
+
+        for _ in 0..edits {
+            ta.undo();
+        }
+        assert_eq!(
+            ta.lines(),
+            &["cat", "cat", "cat"],
+            "exactly `edits` undo() calls must fully restore the original text"
+        );
+    }
+
+    #[test]
+    fn typing_a_whole_word_across_selected_cursors_undoes_fully_across_keystrokes() {
+        // Same scenario as the app itself: Ctrl+D-select "cat" on 3 lines,
+        // then type "dog" as three *separate* keystrokes (three separate
+        // `replay_keystroke` calls, exactly as `handle_edit_key` makes one
+        // per `KeyEvent`) — summing every call's own returned edit count
+        // and calling `undo()` that many times total must fully restore
+        // "cat" on every line, not get stuck partway.
+        let mut ta = textarea(&["cat", "cat", "cat"]);
+        ta.move_cursor(CursorMove::Jump(0, 0));
+        ta.start_selection();
+        ta.move_cursor(CursorMove::Jump(0, 3));
+        let mut secondary = vec![
+            CursorState {
+                pos: (1, 3),
+                anchor: Some((1, 0)),
+            },
+            CursorState {
+                pos: (2, 3),
+                anchor: Some((2, 0)),
+            },
+        ];
+        let mut total_edits = 0usize;
+        for c in ['d', 'o', 'g'] {
+            total_edits += replay_keystroke(&mut ta, key(c), &mut secondary);
+        }
+        assert_eq!(ta.lines(), &["dog", "dog", "dog"]);
+
+        for _ in 0..total_edits {
+            ta.undo();
+        }
+        assert_eq!(
+            ta.lines(),
+            &["cat", "cat", "cat"],
+            "summing every keystroke's own edit count must undo the whole word"
+        );
+    }
+
+    #[test]
+    fn enter_shifts_later_rows_without_desyncing_other_cursors() {
+        // Primary splits row 0 ("abc" -> "a"/"bc"); the secondary on row 1
+        // gets its *own* Enter too (multi-cursor replays the same key at
+        // every cursor), splitting "def" -> "d"/"ef" — but it must land on
+        // whatever row that split ends up at post-primary-shift (row 3),
+        // not the stale pre-shift row 2.
+        let mut ta = textarea(&["abc", "def"]);
+        ta.move_cursor(CursorMove::Jump(0, 1)); // between 'a' and 'bc'
+        let mut secondary = vec![CursorState {
+            pos: (1, 1),
+            anchor: None,
+        }];
+        let key_enter = KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE);
+        let edits = replay_keystroke(&mut ta, key_enter, &mut secondary);
+        assert_eq!(edits, 2);
+        assert_eq!(ta.lines(), &["a", "bc", "d", "ef"]);
+        assert_eq!(ta.cursor(), (1, 0));
+        assert_eq!(secondary[0].pos, (3, 0));
+    }
+
+    #[test]
+    fn two_cursors_on_the_same_row_accumulate_column_shift() {
+        // Typing 'X' at col 0 pushes everything after it one column to the
+        // right — a second cursor on the *same* row at (originally) col 3
+        // must land at col 4 to still be typing in the same place it was
+        // pointing at before either edit happened.
+        let mut ta = textarea(&["abcdef"]);
+        ta.move_cursor(CursorMove::Jump(0, 0));
+        let mut secondary = vec![CursorState {
+            pos: (0, 3),
+            anchor: None,
+        }];
+        let edits = replay_keystroke(&mut ta, key('X'), &mut secondary);
+        assert_eq!(edits, 2);
+        assert_eq!(ta.lines(), &["XabcXdef"]);
+        assert_eq!(ta.cursor(), (0, 1));
+        assert_eq!(secondary[0].pos, (0, 5));
+    }
+
+    #[test]
+    fn navigation_keys_report_zero_edits() {
+        let mut ta = textarea(&["hello"]);
+        let mut secondary = vec![CursorState {
+            pos: (0, 0),
+            anchor: None,
+        }];
+        let right = KeyEvent::new(KeyCode::Right, KeyModifiers::NONE);
+        let edits = replay_keystroke(&mut ta, right, &mut secondary);
+        assert_eq!(edits, 0);
+    }
+
+    #[test]
+    fn add_cursor_at_dedupes_against_primary_and_existing() {
+        let mut secondary = Vec::new();
+        add_cursor_at(&mut secondary, (0, 0), (1, 1));
+        add_cursor_at(&mut secondary, (0, 0), (1, 1)); // duplicate
+        add_cursor_at(&mut secondary, (0, 0), (0, 0)); // same as primary
+        assert_eq!(secondary.len(), 1);
+    }
+
+    #[test]
+    fn add_occurrence_reports_false_once_already_present() {
+        let mut secondary = Vec::new();
+        assert!(add_occurrence(&mut secondary, 0, 2, 5));
+        assert!(!add_occurrence(&mut secondary, 0, 2, 5));
+        assert_eq!(secondary.len(), 1);
+    }
+}

--- a/shiki-tui/src/panel_settings.rs
+++ b/shiki-tui/src/panel_settings.rs
@@ -17,15 +17,17 @@ pub enum SettingsSection {
     General,
     Theme,
     Git,
+    Editor,
     Notebooks,
     Snippets,
 }
 
 impl SettingsSection {
-    pub const ALL: [SettingsSection; 5] = [
+    pub const ALL: [SettingsSection; 6] = [
         SettingsSection::General,
         SettingsSection::Theme,
         SettingsSection::Git,
+        SettingsSection::Editor,
         SettingsSection::Notebooks,
         SettingsSection::Snippets,
     ];
@@ -35,6 +37,7 @@ impl SettingsSection {
             SettingsSection::General => "GENERAL",
             SettingsSection::Theme => "THEME",
             SettingsSection::Git => "GIT",
+            SettingsSection::Editor => "EDITOR",
             SettingsSection::Notebooks => "NOTEBOOKS",
             SettingsSection::Snippets => "SNIPPETS",
         }
@@ -116,6 +119,31 @@ impl GitField {
         GitField::AutoSync,
         GitField::AutoSyncEvery,
         GitField::RemoteTemplate,
+    ];
+}
+
+/// EDITOR's rows — every field is a plain bool toggle (no drill-down, same
+/// flat shape as GENERAL/GIT), gating one native-editor UX behavior each;
+/// see `EditorConfig`'s own doc comments for what each one does and why it
+/// defaults the way it does.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum EditorField {
+    MouseSelection,
+    FindReplace,
+    OsClipboard,
+    SelectAllCtrlA,
+    LineNumbers,
+    MultiCursor,
+}
+
+impl EditorField {
+    pub const ALL: [EditorField; 6] = [
+        EditorField::MouseSelection,
+        EditorField::FindReplace,
+        EditorField::OsClipboard,
+        EditorField::SelectAllCtrlA,
+        EditorField::LineNumbers,
+        EditorField::MultiCursor,
     ];
 }
 
@@ -246,6 +274,26 @@ fn git_rows(app: &App) -> Vec<Line<'static>> {
     ]
 }
 
+fn editor_rows(app: &App) -> Vec<Line<'static>> {
+    let cfg = &app.config;
+    vec![
+        row_line(
+            app,
+            "mouse_selection",
+            cfg.editor.mouse_selection.to_string(),
+        ),
+        row_line(app, "find_replace", cfg.editor.find_replace.to_string()),
+        row_line(app, "os_clipboard", cfg.editor.os_clipboard.to_string()),
+        row_line(
+            app,
+            "select_all_ctrl_a",
+            cfg.editor.select_all_ctrl_a.to_string(),
+        ),
+        row_line(app, "line_numbers", cfg.editor.line_numbers.to_string()),
+        row_line(app, "multi_cursor", cfg.editor.multi_cursor.to_string()),
+    ]
+}
+
 /// NOTEBOOKS level 1 — one row per real notebook, showing its git remote
 /// (redacted) rather than the per-notebook sync-policy overrides this used
 /// to show instead; `notebook_field_rows` (level 2) covers those.
@@ -372,6 +420,7 @@ pub fn build(app: &App) -> Vec<Line<'static>> {
         SettingsSection::General => general_rows(app),
         SettingsSection::Theme => theme_rows(app),
         SettingsSection::Git => git_rows(app),
+        SettingsSection::Editor => editor_rows(app),
         SettingsSection::Notebooks => match &app.settings_notebook_drill {
             Some(name) => notebook_field_rows(app, name),
             None => notebook_list_rows(app),


### PR DESCRIPTION
## Summary

Adds a full mouse/keyboard UX overhaul to the native note editor, all opt-in via a new `[editor]` config section (EDITOR tab in Settings, leader+`s`) so nothing changes unless explicitly enabled:

- **`mouse_selection`** (on by default): click to position the cursor, click-and-drag to select, double-click for a word, triple-click for a line.
- **`find_replace`** (on by default): Ctrl+F opens a find/replace bar with live search-as-you-type, next/previous match, replace one/all.
- **`os_clipboard`** (off by default): Ctrl+C/X/V use the real OS clipboard via `arboard`, falling back automatically to the existing OSC 52 mechanism when there's no display server (e.g. SSH).
- **`select_all_ctrl_a`** (off by default): Ctrl+A selects the whole buffer instead of tui-textarea's Emacs-style "move to start of line".
- **`line_numbers`** (off by default): a line-number gutter.
- **`multi_cursor`** (off by default): full multi-cursor editing — Alt+Click or Ctrl+Alt+Up/Down (VS Code's own "Add Cursor Above/Below") add cursors, Ctrl+D selects the word under the cursor and adds the next occurrence on each further press, typing/Backspace/Delete/Enter/navigation all replay across every cursor at once, Ctrl+U/Ctrl+R undo/redo a multi-cursor edit as one action, and secondary cursors render as a distinct accent-colored block.

Also fixes two pre-existing, unrelated gaps found while testing this: mouse wheel scroll was never handled anywhere in the app, and PageUp/PageDown did nothing inside the editor (its custom word-wrap rendering bypasses `tui-textarea`'s own `Widget` impl, so the internal Viewport those keys scroll was always zero-sized). Added Ctrl+Home/Ctrl+End to jump to the start/end of the whole note.

`scripts/screenshots.sh` and `scripts/demo-gif.sh` are updated to showcase every new feature, verified end-to-end against the real tools (Xvfb/xterm/xdotool, VHS/ttyd), which also surfaced and fixed three real bugs in `demo-gif.sh`'s existing choreography (a hardcoded Settings tab-switch count, a Settings modal that never actually closed at the end of one phase, and a long-standing `XDG_CONFIG_HOME` path bug that meant its hand-written config was never actually being read).

Multi-cursor in particular required a new `multicursor` module since `tui-textarea` has no native support for it at all — built as a replay layer that drives the same single-cursor `TextArea` through every extra cursor position per keystroke (top-to-bottom with a running position delta, since row-count-changing edits like Enter shift every cursor below them), with grouped undo/redo and real-measured (not assumed) undo-history depth per edit.

## Test plan

- [x] `cargo fmt --all`, `cargo clippy --workspace --all-targets`, `cargo test --workspace` all clean
- [x] Live-verified every feature in a real terminal via tmux: click/drag/double/triple-click selection, line-number gutter (incl. hit-testing), find/replace (search, replace-one, replace-all), real OS clipboard round-trip (`wl-copy`/`wl-paste`), Ctrl+A toggle, full multi-cursor (Alt+Click, Ctrl+Alt+Up/Down, Ctrl+D repeated selection + simultaneous typing, Esc-collapses-cursors-first, grouped undo/redo), mouse wheel scroll, PageUp/PageDown, Ctrl+Home/Ctrl+End
- [x] `scripts/screenshots.sh` run end-to-end (all 16 themes) — new EDITOR/multi-cursor/find-replace screenshots inspected visually
- [x] `scripts/demo-gif.sh` run end-to-end multiple times while debugging the pre-existing bugs above, final recording verified frame-by-frame

## Known limitation

`os_clipboard`'s real OS-clipboard path was verified end-to-end in this dev environment (which has a working Wayland session via WSLg) — genuinely untestable in a headless/SSH-only environment, where it's expected to fall back to OSC 52 automatically.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>