### PR TITLE
feat: remember last session on quit (general.remember_last_session)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to shiki are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this project doesn't follow strict
 semver yet (pre-1.0), but version bumps are still meaningful and tracked here.
 
+## [Unreleased]
+
+### Added
+
+- `general.remember_last_session` (on by default): quitting the TUI now saves exactly where you
+  were — the selected notebook, the folder inside it, the selected note or folder, and which panel
+  (NOTEBOOKS/NOTES/PREVIEW) had focus — and the next launch restores it verbatim instead of always
+  starting at the first notebook's root. Toggleable from the GENERAL tab in Settings (leader+`s`)
+  or by hand-editing `config.toml`. A renamed/deleted notebook or a moved note is silently ignored
+  rather than erroring — the app just falls back to its normal default startup state.
+
 ## [0.8.8] - 2026-07-29
 
 ### Added

--- a/IDEA.md
+++ b/IDEA.md
@@ -467,6 +467,13 @@ mouse_drag_selection = true
 # When true, text-input prompts that have one (e.g. new notebook) show a
 # small hint line explaining non-obvious input, like pasting a git URL.
 show_hints = true
+# When true, quitting the TUI remembers exactly where you were — which
+# notebook, which folder inside it, which note/folder was selected, and
+# which panel (NOTEBOOKS/NOTES/PREVIEW) had focus — and the next launch
+# restores it verbatim instead of always starting at the first notebook's
+# root. A renamed/deleted notebook or moved note is silently ignored rather
+# than erroring; the app just falls back to the default startup state.
+remember_last_session = true
 
 [keybindings]
 leader = "space"

--- a/docs/documentation.html
+++ b/docs/documentation.html
@@ -648,6 +648,7 @@ Content in **markdown**.
           <tr><td><code>mouse_drag_selection</code></td><td><code>true</code></td><td>A plain click on a note's body in PREVIEW jumps into edit mode with the cursor on that line; click-and-drag instead selects text and copies it to the clipboard as soon as you release the mouse button — the same clipboard mechanism the logs modal's <code>y</code>/<code>c</code> uses</td></tr>
           <tr><td><code>data_dir</code></td><td>unset (platform default)</td><td>Point the <em>entire</em> notebooks root somewhere else — an absolute path to an existing folder of markdown notes (an Obsidian vault, for instance) instead of <code>~/.local/share/shiki/</code>. Every notebook without its own <code>path</code> (below) lives as a subdirectory of this</td></tr>
           <tr><td><code>show_hints</code></td><td><code>true</code></td><td>Shows a small muted hint line under the input box for text prompts whose behavior isn't obvious from the title alone — currently just new-notebook, explaining that a git URL clones and a filesystem path adopts an existing directory</td></tr>
+          <tr><td><code>remember_last_session</code></td><td><code>true</code></td><td>Quitting saves exactly where you were — notebook, folder, selected note/folder, and which panel had focus — and the next launch restores it instead of always starting at the first notebook's root. A renamed/deleted notebook or moved note is ignored gracefully rather than erroring</td></tr>
         </tbody>
       </table>
       <div class="doc-callout">
@@ -852,6 +853,10 @@ mouse_drag_selection = true
 # When true, text-input prompts that have one (e.g. new notebook) show a
 # small hint line explaining non-obvious input, like pasting a git URL.
 show_hints = true
+# When true, quitting the TUI remembers exactly where you were — notebook,
+# folder, selected note/folder, and focused panel — and the next launch
+# restores it instead of always starting at the first notebook's root.
+remember_last_session = true
 
 [keybindings]
 leader = "space"

