### PR TITLE
fix: focus Preview after creating a new note

### DIFF
--- a/shiki-tui/src/key_handlers.rs
+++ b/shiki-tui/src/key_handlers.rs
@@ -2140,10 +2140,15 @@ impl App {
                         let _ = note.save();
                     }
                     self.reload_notes();
-                    self.focus = Focus::Notes;
                     if let Some(idx) = self.notes.iter().position(|n| n.path == note.path) {
                         self.selected_note = self.folders.len() + idx;
                     }
+                    // Jump straight to Preview so NOTEBOOKS/NOTES collapse and
+                    // the fresh note's own editor is what's full-screen (in the
+                    // narrow/short `single` layout tier, the inline editor
+                    // always renders into `areas.preview` — leaving focus on
+                    // Notes would render it into a zero-sized area there).
+                    self.focus = Focus::Preview;
                     self.set_status(format!("created '{title}'"));
                     // Drop straight into the inline editor — a fresh note
                     // (blank or templated) isn't useful to just sit on.


### PR DESCRIPTION
## Summary
- Creating a note (`a` in Notes) now sets `App.focus = Focus::Preview` right before opening the inline editor, instead of leaving it on `Focus::Notes`.
- This makes NOTEBOOKS/NOTES collapse (columned/stacked tiers) or fully hide (narrow `single` tier) and the fresh note's editor render full-screen, as requested.
- Fixes a latent bug too: in the narrow/short `single` layout tier, the inline editor always renders into `areas.preview` — leaving focus on Notes meant it rendered into a zero-sized area there.

## Test plan
- [x] `cargo check --workspace`
- [x] `cargo fmt --all` / `cargo clippy --workspace --all-targets` (clean)
- [x] Verified live via tmux with isolated `XDG_CONFIG_HOME`/`XDG_DATA_HOME`: created a notebook, pressed `a` in Notes, typed a title, picked "blank" template — confirmed NOTEBOOKS/NOTES collapse to a 1-column sliver and the editor opens full-screen in Preview; saved and confirmed it stays on Preview showing the new note.