### PR TITLE
fix: ask before destroying a notebook's directory on delete

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,26 @@ semver yet (pre-1.0), but version bumps are still meaningful and tracked here.
 
 ## [Unreleased]
 
+### Changed
+
+- Deleting a notebook (notebooks-scope `d`) now asks a real question instead of always destroying
+  the directory: `[d]` deletes the notebook's files for real, `[r]` only stops tracking it as a
+  notebook and leaves the directory completely untouched on disk, `[Esc]` cancels. Previously this
+  confirm dialog was a plain "delete notebook and all its notes? (y/n)" that unconditionally called
+  `remove_dir_all` on `y` — dangerous for a notebook adopted from an external directory (an
+  Obsidian vault, an existing repo) where the folder was never shiki's to destroy in the first
+  place. "Just untrack" sets a new `[notebooks.<name>] hidden = true` in `config.toml`; there's no
+  in-app way to undo that yet, so reversing it means clearing the flag by hand and relaunching.
+
+### Fixed
+
+- Saving the scratchpad (leader+`p`, Ctrl+S) as a note no longer opens the template picker: since
+  the scratchpad body always won over a rendered template anyway, picking a real template there
+  previously created a note whose body was just the raw scratchpad text but whose `template:`
+  frontmatter field named a template that was never actually applied. It now skips straight to a
+  blank note using the scratchpad's own text, and `create_note_with_template` no longer stamps
+  `frontmatter.template` in any path unless that template's render genuinely became the note's body.
+
 ## [0.8.9] - 2026-07-30
 
 ### Added

--- a/shiki-config/src/config.rs
+++ b/shiki-config/src/config.rs
@@ -846,6 +846,15 @@ pub struct NotebookGitOverride {
     /// value is ignored rather than honored.
     #[serde(default)]
     pub path: Option<String>,
+    /// Set when "delete notebook" was answered with "just remove the
+    /// reference" instead of "delete the files" — the directory on disk is
+    /// left completely untouched, this only tells `App::reload_notebooks`
+    /// to stop listing it as a tracked notebook. There's deliberately no
+    /// in-app "un-hide" yet; reversing this means clearing the flag (or the
+    /// whole `[notebooks.<name>]` table, if `path` isn't also set) by hand
+    /// in `config.toml` and relaunching.
+    #[serde(default)]
+    pub hidden: bool,
 }
 
 /// `[git]` settings resolved for one specific notebook — see `Config::sync_for`.