--- a/shiki-config/src/config.rs
+++ b/shiki-config/src/config.rs
@@ -58,6 +58,14 @@ pub struct General {
     /// initial fields.
     #[serde(default = "default_true")]
     pub show_hints: bool,
+    /// When true, quitting the TUI saves exactly where you were (notebook,
+    /// folder, selected note/folder, and which panel had focus) and the next
+    /// launch restores it verbatim instead of always starting at the first
+    /// notebook's root. Defaults to `true`, so this needs the named-default-fn
+    /// form rather than bare `#[serde(default)]`, which would resolve a
+    /// missing key to `false`. See `shiki_config::SessionState`.
+    #[serde(default = "default_true")]
+    pub remember_last_session: bool,
 }
 
 impl Default for General {
@@ -70,6 +78,7 @@ impl Default for General {
             mouse_drag_selection: true,
             data_dir: None,
             show_hints: true,
+            remember_last_session: true,
         }
     }
 }
@@ -988,6 +997,18 @@ impl Config {
             .join("trash"))
     }
 
+    /// Where `general.remember_last_session`'s state (`SessionState`) is
+    /// persisted — the config dir, for the exact same collision reason as
+    /// `default_log_path`/`default_trash_dir`: the data dir's top level is
+    /// user-named notebooks, so a fixed filename placed there could collide
+    /// with one.
+    pub fn default_session_path() -> Result<PathBuf> {
+        Ok(Self::default_path()?
+            .parent()
+            .expect("config path always has a parent")
+            .join("session.toml"))
+    }
+
     /// Loads the config from `path`, or creates and saves a default config if it doesn't exist.
     pub fn load_or_init(path: &Path) -> Result<Self> {
         if path.exists() {
@@ -1077,7 +1098,10 @@ fn section_comment(line: &str) -> Option<&'static str> {
 #   at an existing Obsidian vault or any markdown folder to use it as the
 #   notebooks root. Unset defaults to the platform data directory.
 # - show_hints: when true, text-input prompts that have one (e.g. new
-#   notebook) show a small hint line explaining non-obvious input."
+#   notebook) show a small hint line explaining non-obvious input.
+# - remember_last_session: when true, quitting saves exactly where you were
+#   (notebook, folder, selected note/folder, focused panel) and the next
+#   launch restores it instead of starting at the first notebook's root."
         }
         "[keybindings]" => {
             "\

--- a/shiki-config/src/lib.rs
+++ b/shiki-config/src/lib.rs
@@ -1,6 +1,8 @@
 pub mod config;
+pub mod session;
 pub mod theme;
 pub mod themes;
 
 pub use config::Config;
+pub use session::SessionState;
 pub use theme::Theme;

--- a/shiki-config/src/session.rs
+++ b/shiki-config/src/session.rs
@@ -1,0 +1,119 @@
+use std::path::Path;
+
+use serde::{Deserialize, Serialize};
+
+use crate::config::Result;
+
+/// Whichever single entry (folder or note) was highlighted in NOTES at the
+/// point the session was saved. A plain `Option<String>` name isn't enough
+/// on its own since a folder and a note can share a display name — the
+/// `kind` tag disambiguates which list (`Notebook::list_dir`'s folders vs.
+/// notes) to look it up in on restore.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum SelectedEntry {
+    Folder {
+        name: String,
+    },
+    /// `stem` is the note's filename without its `.md` extension — the same
+    /// identity `refresh_notes_preserve_selection` already re-selects by
+    /// after a reload, reused here instead of a second matching scheme.
+    Note {
+        stem: String,
+    },
+}
+
+/// Persisted "where was I" state for `general.remember_last_session` — which
+/// notebook, which folder inside it, which entry was selected, and which
+/// panel had focus, restored verbatim on the next launch. Saved once, right
+/// before the app exits (see `shiki-tui`'s `App::save_session`); this struct
+/// itself has no knowledge of the TUI's `Focus` enum (shiki-config sits
+/// below shiki-tui in the dependency chain, see CLAUDE.md's Architecture
+/// section), so `focus` is stored as a plain lowercase string
+/// (`"notebooks"`/`"notes"`/`"preview"`) and translated on both ends by the
+/// caller instead.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
+pub struct SessionState {
+    pub notebook: String,
+    /// Breadcrumb of folder names from the notebook root — empty means the
+    /// notebook's root folder itself.
+    #[serde(default)]
+    pub notes_path: Vec<String>,
+    #[serde(default)]
+    pub selected: Option<SelectedEntry>,
+    #[serde(default)]
+    pub focus: String,
+}
+
+impl SessionState {
+    /// Reads a previously saved session, if the file exists and is valid.
+    /// Any failure (missing file, unreadable, malformed TOML) is treated the
+    /// same way — no session to restore — rather than surfacing an error;
+    /// losing the exact cursor position on a corrupt/missing file is not
+    /// worth failing startup over.
+    pub fn load(path: &Path) -> Option<Self> {
+        let contents = std::fs::read_to_string(path).ok()?;
+        toml::from_str(&contents).ok()
+    }
+
+    pub fn save(&self, path: &Path) -> Result<()> {
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+        let contents = toml::to_string_pretty(self)?;
+        std::fs::write(path, contents)?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn save_then_load_round_trips() {
+        let dir = std::env::temp_dir().join(format!(
+            "shiki-session-test-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        let path = dir.join("session.toml");
+        let session = SessionState {
+            notebook: "work".into(),
+            notes_path: vec!["projects".into(), "shiki".into()],
+            selected: Some(SelectedEntry::Note {
+                stem: "roadmap".into(),
+            }),
+            focus: "preview".into(),
+        };
+        session.save(&path).expect("save must succeed");
+        let loaded = SessionState::load(&path).expect("a just-saved session must load back");
+        assert_eq!(loaded, session);
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn load_returns_none_for_a_missing_file() {
+        assert!(SessionState::load(Path::new("/nonexistent/shiki-session.toml")).is_none());
+    }
+
+    #[test]
+    fn load_returns_none_for_malformed_toml() {
+        let dir = std::env::temp_dir().join(format!(
+            "shiki-session-malformed-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("session.toml");
+        std::fs::write(&path, "not valid toml {{{").unwrap();
+        assert!(SessionState::load(&path).is_none());
+        std::fs::remove_dir_all(&dir).ok();
+    }
+}

--- a/shiki-tui/src/app.rs
+++ b/shiki-tui/src/app.rs
@@ -69,6 +69,27 @@ impl Focus {
             Focus::Preview => Focus::Notes,
         }
     }
+
+    /// For `general.remember_last_session` — `shiki_config::SessionState`
+    /// doesn't know about this enum at all (shiki-config sits below
+    /// shiki-tui in the dependency chain), so it's persisted as a plain
+    /// lowercase string and translated on both ends here instead.
+    pub(crate) fn as_session_str(self) -> &'static str {
+        match self {
+            Focus::Notebooks => "notebooks",
+            Focus::Notes => "notes",
+            Focus::Preview => "preview",
+        }
+    }
+
+    pub(crate) fn from_session_str(s: &str) -> Option<Self> {
+        match s {
+            "notebooks" => Some(Focus::Notebooks),
+            "notes" => Some(Focus::Notes),
+            "preview" => Some(Focus::Preview),
+            _ => None,
+        }
+    }
 }
 
 /// How the NOTES list is ordered; cycled by `Action::SortNotes`.
@@ -813,7 +834,7 @@ impl App {
             .position(|t| t.name == theme.name)
             .unwrap_or(0);
 
-        Ok(Self {
+        let mut app = Self {
             config,
             theme,
             store,
@@ -924,7 +945,58 @@ impl App {
             sync_in_flight: None,
             sync_rx: None,
             spinner_frame: 0,
-        })
+        };
+
+        if app.config.general.remember_last_session {
+            if let Some(session) = Config::default_session_path()
+                .ok()
+                .and_then(|path| shiki_config::SessionState::load(&path))
+            {
+                app.restore_session(session);
+            }
+        }
+
+        Ok(app)
+    }
+
+    /// Applies a previously saved `SessionState` (`general.remember_last_session`)
+    /// on top of the just-constructed default state (first notebook, root
+    /// folder, `Focus::Notebooks`) — called once from `new`, right after
+    /// construction, since restoring is really a post-construction mutation
+    /// (select a different notebook, descend into a folder, re-select an
+    /// entry) rather than something `new` can compute up front. Anything that
+    /// no longer resolves (a renamed/deleted notebook, a moved note, an
+    /// unrecognized focus string) is silently left at that default instead
+    /// of erroring — a stale session file should degrade gracefully, never
+    /// block startup.
+    fn restore_session(&mut self, session: shiki_config::SessionState) {
+        let Some(idx) = self
+            .notebooks
+            .iter()
+            .position(|nb| nb.name == session.notebook)
+        else {
+            return;
+        };
+        self.selected_notebook = idx;
+        self.notes_path = session.notes_path;
+        self.reload_notes();
+
+        self.selected_note = match session.selected {
+            Some(shiki_config::session::SelectedEntry::Folder { name }) => {
+                self.folders.iter().position(|f| *f == name).unwrap_or(0)
+            }
+            Some(shiki_config::session::SelectedEntry::Note { stem }) => self
+                .notes
+                .iter()
+                .position(|n| n.file_stem() == stem)
+                .map(|i| self.folders.len() + i)
+                .unwrap_or(0),
+            None => 0,
+        };
+
+        if let Some(focus) = Focus::from_session_str(&session.focus) {
+            self.focus = focus;
+        }
     }
 
     /// Sets the status-bar message and records it in `log_history`, so an
@@ -1903,6 +1975,7 @@ pub fn run<B: Backend>(terminal: &mut Terminal<B>, app: &mut App) -> io::Result<
             }
         }
     }
+    app.save_session();
     Ok(())
 }
 

--- a/shiki-tui/src/key_handlers.rs
+++ b/shiki-tui/src/key_handlers.rs
@@ -292,6 +292,15 @@ impl App {
             self.set_status(format!("show_hints -> {}", self.config.general.show_hints));
             return;
         }
+        if field == GeneralField::RememberLastSession {
+            self.config.general.remember_last_session = !self.config.general.remember_last_session;
+            self.save_config();
+            self.set_status(format!(
+                "remember_last_session -> {}",
+                self.config.general.remember_last_session
+            ));
+            return;
+        }
         let (label, prefill) = match field {
             GeneralField::DefaultNotebook => (
                 "default_notebook",
@@ -303,7 +312,8 @@ impl App {
             }
             GeneralField::UseFavoriteEditor
             | GeneralField::MouseDragSelection
-            | GeneralField::ShowHints => unreachable!(),
+            | GeneralField::ShowHints
+            | GeneralField::RememberLastSession => unreachable!(),
         };
         self.show_settings = false;
         self.pending_input_title = Some(format!(" {label} "));
@@ -620,6 +630,39 @@ impl App {
         if let Ok(path) = Config::default_path() {
             let _ = self.config.save(&path);
         }
+    }
+    /// Persists `general.remember_last_session`'s state — called once, right
+    /// after the main loop in `run()` exits, just before the process actually
+    /// quits. See `App::restore_session` for the read side, applied at
+    /// startup. A no-op when the setting is off, or when there's no selected
+    /// notebook at all (an empty store) — nothing meaningful to remember.
+    pub(crate) fn save_session(&self) {
+        if !self.config.general.remember_last_session {
+            return;
+        }
+        let Some(notebook) = self.selected_notebook() else {
+            return;
+        };
+        let Ok(path) = Config::default_session_path() else {
+            return;
+        };
+        let selected = if self.selected_note < self.folders.len() {
+            self.folders
+                .get(self.selected_note)
+                .map(|name| shiki_config::session::SelectedEntry::Folder { name: name.clone() })
+        } else {
+            self.selected_note()
+                .map(|note| shiki_config::session::SelectedEntry::Note {
+                    stem: note.file_stem(),
+                })
+        };
+        let session = shiki_config::SessionState {
+            notebook: notebook.name.clone(),
+            notes_path: self.notes_path.clone(),
+            selected,
+            focus: self.focus.as_session_str().to_string(),
+        };
+        let _ = session.save(&path);
     }
     /// Queues `config.toml` for external editing — same
     /// `want_external_edit` mechanism a note's `E`/favorite-editor `i` use,
@@ -2530,6 +2573,7 @@ impl App {
                         GeneralField::UseFavoriteEditor => "use_favorite_editor",
                         GeneralField::MouseDragSelection => "mouse_drag_selection",
                         GeneralField::ShowHints => "show_hints",
+                        GeneralField::RememberLastSession => "remember_last_session",
                     };
                     self.save_config();
                     self.set_status(format!("{label} -> '{value}'"));

--- a/shiki-tui/src/panel_settings.rs
+++ b/shiki-tui/src/panel_settings.rs
@@ -67,16 +67,18 @@ pub enum GeneralField {
     UseFavoriteEditor,
     MouseDragSelection,
     ShowHints,
+    RememberLastSession,
 }
 
 impl GeneralField {
-    pub const ALL: [GeneralField; 6] = [
+    pub const ALL: [GeneralField; 7] = [
         GeneralField::DefaultNotebook,
         GeneralField::Editor,
         GeneralField::DailyTemplate,
         GeneralField::UseFavoriteEditor,
         GeneralField::MouseDragSelection,
         GeneralField::ShowHints,
+        GeneralField::RememberLastSession,
     ];
 }
 
@@ -231,6 +233,11 @@ fn general_rows(app: &App) -> Vec<Line<'static>> {
             cfg.general.mouse_drag_selection.to_string(),
         ),
         row_line(app, "show_hints", cfg.general.show_hints.to_string()),
+        row_line(
+            app,
+            "remember_last_session",
+            cfg.general.remember_last_session.to_string(),
+        ),
     ]
 }
 


