### PR TITLE
Version pill opens a changelog popover

### DIFF
--- a/docs/css/styles.css
+++ b/docs/css/styles.css
@@ -792,23 +792,28 @@ code, .code {
   margin-top: 32px;
 }
 
-#changelog-content h3 {
+/* .changelog-body is shared by the full on-page section (#changelog-content)
+   and the version-pill popover's body (#version-popover-content) — both
+   render the exact same renderChangelog() output, just at different sizes/
+   max-version counts, so they render it with the same rules rather than
+   two independently-maintained copies. */
+.changelog-body h3 {
   color: var(--accent);
   font-size: 1.1rem;
   margin: 32px 0 6px;
 }
 
-#changelog-content h3:first-child {
+.changelog-body h3:first-child {
   margin-top: 0;
 }
 
-#changelog-content .cl-date {
+.changelog-body .cl-date {
   color: var(--muted);
   font-size: 0.85rem;
   font-weight: 400;
 }
 
-#changelog-content h4 {
+.changelog-body h4 {
   font-size: 0.8rem;
   text-transform: uppercase;
   letter-spacing: 0.06em;
@@ -816,17 +821,17 @@ code, .code {
   margin: 16px 0 6px;
 }
 
-#changelog-content ul {
+.changelog-body ul {
   margin: 0 0 8px;
   padding-left: 20px;
 }
 
-#changelog-content li {
+.changelog-body li {
   margin-bottom: 6px;
   font-size: 0.92rem;
 }
 
-#changelog-content li::marker {
+.changelog-body li::marker {
   color: var(--accent);
 }
 
@@ -838,6 +843,80 @@ code, .code {
 .changelog-more {
   margin-top: 24px;
 }
+
+/* ==========================================================================
+   Version-pill popover — a compact "what's new" card anchored to the nav's
+   version chip, present on every page (unlike the full #changelog section
+   above, which only exists on index.html). See initVersionPopover() in
+   main.js.
+   ========================================================================== */
+
+.version-chip-wrap {
+  position: relative;
+  display: inline-block;
+}
+
+.pill-button {
+  font: inherit;
+  cursor: pointer;
+  transition: border-color 0.15s, color 0.15s;
+}
+
+.pill-button:hover,
+.pill-button[aria-expanded="true"] {
+  border-color: var(--accent);
+  color: var(--accent);
+}
+
+.pill-button:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+.version-popover {
+  position: absolute;
+  top: calc(100% + 10px);
+  right: 0;
+  width: min(360px, calc(100vw - 48px));
+  max-height: min(70vh, 480px);
+  overflow-y: auto;
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  box-shadow: 0 20px 40px -12px rgba(0, 0, 0, 0.45);
+  padding: 16px 18px;
+  z-index: 20;
+  text-align: left;
+}
+
+.version-popover-header {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 12px;
+  padding-bottom: 10px;
+  margin-bottom: 4px;
+  border-bottom: 1px solid var(--border);
+  font-size: 0.9rem;
+}
+
+.version-popover-header strong {
+  color: var(--fg);
+}
+
+.version-popover-header a {
+  font-size: 0.8rem;
+  white-space: nowrap;
+}
+
+.version-popover-body {
+  margin-top: 0;
+}
+
+/* No dedicated narrow-viewport rule for .version-popover: `.topbar nav`
+   (which contains the whole chip+popover) is already `display: none` below
+   900px (see Responsive below), so the popover can never actually be open
+   at any width where it would need one. */
 
 /* ==========================================================================
    Footer

--- a/docs/documentation.html
+++ b/docs/documentation.html
@@ -49,7 +49,18 @@
       <a href="documentation.html" class="active">Docs</a>
       <a href="index.html#changelog">Changelog</a>
       <a href="https://github.com/sazardev/shiki">GitHub</a>
-      <span class="pill" id="version-pill" hidden></span>
+      <span class="version-chip-wrap" id="version-chip-wrap">
+        <button type="button" class="pill pill-button" id="version-pill" hidden></button>
+        <div class="version-popover" id="version-popover" role="dialog" aria-label="What's new" hidden>
+          <div class="version-popover-header">
+            <strong>What's new</strong>
+            <a href="https://github.com/sazardev/shiki/blob/main/CHANGELOG.md" target="_blank" rel="noopener">Full changelog →</a>
+          </div>
+          <div class="version-popover-body changelog-body" id="version-popover-content">
+            <p class="changelog-loading">Loading changelog…</p>
+          </div>
+        </div>
+      </span>
     </nav>
   </header>
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -79,7 +79,18 @@
       <a href="documentation.html">Docs</a>
       <a href="#changelog">Changelog</a>
       <a href="https://github.com/sazardev/shiki">GitHub</a>
-      <span class="pill" id="version-pill" hidden></span>
+      <span class="version-chip-wrap" id="version-chip-wrap">
+        <button type="button" class="pill pill-button" id="version-pill" hidden></button>
+        <div class="version-popover" id="version-popover" role="dialog" aria-label="What's new" hidden>
+          <div class="version-popover-header">
+            <strong>What's new</strong>
+            <a href="https://github.com/sazardev/shiki/blob/main/CHANGELOG.md" target="_blank" rel="noopener">Full changelog →</a>
+          </div>
+          <div class="version-popover-body changelog-body" id="version-popover-content">
+            <p class="changelog-loading">Loading changelog…</p>
+          </div>
+        </div>
+      </span>
     </nav>
   </header>
 
@@ -319,7 +330,7 @@ extract, and put it on your $PATH.</pre>
       <p class="muted">Everything that's shipped — new features, real fixes, the occasional
       oops. No highlight reel, no spin.</p>
 
-      <div id="changelog-content">
+      <div id="changelog-content" class="changelog-body">
         <p class="changelog-loading">Loading changelog…</p>
       </div>
       <p class="changelog-more">

--- a/docs/js/main.js
+++ b/docs/js/main.js
@@ -120,6 +120,26 @@ function initTheme() {
 
 const CHANGELOG_URL = "https://raw.githubusercontent.com/sazardev/shiki/main/CHANGELOG.md";
 const CHANGELOG_MAX_VERSIONS = 5;
+// The version-pill popover (see initVersionPopover below) shows fewer
+// entries than the full on-page section — it's a quick "what's new" glance
+// anchored to the pill, not a replacement for the full changelog.
+const CHANGELOG_POPOVER_MAX_VERSIONS = 3;
+
+// Both the full changelog section and the popover render the same
+// CHANGELOG.md — fetched once and cached (module-level promise, not just a
+// variable) so opening the popover on the homepage doesn't re-fetch what
+// loadChangelog() already pulled, and two rapid popover toggles before the
+// first fetch resolves don't fire a second request either.
+let changelogMarkdownPromise = null;
+function fetchChangelogMarkdown() {
+  if (!changelogMarkdownPromise) {
+    changelogMarkdownPromise = fetch(CHANGELOG_URL).then((res) => {
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      return res.text();
+    });
+  }
+  return changelogMarkdownPromise;
+}
 
 function escapeHtml(str) {
   return str
@@ -136,10 +156,10 @@ function renderInline(text) {
   return out;
 }
 
-function renderChangelog(markdown) {
+function renderChangelog(markdown, maxVersions = CHANGELOG_MAX_VERSIONS) {
   const lines = markdown.split("\n");
   let html = "";
-  let versionCount = 0;
+  let shownVersions = 0;
   let inList = false;
   let skipping = false;
   // Continuation lines of a wrapped bullet are accumulated here as *raw*
@@ -149,6 +169,23 @@ function renderChangelog(markdown) {
   // physical lines, and matching backtick/asterisk pairs line-by-line
   // (the previous approach) can't see across that line break.
   let pendingBullet = null;
+  // A version header (`## [x.y.z]`) is held here instead of appended to
+  // `html` immediately — flushed only once real content (a category header
+  // or a bullet) actually follows it. This is what keeps a currently-empty
+  // `## [Unreleased]` from rendering as a bare, content-less heading: if
+  // the *next* version header arrives before this one was ever flushed,
+  // it's simply discarded, and an empty section never counts against
+  // `maxVersions` either (so the cap always shows that many real entries,
+  // not fewer because one slot went to an empty section).
+  let pendingHeaderHtml = null;
+
+  const flushHeader = () => {
+    if (pendingHeaderHtml !== null) {
+      html += pendingHeaderHtml;
+      shownVersions += 1;
+      pendingHeaderHtml = null;
+    }
+  };
 
   const closeList = () => {
     flushBullet();
@@ -170,15 +207,15 @@ function renderChangelog(markdown) {
 
     const versionMatch = line.match(/^##\s+\[([^\]]+)\]\s*(-\s*(.+))?/);
     if (versionMatch) {
-      versionCount += 1;
-      if (versionCount > CHANGELOG_MAX_VERSIONS) {
+      closeList();
+      pendingHeaderHtml = null; // the previous section never got real content — drop its heading
+      if (shownVersions >= maxVersions) {
         skipping = true;
         continue;
       }
       skipping = false;
-      closeList();
       const date = versionMatch[3] ? `<span class="cl-date"> — ${escapeHtml(versionMatch[3])}</span>` : "";
-      html += `<h3>${escapeHtml(versionMatch[1])}${date}</h3>`;
+      pendingHeaderHtml = `<h3>${escapeHtml(versionMatch[1])}${date}</h3>`;
       continue;
     }
 
@@ -187,6 +224,7 @@ function renderChangelog(markdown) {
     const categoryMatch = line.match(/^###\s+(.+)/);
     if (categoryMatch) {
       closeList();
+      flushHeader();
       html += `<h4>${escapeHtml(categoryMatch[1])}</h4>`;
       continue;
     }
@@ -194,6 +232,7 @@ function renderChangelog(markdown) {
     const bulletMatch = line.match(/^-\s+(.+)/);
     if (bulletMatch) {
       flushBullet();
+      flushHeader();
       if (!inList) {
         html += "<ul>";
         inList = true;
@@ -222,13 +261,68 @@ async function loadChangelog() {
   const container = document.getElementById("changelog-content");
   if (!container) return; // this script is shared across pages — not every page has a changelog
   try {
-    const res = await fetch(CHANGELOG_URL);
-    if (!res.ok) throw new Error(`HTTP ${res.status}`);
-    const text = await res.text();
+    const text = await fetchChangelogMarkdown();
     container.innerHTML = renderChangelog(text);
   } catch (err) {
     container.innerHTML = `<p class="changelog-error">Couldn't load the live changelog right now. See it directly on <a href="https://github.com/sazardev/shiki/blob/main/CHANGELOG.md">GitHub</a>.</p>`;
   }
+}
+
+// ---------------------------------------------------------------------------
+// Version-pill popover — clicking the "latest: vX.Y.Z" chip in the nav (see
+// loadLatestRelease below, which fills in its text) drops down a small card
+// with the most recent changelog entries, instead of the chip being a dead
+// label. Present on every page that includes this script (the chip itself
+// is in the shared nav markup), unlike the full changelog section, which
+// only exists on index.html — so this is the one place every page gets a
+// real "what's new" glance, not just the homepage.
+// ---------------------------------------------------------------------------
+
+function initVersionPopover() {
+  const wrap = document.getElementById("version-chip-wrap");
+  const button = document.getElementById("version-pill");
+  const popover = document.getElementById("version-popover");
+  const content = document.getElementById("version-popover-content");
+  if (!wrap || !button || !popover || !content) return; // shared script — not every page/state has all four
+
+  let loaded = false;
+
+  const open = () => {
+    popover.hidden = false;
+    button.setAttribute("aria-expanded", "true");
+    if (!loaded) {
+      loaded = true;
+      fetchChangelogMarkdown()
+        .then((text) => {
+          content.innerHTML = renderChangelog(text, CHANGELOG_POPOVER_MAX_VERSIONS);
+        })
+        .catch(() => {
+          loaded = false; // a later open() retries instead of being stuck on the error forever
+          content.innerHTML = `<p class="changelog-error">Couldn't load the live changelog right now. See it directly on <a href="https://github.com/sazardev/shiki/blob/main/CHANGELOG.md">GitHub</a>.</p>`;
+        });
+    }
+  };
+
+  const close = () => {
+    popover.hidden = true;
+    button.setAttribute("aria-expanded", "false");
+  };
+
+  button.setAttribute("aria-expanded", "false");
+  button.addEventListener("click", () => (popover.hidden ? open() : close()));
+
+  // Click-outside and Escape both close it — the same pair of dismissal
+  // gestures a native <select>/menu supports, so it doesn't feel like a
+  // half-built widget next to the rest of the browser's own UI.
+  document.addEventListener("click", (e) => {
+    if (!popover.hidden && !wrap.contains(e.target)) close();
+  });
+  document.addEventListener("keydown", (e) => {
+    if (e.key === "Escape" && !popover.hidden) {
+      close();
+      button.focus();
+    }
+  });
 }
 
 // ---------------------------------------------------------------------------
@@ -461,4 +555,5 @@ document.addEventListener("DOMContentLoaded", () => {
   loadLatestRelease();
   loadContributors();
   initCopyButtons();
+  initVersionPopover();
 });


### PR DESCRIPTION
## Summary
- The nav's "latest: vX.Y.Z" chip is now a real button — clicking it opens a small popover with the 3 most recent changelog entries, instead of being a static, unclickable label.
- Present on every page that includes `main.js` (homepage + documentation.html), not just the homepage's full changelog section — same fetch/render code, now cached so both don't double-fetch `CHANGELOG.md`.
- Closes on outside click, `Escape`, or clicking the chip again.
- Fix: `renderChangelog()` no longer renders a bare `## [Unreleased]` heading with nothing under it when that section is empty — a version header is only flushed once real content follows it, and empty sections don't count against the max-versions cap.

## Test plan
- [x] Verified live with a local server + headless Chromium (Playwright): popover opens/closes via click, outside-click, and Escape on both `index.html` and `documentation.html`
- [x] Verified across dark (gruvbox-dark) and light (gruvbox-light) site themes — correct colors, no contrast issues
- [x] Confirmed no console errors
- [x] Confirmed the empty-Unreleased-heading fix on both the popover and the full on-page changelog section

🤖 Generated with [Claude Code](https://claude.com/claude-code)