--- a/shiki-tui/src/confirm.rs
+++ b/shiki-tui/src/confirm.rs
@@ -7,20 +7,41 @@ use ratatui::Frame;
 #[derive(Debug, Clone)]
 pub struct ConfirmDialog {
     pub message: String,
+    hint: String,
 }
 
 impl ConfirmDialog {
     pub fn new(message: impl Into<String>) -> Self {
         Self {
             message: message.into(),
+            hint: "(y/n)".into(),
         }
+    }
+
+    /// Same dialog, but with a custom key hint instead of the default
+    /// "(y/n)" — for confirmations with more than a plain yes/no choice, e.g.
+    /// `App::start_delete_notebook`'s delete-files-vs-keep-files-and-just-untrack
+    /// prompt.
+    pub fn with_hint(message: impl Into<String>, hint: impl Into<String>) -> Self {
+        Self {
+            message: message.into(),
+            hint: hint.into(),
+        }
+    }
+
+    /// Length of the full rendered line (`message` + separator + `hint`) —
+    /// `app::draw` sizes the popup off this, not off `message` alone, so a
+    /// longer hint (e.g. `with_hint`'s three-way key list) doesn't get
+    /// clipped by a popup only wide enough for the plain "(y/n)" case.
+    pub fn display_len(&self) -> usize {
+        self.message.len() + 2 + self.hint.len()
     }
 
     /// Renders into the exact `area` given — the caller (see `app::draw`) is
     /// responsible for centering/sizing it, so this doesn't recompute its own
     /// centered rect on top of an already-centered one.
     pub fn render(&self, frame: &mut Frame, area: Rect, accent: ratatui::style::Color) {
-        let paragraph = Paragraph::new(format!("{}  (y/n)", self.message)).block(
+        let paragraph = Paragraph::new(format!("{}  {}", self.message, self.hint)).block(
             Block::default()
                 .title(" Confirm ")
                 .borders(Borders::ALL)

--- a/shiki-tui/src/draw.rs
+++ b/shiki-tui/src/draw.rs
@@ -196,7 +196,7 @@ pub fn draw(frame: &mut Frame, app: &App) {
     }
 
     if let Some(dialog) = &app.confirm {
-        let popup_area = centered_rect(frame.area(), (dialog.message.len() as u16 + 12).max(30), 3);
+        let popup_area = centered_rect(frame.area(), (dialog.display_len() as u16 + 4).max(30), 3);
         frame.render_widget(Clear, popup_area);
         dialog.render(frame, popup_area, hex_to_color(&app.theme.warning));
     }

--- a/shiki-tui/src/key_handlers.rs
+++ b/shiki-tui/src/key_handlers.rs
@@ -621,6 +621,7 @@ impl App {
             if over.auto_push.is_none()
                 && over.auto_sync.is_none()
                 && over.auto_sync_every.is_none()
+                && !over.hidden
             {
                 self.config.notebooks.remove(name);
             }
@@ -1816,11 +1817,59 @@ impl App {
             Err(err) => self.set_status(format!("couldn't open browser: {err}")),
         }
     }
+    /// Notebook delete gets a real three-way choice instead of the shared
+    /// y/n confirm every other delete target uses — a notebook's directory
+    /// can hold files that exist nowhere else (unlike a note/folder delete,
+    /// which always has `trash_path`'s safety net) and, for an adopted
+    /// notebook, might not even live under shiki's own data dir at all (an
+    /// Obsidian vault, an existing repo someone pointed shiki at). Answered
+    /// in `handle_delete_notebook_confirm_key`.
     fn start_delete_notebook(&mut self) {
         if let Some(nb) = self.selected_notebook() {
-            let message = format!("Delete notebook '{}' and all its notes?", nb.name);
+            let message = format!("Delete notebook '{}'?", nb.name);
             self.pending_delete = Some((DeleteTarget::Notebook, nb.path.clone()));
-            self.confirm = Some(confirm::ConfirmDialog::new(message));
+            self.confirm = Some(confirm::ConfirmDialog::with_hint(
+                message,
+                "[d] delete files  [r] keep files, just untrack  [Esc] cancel",
+            ));
+        }
+    }
+    /// The three-way answer to `start_delete_notebook`'s prompt. `d`
+    /// actually removes the directory (the old, only behavior); `r` leaves
+    /// the directory completely untouched on disk and just sets
+    /// `NotebookGitOverride::hidden` so `App::reload_notebooks` stops
+    /// listing it — anything else (`Esc`, `n`, ...) cancels.
+    fn handle_delete_notebook_confirm_key(&mut self, key: KeyEvent) {
+        self.confirm = None;
+        let Some((DeleteTarget::Notebook, path)) = self.pending_delete.take() else {
+            return;
+        };
+        let name = path
+            .file_name()
+            .map(|n| n.to_string_lossy().to_string())
+            .unwrap_or_default();
+        match key.code {
+            KeyCode::Char('d') | KeyCode::Char('D') => {
+                let _ = self.store.delete(&name);
+                self.reload_notebooks();
+                self.set_status(format!("notebook '{name}' deleted"));
+            }
+            KeyCode::Char('r') | KeyCode::Char('R') => {
+                self.config
+                    .notebooks
+                    .entry(name.clone())
+                    .or_default()
+                    .hidden = true;
+                self.save_config();
+                self.reload_notebooks();
+                self.set_status(format!(
+                    "notebook '{name}' untracked — files left in place at '{}'",
+                    path.display()
+                ));
+            }
+            _ => {
+                self.set_status("notebook delete cancelled".into());
+            }
         }
     }
     /// Handles either a note or a folder selection — folders never had a
@@ -2184,7 +2233,15 @@ impl App {
     /// (`apply_quick_template`), so the two can't drift into creating notes
     /// differently from each other.
     fn create_note_with_template(&mut self, title: String, template_choice: Option<String>) {
-        let body = match self.pending_new_note_body.take() {
+        let pending_body = self.pending_new_note_body.take();
+        // A scratchpad-originated body always wins over the template — see
+        // the caller's own guard, which skips the picker in that case — but
+        // the `@`-dropdown fast path can still hand in a `template_choice`
+        // alongside a pending scratchpad body, so this stays defensive here
+        // too: `frontmatter.template` must only ever record a template that
+        // actually rendered the body, not one that was picked but discarded.
+        let template_applied = pending_body.is_none() && template_choice.is_some();
+        let body = match pending_body {
             Some(body) => body,
             None => match &template_choice {
                 Some(name) => Config::default_templates_dir()
@@ -2204,9 +2261,11 @@ impl App {
         match self.selected_notebook().cloned() {
             Some(nb) => match nb.create_note_in(&self.notes_relative_path(), &title, body) {
                 Ok(mut note) => {
-                    if let Some(name) = &template_choice {
-                        note.frontmatter.template = Some(name.clone());
-                        let _ = note.save();
+                    if template_applied {
+                        if let Some(name) = &template_choice {
+                            note.frontmatter.template = Some(name.clone());
+                            let _ = note.save();
+                        }
                     }
                     self.reload_notes();
                     if let Some(idx) = self.notes.iter().position(|n| n.path == note.path) {
@@ -2456,11 +2515,21 @@ impl App {
                 } else {
                     value
                 };
+                // A scratchpad save already has its body — merging that
+                // freeform text with a template has no clear insertion
+                // point, so skip the picker entirely and create it blank
+                // rather than letting a chosen template silently not apply
+                // (see `create_note_with_template`'s own guard for the case
+                // where a template is still picked via the `@`-dropdown).
+                self.mode = Mode::Normal;
+                if self.pending_new_note_body.is_some() {
+                    self.create_note_with_template(title, None);
+                    return;
+                }
                 // The note itself isn't created yet — `open_template_picker`
                 // takes over from here and creates it once a template (or
                 // "blank") is actually chosen.
                 self.open_template_picker(title);
-                self.mode = Mode::Normal;
                 return;
             }
             Some(PendingInput::NewFolder) => {
@@ -2790,6 +2859,10 @@ impl App {
         self.mode = Mode::Normal;
     }
     fn handle_confirm_key(&mut self, key: KeyEvent) {
+        if matches!(self.pending_delete, Some((DeleteTarget::Notebook, _))) {
+            self.handle_delete_notebook_confirm_key(key);
+            return;
+        }
         match key.code {
             KeyCode::Char('y') | KeyCode::Char('Y') => {
                 if let Some((target, path)) = self.pending_delete.take() {
@@ -2821,15 +2894,9 @@ impl App {
                                 format!("deleted '{name}'")
                             });
                         }
-                        DeleteTarget::Notebook => {
-                            let name = path
-                                .file_name()
-                                .map(|n| n.to_string_lossy().to_string())
-                                .unwrap_or_default();
-                            let _ = self.store.delete(&name);
-                            self.reload_notebooks();
-                            self.set_status(format!("notebook '{name}' deleted"));
-                        }
+                        DeleteTarget::Notebook => unreachable!(
+                            "notebook deletes are intercepted earlier, in handle_delete_notebook_confirm_key"
+                        ),
                         DeleteTarget::Folder => {
                             let name = path
                                 .file_name()

--- a/shiki-tui/src/sync.rs
+++ b/shiki-tui/src/sync.rs
@@ -23,7 +23,24 @@ pub(crate) enum GitOpKind {
 
 impl App {
     pub(crate) fn reload_notebooks(&mut self) {
-        self.notebooks = self.store.list().unwrap_or_default();
+        // A notebook "deleted" via the keep-files/just-untrack choice (see
+        // `App::handle_delete_notebook_confirm_key`) still fully exists on
+        // disk and in `self.store` — it's excluded here, and only here, so
+        // it stops showing up anywhere the notebook list is used, without
+        // needing its own invalidation logic anywhere else.
+        self.notebooks = self
+            .store
+            .list()
+            .unwrap_or_default()
+            .into_iter()
+            .filter(|nb| {
+                !self
+                    .config
+                    .notebooks
+                    .get(&nb.name)
+                    .is_some_and(|over| over.hidden)
+            })
+            .collect();
         if self.notebooks.is_empty() {
             self.selected_notebook = 0;
         } else {


### PR DESCRIPTION
## Summary
- Deleting a notebook (notebooks-scope `d`) used to call `remove_dir_all` on the directory unconditionally, with no way to just stop tracking it — dangerous for a notebook adopted from an external directory (an Obsidian vault, an existing repo) that shiki never owned in the first place.
- The confirm dialog now offers a real three-way choice: `[d]` deletes the directory for real (unchanged behavior), `[r]` only stops tracking it as a notebook while leaving the directory completely untouched on disk, `[Esc]` cancels.
- "Just untrack" persists as a new `[notebooks.<name>] hidden = true` in `config.toml`; `App::reload_notebooks` filters those out. There's no in-app "un-hide" yet — reversing it means clearing the flag by hand and relaunching (documented in the field's own doc comment and in the CHANGELOG entry).
- Also fixed the confirm popup's width calculation (`draw.rs`), which previously sized off `message.len()` alone and clipped the new longer three-way hint text.

## Test plan
- [x] `cargo fmt --all`
- [x] `cargo clippy --workspace --all-targets` clean
- [x] `cargo check --workspace` clean
- [x] Verified live via tmux against an isolated `XDG_CONFIG_HOME`/`XDG_DATA_HOME`:
  - `[d]` on a real notebook physically removes the directory (unchanged behavior)
  - `[r]` removes the notebook from the TUI list while the directory remains fully intact on disk, with `[notebooks.<name>] hidden = true` written to `config.toml`
  - `[Esc]` cancels cleanly with no side effects
- [x] `CHANGELOG.md` updated under `## [Unreleased]`

🤖 Generated with [Claude Code](https://claude.com/claude-code)