### PR DESCRIPTION
## Summary
- New `general.remember_last_session` setting (default `true`): quitting the TUI now saves exactly where you were — selected notebook, folder breadcrumb inside it, selected note/folder, and which panel (NOTEBOOKS/NOTES/PREVIEW) had focus — and the next launch restores it verbatim instead of always starting at the first notebook's root.
- Persisted via a new `shiki_config::SessionState` to `~/.config/shiki/session.toml` (config dir, same notebook-name-collision reasoning as the existing log/trash paths).
- Toggleable from the GENERAL tab in Settings (`leader`+`s`), same in-place-toggle-and-save pattern as `use_favorite_editor`/`mouse_drag_selection`/`show_hints`.
- A renamed/deleted notebook or a moved note degrades gracefully back to the normal default startup state instead of erroring.

## Test plan
- [x] `cargo fmt --all`, `cargo clippy --workspace --all-targets` clean
- [x] `cargo test --workspace` — all passing, including new `shiki-config::session` unit tests (round-trip save/load, missing file, malformed TOML)
- [x] Live verification via tmux with isolated `XDG_CONFIG_HOME`/`XDG_DATA_HOME`:
  - Navigated into a nested folder (`beta/projects/shiki`), selected a note, focused PREVIEW, quit — confirmed `session.toml` recorded notebook/path/selection/focus correctly.
  - Relaunched — confirmed the app came up with the exact same notebook, breadcrumb, selected note, and PREVIEW focus.
  - Set `remember_last_session = false` — confirmed the app falls back to the default startup state (first notebook alphabetically, root, NOTEBOOKS focus) and that quitting again does **not** overwrite the previously saved `session.toml`.
  - Toggled the new Settings row (GENERAL tab) with `Enter` — confirmed it flips and persists to `config.toml` immediately.
- [x] Docs updated: `IDEA.md`, `docs/documentation.html` (config reference table + example), `CHANGELOG.md` (`Unreleased` section)

🤖 Generated with [Claude Code](https://claude.com/claude-code)