### PR TITLE
Deep review fixes: correctness, perf, CI, DX, and site polish

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -1,0 +1,18 @@
+# Config for `cargo audit` (.github/workflows/ci.yml's `audit` job).
+#
+# Without this file, a future RUSTSEC advisory against a dependency with no
+# upstream fix yet (e.g. one of the transitive advisories CLAUDE.md already
+# notes exist via syntect/ratatui) would hard-block every merge indefinitely,
+# with no configured way to say "known, tracked, not fixable from our own
+# Cargo.toml." Add the advisory ID here with a comment explaining why it's
+# safe to ignore for now, and a reminder to remove the entry once an upstream
+# fix actually lands.
+#
+# Example:
+# [advisories]
+# ignore = [
+#     "RUSTSEC-0000-0000", # unmaintained transitive dep via X, no direct usage of the affected API — tracked in issue #NNN
+# ]
+
+[advisories]
+ignore = []

--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -25,6 +25,7 @@ jobs:
   auto-tag:
     if: contains(github.event.head_commit.message, '[PUBLISH]')
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v7
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,27 +14,65 @@ permissions:
 
 jobs:
   fmt-and-clippy:
-    name: fmt + clippy (ubuntu-latest)
-    runs-on: ubuntu-latest
+    name: fmt + clippy (${{ matrix.os }})
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v7
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: rustfmt, clippy
       - uses: Swatinem/rust-cache@v2
-      - run: cargo fmt --all -- --check
+      # fmt is platform-independent — only worth running once, and clippy's
+      # own output would otherwise get needlessly duplicated 3x in the logs.
+      - if: matrix.os == 'ubuntu-latest'
+        run: cargo fmt --all -- --check
+      # Matrixed rather than ubuntu-only: shiki-core/src/editor.rs has
+      # `#[cfg(target_os = "macos")]`/`#[cfg(target_os = "windows")]` blocks
+      # that an ubuntu-only clippy run would never actually lint.
       - run: cargo clippy --workspace --all-targets -- -D warnings
 
-  build:
-    name: build + check (${{ matrix.os }})
+  audit:
+    name: cargo audit (dependency vulnerabilities)
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v7
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      # Catches new RUSTSEC advisories on an ongoing basis — the git2 0.19
+      # -> 0.21 bump (see CHANGELOG/CLAUDE.md) was a one-time manual audit;
+      # nothing re-checked automatically for a *new* advisory landing after
+      # that, until this job. `cargo audit` auto-discovers `.cargo/audit.toml`
+      # (repo root, checked out by actions/checkout above) for an ignore
+      # list — see that file for how to allowlist a known, tracked,
+      # not-yet-fixable transitive advisory instead of this job blocking
+      # every merge indefinitely once one is found.
+      - run: cargo install cargo-audit --locked
+      - run: cargo audit
+
+  # A single job, not separate `build`/`test` jobs — `cargo test --workspace`
+  # already compiles every lib/bin target in the workspace (in test profile)
+  # on its way to running the tests, so a prior version of this file that
+  # ran `cargo check` + `cargo build` as a *second*, separate job was paying
+  # for close to the same compilation twice, on every push/PR, across all 3
+  # OSes. `cargo check` still runs first, as a fast fail-fast gate before
+  # paying for the slower full test build.
+  test:
+    name: test (${{ matrix.os }})
     strategy:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v7
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - run: cargo check --workspace
-      - run: cargo build --workspace
+      - run: cargo test --workspace

--- a/.github/workflows/nix-package-check.yml
+++ b/.github/workflows/nix-package-check.yml
@@ -12,6 +12,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v7
 

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -29,6 +29,7 @@ concurrency:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
@@ -36,6 +37,17 @@ jobs:
       - uses: actions/checkout@v7
 
       - uses: actions/configure-pages@v6
+
+      # Stamps today's date into sitemap.xml's <lastmod> entries at deploy
+      # time — this site genuinely does change on every release (screenshots,
+      # version), so a hand-maintained static date would just go stale.
+      # Deliberately not committed back to main: it only rewrites the copy
+      # that gets packaged into this deploy's artifact.
+      - name: Stamp sitemap.xml lastmod
+        run: |
+          set -euo pipefail
+          today="$(date -u +%Y-%m-%d)"
+          sed -i "s#<lastmod>.*</lastmod>#<lastmod>${today}</lastmod>#g" docs/sitemap.xml
 
       - uses: actions/upload-pages-artifact@v3
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,12 +26,13 @@ env:
   BIN_NAME: shiki
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   resolve-tag:
     name: Resolve release tag
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     outputs:
       tag: ${{ steps.resolve.outputs.tag }}
     steps:
@@ -58,6 +59,7 @@ jobs:
             target: aarch64-apple-darwin
             ext: tar.gz
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v7
 
@@ -107,6 +109,16 @@ jobs:
     name: Create GitHub Release
     needs: [build, resolve-tag]
     runs-on: ubuntu-latest
+    timeout-minutes: 10
+    # The only job that needs write access to repo contents — creating a
+    # GitHub Release (`softprops/action-gh-release`) via the default
+    # `GITHUB_TOKEN`. Every other job either only reads (`build`,
+    # `resolve-tag`, `publish-crates`) or pushes with `RELEASE_TAG_PAT`
+    # instead of `GITHUB_TOKEN` (`update-packaging-manifests`,
+    # `update-screenshots` — see their own steps for why), so they don't
+    # need this permission at all.
+    permissions:
+      contents: write
     outputs:
       version: ${{ steps.version.outputs.version }}
     steps:
@@ -140,6 +152,7 @@ jobs:
     name: Update AUR/Scoop/Homebrew manifests from release checksums
     needs: [release, resolve-tag]
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v7
         with:
@@ -380,6 +393,7 @@ jobs:
     # instead of adding retry/rebase logic to paper over it.
     needs: [release, resolve-tag, update-packaging-manifests]
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v7
         with:
@@ -484,6 +498,7 @@ jobs:
     name: Publish to crates.io
     needs: release
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v7
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,9 @@ semver yet (pre-1.0), but version bumps are still meaningful and tracked here.
 
 ### Fixed
 
+- The empty NOTEBOOKS panel's hint said `press \`A\` to create one`, but the actual default
+  keybinding for it is lowercase `a` (found by actually using the freshly-built app, not just
+  reading the diff).
 - A note's frontmatter parser used to truncate at the *first* line reading exactly `---` anywhere in
   the file — a YAML block scalar that legitimately contained such a line lost every field after it.
   It now requires that line to be the real closing delimiter.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,104 @@ semver yet (pre-1.0), but version bumps are still meaningful and tracked here.
 
 ## [Unreleased]
 
+### Added
+
+- `shiki notebook delete <name> --yes` — the CLI had no way to delete a notebook at all, despite
+  the TUI supporting it; `--yes` is required (mirrors the TUI's own confirm dialog) since this
+  permanently removes the notebook's directory and every note in it.
+- `shiki doctor` now also checks: unrecognized keys anywhere in `config.toml` (a generic diff
+  against `Config::default()`'s own shape, so it can't drift out of sync with the struct fields the
+  way a hand-maintained list of "known keys" would); `general.default_notebook` actually matching an
+  existing notebook; `data_dir` being a real directory, not just existing; two notebooks resolving to
+  the same path on disk; `git.remote_template` containing its `{notebook}` placeholder; and
+  `git.sign_commits` having an actual signing key configured.
+- `shiki-core`/`shiki-config` test coverage: `note.rs`, `tags.rs`, `daily.rs`, and `session.rs` had
+  zero tests despite being pure, easily-testable logic — added coverage for frontmatter parsing
+  (including the CRLF and YAML-block-scalar fixes below), slugify, tag indexing, daily-note
+  creation, and session-path sanitization.
+- CI: a `cargo audit` job (with a `.cargo/audit.toml` ignore-list mechanism for a known,
+  not-yet-fixable transitive advisory) and a real `cargo test --workspace` job, both missing before.
+
+### Changed
+
+- `shiki sync` (CLI) now resolves `auto_push`/`auto_commit` per-notebook (`Config::sync_for`)
+  instead of always reading the global `[git]` defaults, matching the TUI's `s`/`u` behavior; it also
+  now writes the same file-named commit message the TUI does (`git::diff_summary`) instead of a bare
+  `"{prefix}sync"`, and gives a clear error instead of a raw libgit2 one when no remote is configured.
+- `shiki search`/`shiki list`/`shiki notebook list`'s note counts now walk every folder
+  (`all_notes_recursive`), not just the notebook root — a note nested in a subfolder used to be
+  invisible to these commands while still being editable by name via `shiki edit`.
+- `shiki new`/`shiki edit`/`shiki daily` now respect `general.use_favorite_editor` the same way the
+  TUI's `i` binding does, instead of always using the plain configured `general.editor`.
+- The self-updater (leader+`U`) now installs the *exact* version its confirm dialog showed, rather
+  than re-resolving "latest" a second time — a new release landing in the gap between check and
+  confirmation could previously install a different version than what was displayed.
+- CI's `fmt-and-clippy` job is now matrixed across all three OSes (fmt itself still only runs once,
+  on Linux) so clippy actually lints the `#[cfg(target_os = "macos"/"windows")]` blocks in
+  `shiki-core/src/editor.rs`; the old separate `build` job was folded into `test` (it was paying for
+  close to the same compilation a second time on every push).
+- Every workflow job across all 5 `.github/workflows/*.yml` files now has a `timeout-minutes`, and
+  `release.yml`'s `contents: write` permission is scoped to just the `release` job instead of the
+  whole workflow.
+- The marketing site: a working hamburger menu below 900px (the nav used to just disappear with no
+  replacement), with a real focus trap and no lingering stale popover state when it closes; `.ref-table`
+  now scrolls horizontally in its own container instead of the whole page; TOC/search jumps in
+  `documentation.html` no longer land headings underneath the sticky top bars; the 12 per-theme
+  gallery screenshots no longer double-download (wrong theme, then the right one) on load; the hero
+  GIF respects `prefers-reduced-motion`; `loadLatestRelease`'s fetch has a timeout.
+
+### Fixed
+
+- A note's frontmatter parser used to truncate at the *first* line reading exactly `---` anywhere in
+  the file — a YAML block scalar that legitimately contained such a line lost every field after it.
+  It now requires that line to be the real closing delimiter.
+- Frontmatter written with CRLF line endings (round-tripped through an external editor on Windows)
+  used to fail to parse entirely, falling back to a synthesized title as if the note had no
+  frontmatter at all.
+- `create_note_in`/`rename_note_at` could silently overwrite another note whose title slugified to
+  the same filename (e.g. "Q3 Report" vs. "Q3, Report!"); both now dedupe with a `-2`/`-3` suffix, and
+  a symbol/emoji-only title falls back to a timestamp-based slug instead of an empty one.
+- `Notebook::collect_notes`'s recursive walk had no guard against a self-referential symlink inside a
+  notebook, which could stack-overflow global search.
+- `Template::render` (used by note templates and the `/`-menu) did naive sequential
+  find-and-replace per placeholder, so a variable's value containing another placeholder's literal
+  text (e.g. a title like "Meeting {{date}} notes") got that text substituted again on the next pass.
+  It now does a single left-to-right scan.
+- `editor::command_for` split an editor command on plain whitespace with no quoting support, breaking
+  any configured/detected editor whose path contains a space (common on Windows).
+- `git::redact_credentials` treated the *first* `@` anywhere in a URL as credentials to redact — a
+  self-hosted remote with a legitimate `@` in its path (e.g. `.../notes@backup.git`) got silently
+  mangled in logs.
+- `general.daily_template` was a fully documented, Settings-editable config field that
+  `daily::create_or_open` never actually read — it always hardcoded `"daily"` regardless. Both the
+  CLI (`shiki daily`) and the TUI now pass the configured value through.
+- `copy_folder_to`/`move_folder_to` had no guard against a destination that is the source itself, or
+  nested inside it — reachable through the `m` (move) prompt's prefilled address — which used to
+  recurse forever creating nested copies of the folder inside itself.
+- `git::status()` reported a notebook as clean (`dirty_count = 0`) even when the underlying
+  `repo.statuses(None)` call itself failed (locked index, permissions, a corrupted repo); the footer
+  and drawer now show a distinct "status?" indicator instead.
+- Applying a slash-command or a `[[wikilink]]` selection while multiple cursors were active only
+  ever edited the primary cursor's text, leaving every secondary cursor with its own unconsumed
+  literal text and a desynced position for the rest of the editing session. Both now collapse to a
+  single cursor before applying.
+- `p` (pull one notebook) reset the NOTES selection and preview scroll back to the top whenever the
+  pulled notebook was still selected, even if the user had since navigated to a different note/folder
+  within it — same bug already fixed for `P` (pull all), now fixed for the single-notebook case too.
+- A hand-edited or corrupted `session.toml` with `notes_path` containing `".."` components could
+  make the NOTES panel navigate outside the notebook (and the data directory) on restore; path
+  components are now sanitized on load.
+- `find_note` (used by `edit`/`show`/`daily`/`new`) could silently resolve to the wrong note when two
+  notes in different folders shared a title/slug, a possible ambiguity introduced when note lookup
+  became recursive; it now errors with both folders listed instead of guessing.
+- `TagIndex::build` was rebuilt on every draw tick while the tags modal was open, and even after
+  being cached, `App::tag_index()` still cloned the whole cached index on every draw call — both are
+  now a real cache hit with no per-frame rebuild or clone.
+- `wikilinks::backlinks` re-scanned every note (with a fresh `slugify` call) once per link per note,
+  making it cost O(notes × total links in the notebook); it now builds a title/slug index once.
+- `search_text` (global search) allocated a fresh scratch buffer per note on every keystroke instead
+  of reusing one across the scan.
+
 ## [0.8.10] - 2026-07-31
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2955,6 +2955,7 @@ dependencies = [
  "shiki-core",
  "shiki-tui",
  "tokio",
+ "toml",
  "tracing",
  "tracing-subscriber",
 ]

--- a/IDEA.md
+++ b/IDEA.md
@@ -348,6 +348,7 @@ shiki config              # show config path
 shiki notebook create <name>
 shiki notebook list
 shiki notebook rename <old> <new>
+shiki notebook delete <name> --yes  # permanently deletes the notebook and every note in it
 shiki theme list          # list built-in themes, marking the active one
 shiki theme set <name>    # switch theme (persisted to config.toml)
 shiki theme create [--from <name>]  # scaffold all 19 color overrides from a real palette

--- a/README.md
+++ b/README.md
@@ -110,7 +110,8 @@ the [website](https://sazardev.github.io/shiki/#themes).
 - **In-TUI self-update** (leader+`U`) — checks GitHub Releases for a newer version, and on
   confirmation downloads, verifies, installs, and relaunches into it automatically.
 - **`shiki doctor`** — an environment health check that works even with a broken config; also
-  flags duplicate/colliding keybindings and `/`-menu snippet triggers before they cause confusion.
+  flags duplicate/colliding keybindings, `/`-menu snippet triggers, unrecognized `config.toml` keys,
+  and colliding notebook paths before they cause confusion.
 - **CLI commands** alongside the TUI (`new`, `list`, `edit`, `show`, `search`, `daily`, `sync`,
   `notebook`, `theme`, `config`, `doctor`) for quick one-off operations without opening the UI.
 

--- a/docs/css/documentation.css
+++ b/docs/css/documentation.css
@@ -38,6 +38,21 @@
 
 .doc-page section {
   padding: 56px 0;
+  /* `.topbar` (sticky, ~58px) plus `.doc-toc` (sticky, ~44px) below it cover
+     roughly the first 100px of the viewport — without this, a TOC link
+     click or a doc-search jump (`js/documentation.js`'s `flashTarget`) lands
+     the target flush against the top of the scroll container, i.e. hidden
+     underneath both bars. `scroll-behavior: smooth` (styles.css) plus this
+     is what actually keeps the target heading visible after the jump. */
+  scroll-margin-top: 120px;
+}
+
+.doc-page h3[id] {
+  /* Deep-links inside a section (doc-search results, or a future in-page
+     anchor to a specific `<h3 id>` rather than its parent `<section>`)
+     need the same clearance the section-level scroll-margin-top above
+     already gives whole sections. */
+  scroll-margin-top: 120px;
 }
 
 .doc-page h2 {

--- a/docs/css/styles.css
+++ b/docs/css/styles.css
@@ -346,6 +346,26 @@ code, .code {
   color: var(--accent);
 }
 
+/* Hidden on desktop — only shown (see the 900px media query below) once
+   `.topbar nav` itself collapses, as the only remaining way to reach it. */
+.nav-toggle {
+  display: none;
+  background: none;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  color: var(--fg);
+  font-size: 1.1rem;
+  line-height: 1;
+  padding: 8px 12px;
+  cursor: pointer;
+  font-family: inherit;
+}
+
+.nav-toggle:hover {
+  border-color: var(--accent);
+  color: var(--accent);
+}
+
 /* ==========================================================================
    Buttons / pills
    ========================================================================== */
@@ -723,6 +743,54 @@ code, .code {
 }
 
 /* ==========================================================================
+   Reference tables (documentation.html's keybinding/config/CLI tables) —
+   `.ref-table` had no rule here at all before, so long cells (a keybinding's
+   description column especially) forced the whole page to scroll
+   horizontally instead of just the table, unlike every other wide-content
+   block on the site (`.install-card pre` above, `.code-block`). `display:
+   block` + `overflow-x: auto` on the table itself needs no wrapper element
+   in the markup — same "scroll the element itself" trick `.install-card
+   pre` already uses.
+   ========================================================================== */
+
+.ref-table {
+  display: block;
+  overflow-x: auto;
+  width: 100%;
+  border-collapse: collapse;
+  margin: 16px 0;
+  font-size: 0.9rem;
+}
+
+.ref-table th,
+.ref-table td {
+  padding: 8px 14px;
+  text-align: left;
+  border-bottom: 1px solid var(--border);
+  white-space: nowrap;
+}
+
+.ref-table td:last-child {
+  white-space: normal;
+}
+
+.ref-table th {
+  color: var(--muted);
+  font-weight: 700;
+  font-size: 0.8rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.ref-table td code {
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  padding: 1px 6px;
+  font-size: 0.85em;
+}
+
+/* ==========================================================================
    Contributors
    ========================================================================== */
 
@@ -913,10 +981,17 @@ code, .code {
   margin-top: 0;
 }
 
-/* No dedicated narrow-viewport rule for .version-popover: `.topbar nav`
-   (which contains the whole chip+popover) is already `display: none` below
-   900px (see Responsive below), so the popover can never actually be open
-   at any width where it would need one. */
+/* No dedicated narrow-viewport rule for .version-popover: it's positioned
+   relative to `.version-chip-wrap` (`position: relative`, stretched to the
+   mobile nav's full width by the flex-column `.topbar nav` below 900px —
+   see Responsive), so `right: 0` above still lands it within the viewport
+   once the hamburger menu is opened. It used to be true that `.topbar nav`
+   was unconditionally `display: none` below 900px, making the popover
+   unreachable at that width entirely — that stopped being the case once
+   the mobile nav got a working toggle (`#nav-toggle`/`.nav-open` in
+   main.js/styles.css); closing that menu (link click or Escape) also
+   closes this popover via `initNavToggle`, so it can't reappear
+   already-open next time the menu is opened. */
 
 /* ==========================================================================
    Footer
@@ -960,7 +1035,34 @@ footer.site-footer small {
   .hero h1 {
     font-size: 2.2rem;
   }
+  .nav-toggle {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+  }
   .topbar nav {
     display: none;
+    position: absolute;
+    top: 100%;
+    left: 0;
+    right: 0;
+    flex-direction: column;
+    gap: 0;
+    padding: 8px 24px 16px;
+    background: var(--statusbar);
+    border-bottom: 1px solid var(--border);
+  }
+  .topbar nav.nav-open {
+    display: flex;
+  }
+  .topbar nav a {
+    padding: 10px 0;
+    border-bottom: 1px solid var(--border);
+  }
+  .topbar nav a:last-of-type {
+    border-bottom: none;
+  }
+  .topbar nav .version-chip-wrap {
+    padding: 10px 0;
   }
 }

--- a/docs/documentation.html
+++ b/docs/documentation.html
@@ -42,7 +42,8 @@
 
   <header class="topbar">
     <div class="brand"><a href="index.html" style="color:inherit;text-decoration:none;">shiki (私記)</a><span class="cursor"></span></div>
-    <nav>
+    <button type="button" class="nav-toggle" id="nav-toggle" aria-label="Toggle navigation" aria-expanded="false" aria-controls="site-nav">☰</button>
+    <nav id="site-nav">
       <a href="index.html#themes">Themes</a>
       <a href="index.html#features">Features</a>
       <a href="index.html#install">Install</a>
@@ -123,7 +124,7 @@
 
       <h3>2. The three panels</h3>
       <figure class="doc-shot-card">
-        <img data-shot="wide-01-notebooks" width="1260" height="760" src="assets/screenshots/gallery/gruvbox-dark/wide-01-notebooks.png" alt="shiki's three panels: Notebooks on the left, Notes in the middle, Preview on the right" />
+        <img data-shot="wide-01-notebooks" width="1260" height="760" loading="lazy" src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw==" alt="shiki's three panels: Notebooks on the left, Notes in the middle, Preview on the right" />
         <figcaption>NOTEBOOKS (left) → NOTES (middle) → PREVIEW (right). This is the whole app.</figcaption>
       </figure>
       <p style="max-width:70ch;">
@@ -194,15 +195,15 @@
       </p>
       <div class="doc-shot-grid">
         <figure class="doc-shot-card">
-          <img data-shot="wide-03-preview" width="1260" height="760" src="assets/screenshots/gallery/gruvbox-dark/wide-03-preview.png" alt="Wide terminal: all three panels visible, Preview focused and expanded" />
+          <img data-shot="wide-03-preview" width="1260" height="760" loading="lazy" src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw==" alt="Wide terminal: all three panels visible, Preview focused and expanded" />
           <figcaption><strong>Wide</strong> (≥70 columns) — all three panels, the focused one gets the most space.</figcaption>
         </figure>
         <figure class="doc-shot-card">
-          <img data-shot="stacked-overview" width="540" height="760" src="assets/screenshots/gallery/gruvbox-dark/stacked-overview.png" alt="Narrow terminal: panels stacked vertically instead of side by side" />
+          <img data-shot="stacked-overview" width="540" height="760" loading="lazy" src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw==" alt="Narrow terminal: panels stacked vertically instead of side by side" />
           <figcaption><strong>Narrow but tall, or square</strong> (46–70 columns) — same panels, stacked top-to-bottom.</figcaption>
         </figure>
         <figure class="doc-shot-card">
-          <img data-shot="single-overview" width="360" height="228" src="assets/screenshots/gallery/gruvbox-dark/single-overview.png" alt="Very small terminal: only one panel shown at a time, full screen" />
+          <img data-shot="single-overview" width="360" height="228" loading="lazy" src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw==" alt="Very small terminal: only one panel shown at a time, full screen" />
           <figcaption><strong>Very small</strong> (&lt;46 columns or &lt;14 rows) — one panel at a time, full screen.</figcaption>
         </figure>
       </div>
@@ -260,7 +261,7 @@
         straight from your own config, so it can never show you a binding that doesn't really work.
       </p>
       <figure class="doc-shot-card">
-        <img data-shot="wide-04-which-key" width="1260" height="760" src="assets/screenshots/gallery/gruvbox-dark/wide-04-which-key.png" alt="The which-key modal: a searchable, full-screen list of every active keybinding" />
+        <img data-shot="wide-04-which-key" width="1260" height="760" loading="lazy" src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw==" alt="The which-key modal: a searchable, full-screen list of every active keybinding" />
         <figcaption><code>?</code> — every binding, searchable. Type to filter, Enter runs it directly.</figcaption>
       </figure>
 
@@ -381,7 +382,7 @@
         </tbody>
       </table>
       <figure class="doc-shot-card">
-        <img data-shot="wide-10-tree-view" width="1260" height="760" src="assets/screenshots/gallery/gruvbox-dark/wide-10-tree-view.png" alt="Tree view: every folder and note in the notebook shown as one expanded list" />
+        <img data-shot="wide-10-tree-view" width="1260" height="760" loading="lazy" src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw==" alt="Tree view: every folder and note in the notebook shown as one expanded list" />
         <figcaption><code>T</code> in NOTES — the whole notebook's structure at a glance.</figcaption>
       </figure>
 
@@ -397,7 +398,7 @@
         </tbody>
       </table>
       <figure class="doc-shot-card">
-        <img data-shot="wide-11-history" width="1260" height="760" src="assets/screenshots/gallery/gruvbox-dark/wide-11-history.png" alt="Note history modal: every git commit that touched this note, newest first" />
+        <img data-shot="wide-11-history" width="1260" height="760" loading="lazy" src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw==" alt="Note history modal: every git commit that touched this note, newest first" />
         <figcaption><code>H</code> in PREVIEW — real git history for one note, browsable and revertible.</figcaption>
       </figure>
 
@@ -416,7 +417,7 @@
         then saves and exits, as usual).
       </p>
       <figure class="doc-shot-card">
-        <img data-shot="wide-15-slash-menu" width="1260" height="760" src="assets/screenshots/gallery/gruvbox-dark/wide-15-slash-menu.png" alt="The /-menu open inside the inline editor, listing every quick-insert block" />
+        <img data-shot="wide-15-slash-menu" width="1260" height="760" loading="lazy" src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw==" alt="The /-menu open inside the inline editor, listing every quick-insert block" />
         <figcaption>Type <code>/</code> at the start of a line — every built-in block, filterable, plus anything you've added yourself.</figcaption>
       </figure>
       <p>
@@ -474,6 +475,7 @@ shiki config              # show config path
 shiki notebook create &lt;name&gt;
 shiki notebook list
 shiki notebook rename &lt;old&gt; &lt;new&gt;
+shiki notebook delete &lt;name&gt; --yes  # permanently deletes the notebook and every note in it
 shiki theme list          # list built-in themes, marking the active one
 shiki theme set &lt;name&gt;    # switch theme (persisted to config.toml)
 shiki theme create [--from &lt;name&gt;]  # scaffold all 19 color overrides from a real palette
@@ -624,7 +626,7 @@ Content in **markdown**.
         that slot.
       </p>
       <figure class="doc-shot-card">
-        <img data-shot="wide-05-theme-picker" width="1260" height="760" src="assets/screenshots/gallery/gruvbox-dark/wide-05-theme-picker.png" alt="The theme picker modal with a live preview while browsing" />
+        <img data-shot="wide-05-theme-picker" width="1260" height="760" loading="lazy" src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw==" alt="The theme picker modal with a live preview while browsing" />
         <figcaption><code>leader</code> then <code>c</code> — browse with live preview, Enter to keep it, Esc to cancel back to whatever was active before.</figcaption>
       </figure>
     </div>
@@ -772,7 +774,7 @@ multi_cursor = false</pre>
         straight to the note it resolves to.
       </p>
       <figure class="doc-shot-card">
-        <img data-shot="wide-21-wikilink-autocomplete" width="1260" height="760" src="assets/screenshots/gallery/gruvbox-dark/wide-21-wikilink-autocomplete.png" alt="The [[wikilink]] autocomplete menu open mid-edit, showing fuzzy-matched note candidates with folder breadcrumbs" />
+        <img data-shot="wide-21-wikilink-autocomplete" width="1260" height="760" loading="lazy" src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw==" alt="The [[wikilink]] autocomplete menu open mid-edit, showing fuzzy-matched note candidates with folder breadcrumbs" />
         <figcaption>Typing <code>[[</code> opens a fuzzy note picker — same engine as <code>/</code> and global search.</figcaption>
       </figure>
 
@@ -801,7 +803,7 @@ auto_push = true
 path = "/Users/me/obsidian-vaults/alcateia"
 auto_sync = true</pre>
       <figure class="doc-shot-card">
-        <img data-shot="wide-13-drawer" width="1260" height="760" src="assets/screenshots/gallery/gruvbox-dark/wide-13-drawer.png" alt="The notebook drawer showing every notebook's git status" />
+        <img data-shot="wide-13-drawer" width="1260" height="760" loading="lazy" src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw==" alt="The notebook drawer showing every notebook's git status" />
         <figcaption><code>leader</code> then <code>b</code> — every notebook's sync status at a glance, color-coded.</figcaption>
       </figure>
 
@@ -836,7 +838,7 @@ body = "# [{{title}}] {{cursor}}"</pre>
 
       <h3 id="settings-deep-dive">The Settings screen — editing all of the above without touching the file</h3>
       <figure class="doc-shot-card">
-        <img data-shot="wide-14-settings" width="1260" height="760" src="assets/screenshots/gallery/gruvbox-dark/wide-14-settings.png" alt="The Settings screen, GENERAL tab, showing editable config fields" />
+        <img data-shot="wide-14-settings" width="1260" height="760" loading="lazy" src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw==" alt="The Settings screen, GENERAL tab, showing editable config fields" />
         <figcaption><code>leader</code> then <code>s</code> — every option above, editable in place.</figcaption>
       </figure>
       <p style="max-width:70ch;">

--- a/docs/index.html
+++ b/docs/index.html
@@ -72,7 +72,8 @@
 
   <header class="topbar">
     <div class="brand">shiki (私記)<span class="cursor"></span></div>
-    <nav>
+    <button type="button" class="nav-toggle" id="nav-toggle" aria-label="Toggle navigation" aria-expanded="false" aria-controls="site-nav">☰</button>
+    <nav id="site-nav">
       <a href="#themes">Themes</a>
       <a href="#features">Features</a>
       <a href="#install">Install</a>
@@ -122,7 +123,14 @@
             <span class="term-dot green"></span>
             <span class="term-title">shiki — demo</span>
           </div>
-          <img id="hero-screenshot" src="assets/demo.gif" alt="Animated demo of shiki: browsing notebooks and nested folders, global and in-notebook fuzzy search, tags, multi-select batch delete, creating and moving folders, writing a full note, a git commit, and live theme switching" />
+          <picture>
+            <!-- A GIF can't be paused, so a visitor with the OS-level
+                 "reduce motion" preference set gets a static frame instead
+                 of a forced looping animation — `<source media>` is
+                 evaluated before the `<img>` fallback, no JS needed. -->
+            <source srcset="assets/screenshots/gruvbox-dark.png" media="(prefers-reduced-motion: reduce)" />
+            <img id="hero-screenshot" src="assets/demo.gif" alt="Animated demo of shiki: browsing notebooks and nested folders, global and in-notebook fuzzy search, tags, multi-select batch delete, creating and moving folders, writing a full note, a git commit, and live theme switching" />
+          </picture>
         </div>
       </div>
     </div>
@@ -283,8 +291,11 @@ scoop install shiki</pre>
         </div>
         <div class="install-card">
           <h3>Prebuilt binary</h3>
-          <pre>Download from the <a href="https://github.com/sazardev/shiki/releases/latest">latest release</a>,
-extract, and put it on your $PATH.</pre>
+          <p class="theme-note">
+            Grab the archive for your OS from the
+            <a href="https://github.com/sazardev/shiki/releases/latest">latest release</a>,
+            extract it, and put the binary on your <code>$PATH</code>.
+          </p>
         </div>
       </div>
       <p class="muted" style="margin-top: 24px; font-size: 0.9rem;">

--- a/docs/js/main.js
+++ b/docs/js/main.js
@@ -73,6 +73,20 @@ function applyTheme(themeId) {
   // exact filename stem scripts/screenshots.sh writes (e.g.
   // "wide-01-notebooks" or "stacked-overview") — no prefix assumed here,
   // since the wide/stacked/single tiers don't share one naming pattern.
+  //
+  // The HTML deliberately gives these `<img>` tags a tiny transparent
+  // data-URI placeholder as `src` (a real image URL is invalid markup
+  // without one) instead of a real screenshot path — this function is the
+  // only thing that ever points them at an actual screenshot. A hardcoded
+  // `src="…/gruvbox-dark/…"` used to sit in the markup as a "default," but
+  // the browser starts fetching that the moment it parses the tag, well
+  // before this script has a chance to read the saved theme from
+  // `localStorage` — for any visitor whose saved theme wasn't
+  // gruvbox-dark, that meant downloading both the wrong theme's image
+  // *and* the right one, plus a visible flash between them. The data-URI
+  // placeholder costs no network request at all (it's inline base64), so
+  // this function's own fetch of the correct theme's image is the only one
+  // that ever happens.
   document.querySelectorAll("img[data-shot]").forEach((img) => {
     img.src = `assets/screenshots/gallery/${theme.id}/${img.dataset.shot}.png`;
   });
@@ -283,7 +297,7 @@ function initVersionPopover() {
   const button = document.getElementById("version-pill");
   const popover = document.getElementById("version-popover");
   const content = document.getElementById("version-popover-content");
-  if (!wrap || !button || !popover || !content) return; // shared script — not every page/state has all four
+  if (!wrap || !button || !popover || !content) return null; // shared script — not every page/state has all four
 
   let loaded = false;
 
@@ -323,6 +337,14 @@ function initVersionPopover() {
       button.focus();
     }
   });
+
+  // Exposed so `initNavToggle` can close this popover when the mobile nav
+  // itself closes — otherwise `popover.hidden` only goes visually true via
+  // the ancestor `<nav>` getting `display: none`, while this closure's own
+  // `hidden`/`aria-expanded` state stays stale at "open", reappearing
+  // already-open next time the hamburger opens and reporting a mismatched
+  // expanded state to screen readers in the meantime.
+  return { close };
 }
 
 // ---------------------------------------------------------------------------
@@ -363,12 +385,24 @@ function detectPlatformKey() {
   return null;
 }
 
+// A hung (not failed) request otherwise never resolves or rejects — the
+// existing try/catch only guards against a fetch that actually errors out or
+// a non-ok status, neither of which fires for a connection that just sits
+// open. 8s is generous for a single small JSON response.
+const FETCH_TIMEOUT_MS = 8000;
+
+function fetchWithTimeout(url, timeoutMs = FETCH_TIMEOUT_MS) {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  return fetch(url, { signal: controller.signal }).finally(() => clearTimeout(timer));
+}
+
 async function loadLatestRelease() {
   const downloadBtn = document.getElementById("download-btn");
   const pill = document.getElementById("version-pill");
 
   try {
-    const res = await fetch(LATEST_RELEASE_URL);
+    const res = await fetchWithTimeout(LATEST_RELEASE_URL);
     if (!res.ok) throw new Error(`HTTP ${res.status}`);
     const data = await res.json();
     const tag = data.tag_name; // e.g. "v0.8.1"
@@ -443,6 +477,16 @@ async function loadContributors() {
       fetchGithubJson("https://api.github.com/repos/sazardev/shiki/pulls?state=all&per_page=100"),
       fetchGithubJson("https://api.github.com/repos/sazardev/shiki/issues?state=all&per_page=100"),
     ]);
+
+    // A rate-limited or otherwise-erroring GitHub API call can still come
+    // back as a 200 with a JSON *object* (e.g. `{ message: "API rate limit
+    // exceeded" }`) instead of the array these endpoints normally return —
+    // `fetchGithubJson` only checks `res.ok`, not the shape of the body.
+    // Without this, the `for...of` loops below would throw on a non-iterable
+    // and skip the `catch` block's friendlier fallback message entirely.
+    if (![contributors, pulls, issues].every(Array.isArray)) {
+      throw new Error("unexpected (non-array) response shape from GitHub API");
+    }
 
     const people = new Map(); // login -> { avatar_url, html_url, commits, prs, issues }
 
@@ -548,6 +592,74 @@ function initCopyButtons() {
   });
 }
 
+function initNavToggle(versionPopover) {
+  const toggle = document.getElementById("nav-toggle");
+  const nav = document.getElementById("site-nav");
+  if (!toggle || !nav) return;
+
+  // Every link/button actually reachable while the panel is open — used
+  // both to move focus into the panel on open and to trap Tab/Shift+Tab
+  // inside it while it's open, so keyboard focus can't silently wander
+  // into the hero content sitting hidden underneath the still-open panel.
+  const focusable = () =>
+    Array.from(nav.querySelectorAll("a, button")).filter(
+      (el) => !el.hidden && el.offsetParent !== null
+    );
+
+  const setOpen = (open) => {
+    nav.classList.toggle("nav-open", open);
+    toggle.setAttribute("aria-expanded", String(open));
+    toggle.textContent = open ? "✕" : "☰";
+    // The version popover lives inside `nav` — closing the mobile menu
+    // only hides it visually (via the ancestor's `display: none`) unless
+    // its own state is closed too, so do that explicitly rather than
+    // leaving it internally "open" for next time.
+    if (!open && versionPopover) versionPopover.close();
+    if (open) {
+      focusable()[0]?.focus();
+    } else if (nav.contains(document.activeElement)) {
+      // Closing while focus was still inside the panel (Escape, or a link
+      // navigating away) — return it to the control that opened the panel
+      // instead of leaving it on a now-hidden element.
+      toggle.focus();
+    }
+  };
+
+  toggle.addEventListener("click", () => {
+    setOpen(!nav.classList.contains("nav-open"));
+  });
+
+  // Picking a link closes the menu instead of leaving it open over the
+  // section it just navigated to — otherwise the very next scroll shows a
+  // half-screen nav panel obscuring the content it was just used to reach.
+  nav.querySelectorAll("a").forEach((link) => {
+    link.addEventListener("click", () => setOpen(false));
+  });
+
+  document.addEventListener("keydown", (e) => {
+    if (!nav.classList.contains("nav-open")) return;
+    if (e.key === "Escape") {
+      setOpen(false);
+      return;
+    }
+    // Focus trap: Tab past the last item (or Shift+Tab past the first)
+    // wraps within the panel instead of escaping into the hero content
+    // that's still in the DOM (just visually covered) behind it.
+    if (e.key !== "Tab") return;
+    const items = focusable();
+    if (items.length === 0) return;
+    const first = items[0];
+    const last = items[items.length - 1];
+    if (e.shiftKey && document.activeElement === first) {
+      e.preventDefault();
+      last.focus();
+    } else if (!e.shiftKey && document.activeElement === last) {
+      e.preventDefault();
+      first.focus();
+    }
+  });
+}
+
 document.addEventListener("DOMContentLoaded", () => {
   buildSwatches();
   initTheme();
@@ -555,5 +667,6 @@ document.addEventListener("DOMContentLoaded", () => {
   loadLatestRelease();
   loadContributors();
   initCopyButtons();
-  initVersionPopover();
+  const versionPopover = initVersionPopover();
+  initNavToggle(versionPopover);
 });

--- a/docs/sitemap.xml
+++ b/docs/sitemap.xml
@@ -2,11 +2,13 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://sazardev.github.io/shiki/</loc>
+    <lastmod>2026-08-03</lastmod>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>
   <url>
     <loc>https://sazardev.github.io/shiki/documentation.html</loc>
+    <lastmod>2026-08-03</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>

--- a/shiki-cli/Cargo.toml
+++ b/shiki-cli/Cargo.toml
@@ -26,3 +26,4 @@ anyhow.workspace = true
 tracing.workspace = true
 tracing-subscriber.workspace = true
 chrono.workspace = true
+toml.workspace = true

--- a/shiki-cli/src/commands/daily.rs
+++ b/shiki-cli/src/commands/daily.rs
@@ -10,6 +10,7 @@ pub fn run(
     notebook: &str,
     templates_dir: &Path,
     editor: &str,
+    daily_template: &str,
 ) -> Result<()> {
     let nb = match store.get(notebook) {
         Ok(nb) => nb,
@@ -18,7 +19,7 @@ pub fn run(
             .with_context(|| format!("could not create notebook '{notebook}'"))?,
     };
     let today = chrono::Local::now().date_naive();
-    let note = shiki_core::daily::create_or_open(&nb, today, templates_dir)?;
+    let note = shiki_core::daily::create_or_open(&nb, today, templates_dir, daily_template)?;
     println!("daily: {}", note.path.display());
     open_in_editor(editor, &note.path)
 }

--- a/shiki-cli/src/commands/doctor.rs
+++ b/shiki-cli/src/commands/doctor.rs
@@ -511,12 +511,35 @@ fn check_unknown_config_keys(raw: &str, r: &mut Report) {
     let Ok(raw_value) = toml::from_str::<toml::Value>(raw) else {
         return; // already reported as invalid TOML by the caller
     };
-    let Ok(canonical) = toml::Value::try_from(Config::default()) else {
+    // `toml::Value::try_from` omits a struct field entirely when it's a
+    // `None`-valued `Option<T>` — which `Config::default()` alone would be
+    // for every one of these: `general.data_dir`, all 19
+    // `ThemeOverrides` slots, `NotebookGitOverride`'s `auto_push`/
+    // `auto_sync`/`auto_sync_every`/`path`, and `SnippetConfig.label`. A
+    // canonical shape built straight from `Config::default()` would then
+    // have *none* of those keys at all, so setting any single one of them
+    // — every one a real, documented feature — got flagged as "unrecognized"
+    // (caught in review before merge: a config with `theme.bg`,
+    // `notebooks.personal.auto_push`, or `snippets.todo.label` set falsely
+    // warned on all three). Fixed by explicitly populating every such field
+    // with `Some(_)` in the shapes below, so its key actually appears.
+    let mut canonical_config = Config::default();
+    canonical_config.general.data_dir = Some(String::new());
+    canonical_config.theme.overrides =
+        shiki_config::config::ThemeOverrides::from_theme(&shiki_config::Theme::terminal_default());
+    let Ok(canonical) = toml::Value::try_from(canonical_config) else {
         return;
     };
-    let notebook_shape = toml::Value::try_from(NotebookGitOverride::default()).ok();
+    let notebook_shape = toml::Value::try_from(NotebookGitOverride {
+        auto_push: Some(false),
+        auto_sync: Some(false),
+        auto_sync_every: Some(1),
+        path: Some(String::new()),
+        hidden: false,
+    })
+    .ok();
     let snippet_shape = toml::Value::try_from(SnippetConfig {
-        label: None,
+        label: Some(String::new()),
         body: String::new(),
     })
     .ok();
@@ -776,5 +799,69 @@ fn check_snippet_health(config: &Config, r: &mut Report) {
                 triggers.join("] / [snippets.")
             ),
         );
+    }
+}
+
+#[cfg(test)]
+mod check_unknown_config_keys_tests {
+    use super::*;
+
+    #[test]
+    fn does_not_flag_legitimate_optional_fields_as_unrecognized() {
+        // Every one of these is a real, `Option<T>`-typed field that's
+        // `None` in `Config::default()` — a naive canonical shape built
+        // straight from `Config::default()` (via `toml::Value::try_from`,
+        // which omits `None` fields entirely) flagged all of them as
+        // typos the first time this check was written, since setting any
+        // one of them meant its key simply didn't exist in the "known"
+        // shape to compare against.
+        let raw = r##"
+[general]
+default_notebook = "personal"
+data_dir = "/some/custom/path"
+
+[theme]
+name = "gruvbox-dark"
+bg = "#123456"
+
+[notebooks.personal]
+auto_push = true
+auto_sync_every = 5
+path = "/some/notebook/path"
+
+[snippets.todo]
+label = "Todo item"
+body = "- [ ] "
+"##;
+        let mut r = Report::new();
+        check_unknown_config_keys(raw, &mut r);
+        assert_eq!(
+            r.warn, 0,
+            "no legitimate field should be flagged as unrecognized"
+        );
+        assert_eq!(r.ok, 1);
+    }
+
+    #[test]
+    fn still_flags_a_real_typo() {
+        let raw = r#"
+[general]
+remeber_last_session = true
+"#;
+        let mut r = Report::new();
+        check_unknown_config_keys(raw, &mut r);
+        assert_eq!(r.warn, 1);
+        assert_eq!(r.ok, 0);
+    }
+
+    #[test]
+    fn flags_a_nested_notebook_override_typo() {
+        let raw = r#"
+[notebooks.work]
+auto_puush = true
+"#;
+        let mut r = Report::new();
+        check_unknown_config_keys(raw, &mut r);
+        assert_eq!(r.warn, 1);
     }
 }

--- a/shiki-cli/src/commands/doctor.rs
+++ b/shiki-cli/src/commands/doctor.rs
@@ -9,6 +9,7 @@ use std::path::PathBuf;
 
 use anyhow::Result;
 use crossterm::event::KeyCode;
+use shiki_config::config::{NotebookGitOverride, SnippetConfig};
 use shiki_config::Config;
 use shiki_core::NotebookStore;
 use shiki_tui::keybindings::parse_key;
@@ -72,6 +73,7 @@ pub fn run() -> Result<()> {
     );
 
     let config_path = Config::default_path();
+    let mut raw_contents: Option<String> = None;
     let config = match &config_path {
         Ok(path) if !path.exists() => {
             r.warn(
@@ -87,6 +89,7 @@ pub fn run() -> Result<()> {
             Ok(contents) => match Config::parse(&contents) {
                 Ok(cfg) => {
                     r.pass("config", path.display());
+                    raw_contents = Some(contents);
                     Some(cfg)
                 }
                 Err(e) => {
@@ -122,8 +125,16 @@ pub fn run() -> Result<()> {
         r.fail("data dir", "could not determine default data directory");
         return Ok(());
     };
-    if data_dir.exists() {
+    if data_dir.is_dir() {
         r.pass("data dir", data_dir.display());
+    } else if data_dir.exists() {
+        r.fail(
+            "data dir",
+            format!(
+                "{} \u{2014} exists but is not a directory (notebook creation will fail)",
+                data_dir.display()
+            ),
+        );
     } else {
         r.warn(
             "data dir",
@@ -224,6 +235,21 @@ pub fn run() -> Result<()> {
                     notebooks.len()
                 ),
             );
+            check_notebook_path_collisions(&notebooks, &mut r);
+            let default_name = &config.general.default_notebook;
+            if notebooks.iter().any(|nb| &nb.name == default_name) {
+                r.pass("default_notebook", format!("\"{default_name}\" exists"));
+            } else {
+                r.warn(
+                    "default_notebook",
+                    format!(
+                        "\"{default_name}\" doesn't match any existing notebook \u{2014} commands \
+                         that fall back to it (no explicit -n/--notebook) will fail with \
+                         \"notebook not found\" until it's created or `general.default_notebook` \
+                         is updated"
+                    ),
+                );
+            }
         }
         Err(e) => r.fail("notebooks", e),
     }
@@ -231,6 +257,11 @@ pub fn run() -> Result<()> {
     check_keybinding_health(&config, &mut r);
     check_snippet_health(&config, &mut r);
     check_notebook_path_health(&config, &mut r);
+    check_theme_health(&config, &mut r);
+    if let Some(raw) = &raw_contents {
+        check_unknown_config_keys(raw, &mut r);
+    }
+    check_git_config_health(&config, &mut r);
 
     println!("\n{} ok, {} warning(s), {} failed", r.ok, r.warn, r.fail);
     if r.fail > 0 {
@@ -456,6 +487,255 @@ fn check_notebook_path_health(config: &Config, r: &mut Report) {
             names.join(", ")
         ),
     );
+}
+
+/// A typo'd `theme.name` or a malformed hex color override doesn't panic
+/// anywhere — `ThemeConfig::resolve()` falls back to `Theme::terminal_default()`
+/// for an unknown name, and `shiki-tui::render::hex_to_color` falls back to
+/// `Color::Reset` for a bad value — but neither ever tells the user their
+/// config value was actually ignored. This surfaces both at the one place a
+/// user checking "is my config okay" would look.
+/// `Config`'s `#[serde(default)]` fields mean a typo'd key/table anywhere in
+/// `config.toml` (`remeber_last_session`, `[keybinding.global]`) is silently
+/// ignored rather than rejected — there's no `deny_unknown_fields` here on
+/// purpose (that would turn any single typo into a hard failure of the
+/// *entire* config, including every field that parsed fine), but a typo
+/// still deserves a visible warning somewhere. This diffs the raw parsed
+/// TOML against a canonical shape built from `Config::default()` (plus a
+/// synthetic single-entry shape for the two dynamic tables,
+/// `[notebooks.<name>]`/`[snippets.<trigger>]`, whose own keys are
+/// user-chosen names, not part of the schema) — generic over whatever
+/// fields `Config`'s structs actually have, so it can't drift out of sync
+/// with them the way a hand-maintained list of "known field names" would.
+fn check_unknown_config_keys(raw: &str, r: &mut Report) {
+    let Ok(raw_value) = toml::from_str::<toml::Value>(raw) else {
+        return; // already reported as invalid TOML by the caller
+    };
+    let Ok(canonical) = toml::Value::try_from(Config::default()) else {
+        return;
+    };
+    let notebook_shape = toml::Value::try_from(NotebookGitOverride::default()).ok();
+    let snippet_shape = toml::Value::try_from(SnippetConfig {
+        label: None,
+        body: String::new(),
+    })
+    .ok();
+
+    let mut unknown = Vec::new();
+    collect_unknown_keys(
+        &raw_value,
+        &canonical,
+        "",
+        notebook_shape.as_ref(),
+        snippet_shape.as_ref(),
+        &mut unknown,
+    );
+
+    if unknown.is_empty() {
+        r.pass("config keys", "no unrecognized keys found");
+        return;
+    }
+    unknown.sort();
+    for key in unknown {
+        r.warn(
+            "config keys",
+            format!(
+                "`{key}` in config.toml doesn't match any known setting \u{2014} a typo, or \
+                 left over from a different shiki version? It's silently ignored either way"
+            ),
+        );
+    }
+}
+
+fn collect_unknown_keys(
+    raw: &toml::Value,
+    canonical: &toml::Value,
+    path: &str,
+    notebook_shape: Option<&toml::Value>,
+    snippet_shape: Option<&toml::Value>,
+    out: &mut Vec<String>,
+) {
+    let (Some(raw_table), Some(canon_table)) = (raw.as_table(), canonical.as_table()) else {
+        return;
+    };
+    for (key, raw_val) in raw_table {
+        let full_path = if path.is_empty() {
+            key.clone()
+        } else {
+            format!("{path}.{key}")
+        };
+        match canon_table.get(key) {
+            Some(canon_val) => {
+                collect_unknown_keys(
+                    raw_val,
+                    canon_val,
+                    &full_path,
+                    notebook_shape,
+                    snippet_shape,
+                    out,
+                );
+            }
+            None if path == "notebooks" => {
+                if let Some(shape) = notebook_shape {
+                    collect_unknown_keys(raw_val, shape, &full_path, None, None, out);
+                }
+            }
+            None if path == "snippets" => {
+                if let Some(shape) = snippet_shape {
+                    collect_unknown_keys(raw_val, shape, &full_path, None, None, out);
+                }
+            }
+            None => out.push(full_path),
+        }
+    }
+}
+
+fn check_theme_health(config: &Config, r: &mut Report) {
+    let name = &config.theme.name;
+    if name != "default" && shiki_config::themes::by_name(name).is_none() {
+        r.warn(
+            "theme",
+            format!(
+                "theme.name = \"{name}\" doesn't match any built-in theme \u{2014} falling back \
+                 to \"default\" (terminal colors). Run `shiki theme set <name>` to see valid names"
+            ),
+        );
+    } else {
+        r.pass("theme", format!("\"{name}\""));
+    }
+
+    let overrides: [(&str, &Option<String>); 19] = [
+        ("bg", &config.theme.overrides.bg),
+        ("fg", &config.theme.overrides.fg),
+        ("accent", &config.theme.overrides.accent),
+        ("selection", &config.theme.overrides.selection),
+        ("border", &config.theme.overrides.border),
+        ("statusbar", &config.theme.overrides.statusbar),
+        ("highlight", &config.theme.overrides.highlight),
+        ("error", &config.theme.overrides.error),
+        ("warning", &config.theme.overrides.warning),
+        ("success", &config.theme.overrides.success),
+        ("inactive", &config.theme.overrides.inactive),
+        ("scrollbar", &config.theme.overrides.scrollbar),
+        ("tab_active", &config.theme.overrides.tab_active),
+        ("tab_inactive", &config.theme.overrides.tab_inactive),
+        ("panel_title", &config.theme.overrides.panel_title),
+        ("cursor", &config.theme.overrides.cursor),
+        ("link", &config.theme.overrides.link),
+        ("tag", &config.theme.overrides.tag),
+        ("muted", &config.theme.overrides.muted),
+    ];
+    let mut bad: Vec<String> = Vec::new();
+    for (field, value) in overrides {
+        if let Some(v) = value {
+            if !is_valid_color_value(v) {
+                bad.push(format!("{field} = \"{v}\""));
+            }
+        }
+    }
+    if bad.is_empty() {
+        return;
+    }
+    r.warn(
+        "theme overrides",
+        format!(
+            "not a recognized color \u{2014} silently renders as the terminal's reset color \
+             instead: {}",
+            bad.join(", ")
+        ),
+    );
+}
+
+/// Same set of values `shiki-tui::render::hex_to_color` accepts: a known
+/// ANSI name, `"reset"`/empty, or a 6-digit hex string (with or without a
+/// leading `#`). Kept independent of `render::hex_to_color` itself (which
+/// lives in `shiki-tui` and has no "was this valid" return value, only a
+/// color to fall back to) rather than trying to reuse it here.
+fn is_valid_color_value(value: &str) -> bool {
+    match value.to_ascii_lowercase().as_str() {
+        "reset" | "" | "black" | "red" | "green" | "yellow" | "blue" | "magenta" | "cyan"
+        | "white" | "gray" | "grey" | "darkgray" | "darkgrey" => return true,
+        _ => {}
+    }
+    let hex = value.trim_start_matches('#');
+    hex.len() == 6 && hex.chars().all(|c| c.is_ascii_hexdigit())
+}
+
+/// `[notebooks.<name>] path = "..."` is validated for being absolute
+/// (`Config::notebook_custom_paths`) but nothing checks whether two
+/// different notebook names end up pointing at the exact same directory —
+/// a copy-pasted override, or one notebook's custom path accidentally
+/// matching another's, silently makes both names share a single git repo
+/// (writes to one show up as the other). Compares canonicalized paths where
+/// possible so a `..`-relative detour or symlink doesn't hide a real
+/// collision, falling back to the raw path when canonicalization fails
+/// (e.g. the directory doesn't exist yet) rather than skipping the check.
+fn check_notebook_path_collisions(notebooks: &[shiki_core::Notebook], r: &mut Report) {
+    let mut by_path: HashMap<PathBuf, Vec<&str>> = HashMap::new();
+    for nb in notebooks {
+        let key = nb.path.canonicalize().unwrap_or_else(|_| nb.path.clone());
+        by_path.entry(key).or_default().push(&nb.name);
+    }
+    let mut collisions: Vec<Vec<&str>> = by_path
+        .into_values()
+        .filter(|names| names.len() > 1)
+        .collect();
+    for names in &mut collisions {
+        names.sort_unstable();
+    }
+    collisions.sort();
+    for names in collisions {
+        r.warn(
+            "notebook paths",
+            format!(
+                "{} all resolve to the same directory on disk \u{2014} they're silently \
+                 sharing one git repo",
+                names.join(", ")
+            ),
+        );
+    }
+}
+
+/// Two purely local `[git]` preconditions doctor can actually verify without
+/// touching the network:
+///
+/// 1. `remote_template` is meant to contain a `{notebook}` placeholder
+///    (`App::create_notebook_from_url`'s plain-name path substitutes it in) —
+///    a typo'd or missing placeholder means every new notebook silently gets
+///    assigned the exact same literal remote URL, which nobody would notice
+///    until a push collides.
+/// 2. `sign_commits = true` has no effect unless git itself already has a
+///    signing key configured (`user.signingkey`, or `gpg.format = ssh`'s
+///    `user.signingkey` pointing at an SSH key) — `commit_all`'s signing
+///    would otherwise fail on every single commit.
+fn check_git_config_health(config: &Config, r: &mut Report) {
+    let template = &config.git.remote_template;
+    if !template.is_empty() && !template.contains("{notebook}") {
+        r.warn(
+            "git.remote_template",
+            format!(
+                "\"{template}\" has no {{notebook}} placeholder \u{2014} every new plain-name \
+                 notebook would get assigned this exact same literal remote URL"
+            ),
+        );
+    }
+
+    if config.git.sign_commits {
+        let key_configured = std::process::Command::new("git")
+            .args(["config", "--get", "user.signingkey"])
+            .output()
+            .map(|out| out.status.success() && !out.stdout.is_empty())
+            .unwrap_or(false);
+        if key_configured {
+            r.pass("git sign_commits", "user.signingkey is configured");
+        } else {
+            r.warn(
+                "git sign_commits",
+                "git.sign_commits is on but `git config user.signingkey` is empty \u{2014} \
+                 every commit will fail to sign until it's set",
+            );
+        }
+    }
 }
 
 fn check_snippet_health(config: &Config, r: &mut Report) {

--- a/shiki-cli/src/commands/list.rs
+++ b/shiki-cli/src/commands/list.rs
@@ -2,10 +2,10 @@ use anyhow::{Context, Result};
 use shiki_core::NotebookStore;
 
 pub fn run(store: &NotebookStore, notebook: &str) -> Result<()> {
-    let nb = store
-        .get(notebook)
-        .with_context(|| format!("notebook '{notebook}' not found"))?;
-    let notes = nb.list_notes()?;
+    let nb = store.get(notebook).with_context(|| {
+        format!("notebook '{notebook}' not found \u{2014} see `shiki notebook list`")
+    })?;
+    let notes = nb.all_notes_recursive()?;
     if notes.is_empty() {
         println!("({notebook} is empty)");
         return Ok(());

--- a/shiki-cli/src/commands/mod.rs
+++ b/shiki-cli/src/commands/mod.rs
@@ -13,17 +13,45 @@ pub mod theme;
 use anyhow::{Context, Result};
 use shiki_core::{Note, NotebookStore};
 
-/// Resolves a note by slug or by (case-insensitive) title match within a notebook.
+/// Resolves a note by slug or by (case-insensitive) title match within a
+/// notebook — searched recursively across every folder, so two notes with
+/// the same title/slug in different folders both match `needle`. Errors
+/// with a clear disambiguation message (listing each match's folder) rather
+/// than silently returning whichever one the recursive walk happened to
+/// find first — a real ambiguity risk that root-only lookup never had
+/// before `all_notes_recursive` replaced it.
 pub fn find_note(store: &NotebookStore, notebook: &str, needle: &str) -> Result<Note> {
-    let nb = store
-        .get(notebook)
-        .with_context(|| format!("notebook '{notebook}' not found"))?;
+    let nb = store.get(notebook).with_context(|| {
+        format!("notebook '{notebook}' not found \u{2014} see `shiki notebook list`")
+    })?;
     let notes = nb.all_notes_recursive()?;
     let slug = shiki_core::note::Note::slugify(needle);
-    notes
+    let mut matches: Vec<Note> = notes
         .into_iter()
-        .find(|n| n.file_stem() == slug || n.frontmatter.title.eq_ignore_ascii_case(needle))
-        .with_context(|| format!("note '{needle}' not found in '{notebook}'"))
+        .filter(|n| n.file_stem() == slug || n.frontmatter.title.eq_ignore_ascii_case(needle))
+        .collect();
+    match matches.len() {
+        0 => anyhow::bail!("note '{needle}' not found in '{notebook}'"),
+        1 => Ok(matches.remove(0)),
+        _ => {
+            let mut locations: Vec<String> = matches
+                .iter()
+                .map(|n| {
+                    n.path
+                        .strip_prefix(&nb.path)
+                        .unwrap_or(&n.path)
+                        .display()
+                        .to_string()
+                })
+                .collect();
+            locations.sort();
+            anyhow::bail!(
+                "'{needle}' matches {} notes in '{notebook}' \u{2014} be more specific: {}",
+                matches.len(),
+                locations.join(", ")
+            )
+        }
+    }
 }
 
 /// Opens `path` with the configured external editor, waiting for it to finish.

--- a/shiki-cli/src/commands/notebook.rs
+++ b/shiki-cli/src/commands/notebook.rs
@@ -14,8 +14,13 @@ pub fn list(store: &NotebookStore) -> Result<()> {
         return Ok(());
     }
     for nb in notebooks {
-        let count = nb.list_notes().map(|n| n.len()).unwrap_or(0);
-        println!("{}  ({count} notes)", nb.name);
+        match nb.all_notes_recursive() {
+            Ok(notes) => println!("{}  ({} notes)", nb.name, notes.len()),
+            // A failed walk (permissions, I/O) is not the same thing as a
+            // genuinely empty notebook — `unwrap_or(0)` used to make the two
+            // indistinguishable in this output.
+            Err(e) => println!("{}  (error reading notes: {e})", nb.name),
+        }
     }
     Ok(())
 }
@@ -23,5 +28,21 @@ pub fn list(store: &NotebookStore) -> Result<()> {
 pub fn rename(store: &NotebookStore, old: &str, new: &str) -> Result<()> {
     let nb = store.rename(old, new)?;
     println!("renamed to: {}", nb.path.display());
+    Ok(())
+}
+
+/// Permanently deletes a notebook and every note in it (`NotebookStore::delete`
+/// is a plain `remove_dir_all` — no trash/undo). `yes` must be explicitly
+/// passed (`--yes`), mirroring the TUI's own confirm dialog for the same
+/// action, rather than deleting on the bare name alone.
+pub fn delete(store: &NotebookStore, name: &str, yes: bool) -> Result<()> {
+    if !yes {
+        anyhow::bail!(
+            "this permanently deletes '{name}' and every note in it \u{2014} re-run with --yes \
+             to confirm"
+        );
+    }
+    store.delete(name)?;
+    println!("deleted: {name}");
     Ok(())
 }

--- a/shiki-cli/src/commands/search.rs
+++ b/shiki-cli/src/commands/search.rs
@@ -2,10 +2,10 @@ use anyhow::{Context, Result};
 use shiki_core::{NotebookStore, SearchEngine};
 
 pub fn run(store: &NotebookStore, notebook: &str, query: &str) -> Result<()> {
-    let nb = store
-        .get(notebook)
-        .with_context(|| format!("notebook '{notebook}' not found"))?;
-    let notes = nb.list_notes()?;
+    let nb = store.get(notebook).with_context(|| {
+        format!("notebook '{notebook}' not found \u{2014} see `shiki notebook list`")
+    })?;
+    let notes = nb.all_notes_recursive()?;
     let mut engine = SearchEngine::new();
     let hits = engine.search(query, &notes);
     if hits.is_empty() {

--- a/shiki-cli/src/commands/sync.rs
+++ b/shiki-cli/src/commands/sync.rs
@@ -1,21 +1,40 @@
 use anyhow::{Context, Result};
-use shiki_config::config::GitConfig;
+use shiki_config::Config;
 use shiki_core::{git, NotebookStore};
 
-pub fn run(store: &NotebookStore, notebook: &str, git_config: &GitConfig) -> Result<()> {
-    let nb = store
-        .get(notebook)
-        .with_context(|| format!("notebook '{notebook}' not found"))?;
-    let message = format!("{}sync", git_config.commit_prefix);
-    let committed = git::commit_all(&nb.path, &message)?;
-    if committed {
-        println!("commit created in '{notebook}'");
+pub fn run(store: &NotebookStore, notebook: &str, config: &Config) -> Result<()> {
+    let nb = store.get(notebook).with_context(|| {
+        format!("notebook '{notebook}' not found \u{2014} see `shiki notebook list`")
+    })?;
+    let sync = config.sync_for(notebook);
+    if config.git.auto_commit {
+        // Names the actual changed files in the commit message (falling
+        // back to a bare "changes" only if the diff walk itself fails) —
+        // same `git::diff_summary` the TUI's `run_sync_blocking` already
+        // uses, so `shiki sync` and pressing `s` in the TUI produce the
+        // same git history instead of this command always writing a bare
+        // "{prefix}sync" regardless of what actually changed.
+        let summary = git::diff_summary(&nb.path).unwrap_or_else(|_| "changes".to_string());
+        let message = format!("{}{summary}", config.git.commit_prefix);
+        let committed = git::commit_all(&nb.path, &message)?;
+        if committed {
+            println!("commit created in '{notebook}': {summary}");
+        } else {
+            println!("'{notebook}' has no changes");
+        }
     } else {
-        println!("'{notebook}' has no changes");
+        println!("auto_commit is disabled; skipping commit for '{notebook}'");
     }
-    if git_config.auto_push {
-        git::push(&nb.path, &git_config.remote)?;
-        println!("pushed to {}", git_config.remote);
+    if sync.auto_push {
+        if git::remote_url(&nb.path).is_none() {
+            println!(
+                "'{notebook}' has no git remote configured \u{2014} set one (`R` in the TUI, or \
+                 `git -C <notebook path> remote add origin <url>`), then sync again"
+            );
+        } else {
+            git::push(&nb.path, &config.git.remote)?;
+            println!("pushed to {}", config.git.remote);
+        }
     }
     Ok(())
 }

--- a/shiki-cli/src/main.rs
+++ b/shiki-cli/src/main.rs
@@ -1,7 +1,7 @@
 mod commands;
 mod tui;
 
-use anyhow::Result;
+use anyhow::{Context as _, Result};
 use clap::{Parser, Subcommand};
 use shiki_config::Config;
 use shiki_core::NotebookStore;
@@ -77,9 +77,23 @@ enum Commands {
 
 #[derive(Subcommand)]
 enum NotebookAction {
-    Create { name: String },
+    Create {
+        name: String,
+    },
     List,
-    Rename { old: String, new: String },
+    Rename {
+        old: String,
+        new: String,
+    },
+    /// Permanently deletes a notebook and every note in it — irreversible,
+    /// so it requires `--yes` rather than deleting on the bare name alone
+    /// (the TUI's equivalent action is gated behind its own confirm
+    /// dialog; this is the CLI's version of that same guard).
+    Delete {
+        name: String,
+        #[arg(long)]
+        yes: bool,
+    },
 }
 
 #[derive(Subcommand)]
@@ -109,12 +123,11 @@ impl Context {
         let config = Config::load_or_init(&config_path)?;
         let templates_dir = Config::default_templates_dir()?;
         shiki_core::templates::ensure_defaults(&templates_dir)?;
-        let data_dir = config
-            .general
-            .data_dir
-            .as_ref()
-            .map(PathBuf::from)
-            .unwrap_or_else(|| Config::default_data_dir().expect("valid data dir"));
+        let data_dir = match config.general.data_dir.as_ref() {
+            Some(dir) => PathBuf::from(dir),
+            None => Config::default_data_dir()
+                .context("could not determine a default data directory (no $HOME/$XDG_DATA_HOME?) — set general.data_dir in config.toml")?,
+        };
         let custom_paths = config.notebook_custom_paths();
         let store = NotebookStore::new_with_custom_paths(data_dir, custom_paths);
         Ok(Self { config, store })
@@ -122,6 +135,21 @@ impl Context {
 
     fn notebook_name(&self, override_name: Option<String>) -> String {
         override_name.unwrap_or_else(|| self.config.general.default_notebook.clone())
+    }
+
+    /// The editor command to actually launch — `general.use_favorite_editor`
+    /// (the TUI's `i` binding already resolves this way) means the CLI
+    /// should too, rather than always using the plain configured
+    /// `general.editor` regardless of that setting. Falls back to the
+    /// configured editor when favorite-editor detection finds nothing, same
+    /// as the TUI's own fallback.
+    fn resolve_editor(&self) -> String {
+        if self.config.general.use_favorite_editor {
+            if let Some(fav) = shiki_core::editor::detect_favorite_editor() {
+                return fav;
+            }
+        }
+        self.config.general.editor.clone()
     }
 }
 
@@ -145,7 +173,8 @@ fn main() -> Result<()> {
         None => tui::launch(ctx.config, ctx.store),
         Some(Commands::New { title, notebook }) => {
             let notebook = ctx.notebook_name(notebook);
-            commands::new::run(&ctx.store, &notebook, &title, &ctx.config.general.editor)
+            let editor = ctx.resolve_editor();
+            commands::new::run(&ctx.store, &notebook, &title, &editor)
         }
         Some(Commands::List { notebook }) => {
             let notebook = ctx.notebook_name(notebook);
@@ -153,7 +182,8 @@ fn main() -> Result<()> {
         }
         Some(Commands::Edit { note, notebook }) => {
             let notebook = ctx.notebook_name(notebook);
-            commands::edit::run(&ctx.store, &notebook, &note, &ctx.config.general.editor)
+            let editor = ctx.resolve_editor();
+            commands::edit::run(&ctx.store, &notebook, &note, &editor)
         }
         Some(Commands::Show { note, notebook }) => {
             let notebook = ctx.notebook_name(notebook);
@@ -166,16 +196,18 @@ fn main() -> Result<()> {
         Some(Commands::Daily { notebook }) => {
             let notebook = ctx.notebook_name(notebook);
             let templates_dir = Config::default_templates_dir()?;
+            let editor = ctx.resolve_editor();
             commands::daily::run(
                 &ctx.store,
                 &notebook,
                 &templates_dir,
-                &ctx.config.general.editor,
+                &editor,
+                &ctx.config.general.daily_template,
             )
         }
         Some(Commands::Sync { notebook }) => {
             let notebook = ctx.notebook_name(notebook);
-            commands::sync::run(&ctx.store, &notebook, &ctx.config.git)
+            commands::sync::run(&ctx.store, &notebook, &ctx.config)
         }
         Some(Commands::Config) => commands::config::run(),
         Some(Commands::Doctor) => unreachable!("handled before Context::load() above"),
@@ -184,6 +216,9 @@ fn main() -> Result<()> {
             NotebookAction::List => commands::notebook::list(&ctx.store),
             NotebookAction::Rename { old, new } => {
                 commands::notebook::rename(&ctx.store, &old, &new)
+            }
+            NotebookAction::Delete { name, yes } => {
+                commands::notebook::delete(&ctx.store, &name, yes)
             }
         },
         Some(Commands::Theme { action }) => match action {

--- a/shiki-config/src/session.rs
+++ b/shiki-config/src/session.rs
@@ -45,6 +45,25 @@ pub struct SessionState {
     pub focus: String,
 }
 
+/// Rejects a `notes_path` component that would escape the notebook when
+/// joined onto its real path (`self.path.join(relative)` in
+/// `shiki-core::Notebook::list_dir`) — empty, `.`/`..`, or containing a
+/// path separator. `notes_path` is restored verbatim from a persisted
+/// `session.toml`, so a hand-edited or corrupted file with e.g.
+/// `notes_path = ["..", "..", "etc"]` would otherwise let the NOTES panel
+/// walk outside the notebook (and outside the data directory entirely) the
+/// moment the session is restored. Mirrors `notebook::validate_name`'s
+/// rules in `shiki-core` — duplicated rather than shared, since
+/// `shiki-config` doesn't depend on `shiki-core` (see CLAUDE.md's
+/// Architecture section on the one-way dependency chain).
+fn is_safe_path_component(component: &str) -> bool {
+    !component.is_empty()
+        && component != "."
+        && component != ".."
+        && !component.contains('/')
+        && !component.contains('\\')
+}
+
 impl SessionState {
     /// Reads a previously saved session, if the file exists and is valid.
     /// Any failure (missing file, unreadable, malformed TOML) is treated the
@@ -53,7 +72,11 @@ impl SessionState {
     /// worth failing startup over.
     pub fn load(path: &Path) -> Option<Self> {
         let contents = std::fs::read_to_string(path).ok()?;
-        toml::from_str(&contents).ok()
+        let mut session: Self = toml::from_str(&contents).ok()?;
+        session
+            .notes_path
+            .retain(|component| is_safe_path_component(component));
+        Some(session)
     }
 
     pub fn save(&self, path: &Path) -> Result<()> {
@@ -98,6 +121,37 @@ mod tests {
     #[test]
     fn load_returns_none_for_a_missing_file() {
         assert!(SessionState::load(Path::new("/nonexistent/shiki-session.toml")).is_none());
+    }
+
+    #[test]
+    fn load_strips_path_traversal_components_from_notes_path() {
+        let dir = std::env::temp_dir().join(format!(
+            "shiki-session-traversal-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("session.toml");
+        std::fs::write(
+            &path,
+            r#"
+notebook = "work"
+notes_path = ["..", "..", "etc", "projects"]
+focus = "notes"
+"#,
+        )
+        .unwrap();
+
+        let loaded = SessionState::load(&path).expect("valid TOML must still load");
+
+        assert_eq!(
+            loaded.notes_path,
+            vec!["etc".to_string(), "projects".to_string()]
+        );
+        std::fs::remove_dir_all(&dir).ok();
     }
 
     #[test]

--- a/shiki-core/src/daily.rs
+++ b/shiki-core/src/daily.rs
@@ -15,14 +15,24 @@ pub fn daily_note_path(notebook: &Notebook, date: NaiveDate) -> std::path::PathB
         .join(format!("{}-daily.md", date.format("%Y-%m-%d")))
 }
 
-/// Creates (or opens, if it already exists) today's daily note in the given notebook.
-pub fn create_or_open(notebook: &Notebook, date: NaiveDate, templates_dir: &Path) -> Result<Note> {
+/// Creates (or opens, if it already exists) today's daily note in the given
+/// notebook. `template_name` is `general.daily_template` from config (by
+/// filename, without `.md`) — callers pass the configured value through
+/// rather than this function hardcoding `"daily"`, so customizing that
+/// setting (already editable in the Settings GENERAL tab) actually takes
+/// effect instead of being silently ignored.
+pub fn create_or_open(
+    notebook: &Notebook,
+    date: NaiveDate,
+    templates_dir: &Path,
+    template_name: &str,
+) -> Result<Note> {
     let path = daily_note_path(notebook, date);
     if path.exists() {
         return Note::from_file_in_notebook(&path, &notebook.name);
     }
 
-    let body = match Template::load(templates_dir, "daily") {
+    let body = match Template::load(templates_dir, template_name) {
         Ok(template) => {
             let mut vars = HashMap::new();
             vars.insert("date", date.format("%Y-%m-%d").to_string());
@@ -37,9 +47,69 @@ pub fn create_or_open(notebook: &Notebook, date: NaiveDate, templates_dir: &Path
     let mut frontmatter =
         Frontmatter::new(format!("{} Daily", date.format("%Y-%m-%d")), &notebook.name);
     frontmatter.date = date;
-    frontmatter.template = Some("daily".to_string());
+    frontmatter.template = Some(template_name.to_string());
 
     let note = Note::new(path, frontmatter, body);
     note.save()?;
     Ok(note)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_notebook(root: &Path, name: &str) -> Notebook {
+        let path = root.join(name);
+        std::fs::create_dir_all(&path).unwrap();
+        Notebook::new(name, path)
+    }
+
+    #[test]
+    fn daily_note_path_is_date_stamped_at_the_notebook_root() {
+        let tmp = tempfile::tempdir().unwrap();
+        let nb = test_notebook(tmp.path(), "personal");
+        let date = NaiveDate::from_ymd_opt(2024, 3, 7).unwrap();
+
+        let path = daily_note_path(&nb, date);
+
+        assert_eq!(path, nb.path.join("2024-03-07-daily.md"));
+    }
+
+    #[test]
+    fn create_or_open_creates_a_new_note_with_fallback_body_when_no_template_exists() {
+        let tmp = tempfile::tempdir().unwrap();
+        let nb = test_notebook(tmp.path(), "personal");
+        let templates_dir = tmp.path().join("templates"); // deliberately never created
+        let date = NaiveDate::from_ymd_opt(2024, 3, 7).unwrap();
+
+        let note = create_or_open(&nb, date, &templates_dir, "daily").unwrap();
+
+        assert_eq!(note.frontmatter.title, "2024-03-07 Daily");
+        assert_eq!(note.frontmatter.date, date);
+        assert_eq!(note.frontmatter.template.as_deref(), Some("daily"));
+        assert!(note.body.contains("2024-03-07"));
+        assert!(note.path.exists());
+    }
+
+    #[test]
+    fn create_or_open_reopens_the_existing_note_instead_of_overwriting_it() {
+        let tmp = tempfile::tempdir().unwrap();
+        let nb = test_notebook(tmp.path(), "personal");
+        let templates_dir = tmp.path().join("templates");
+        let date = NaiveDate::from_ymd_opt(2024, 3, 7).unwrap();
+
+        let first = create_or_open(&nb, date, &templates_dir, "daily").unwrap();
+        std::fs::write(
+            &first.path,
+            format!(
+                "{}custom edit",
+                "---\ntitle: 2024-03-07 Daily\ndate: 2024-03-07\nnotebook: personal\n---\n\n"
+            ),
+        )
+        .unwrap();
+
+        let second = create_or_open(&nb, date, &templates_dir, "daily").unwrap();
+
+        assert_eq!(second.body, "custom edit");
+    }
 }

--- a/shiki-core/src/editor.rs
+++ b/shiki-core/src/editor.rs
@@ -2,6 +2,12 @@
 //! `use_favorite_editor` config option — an alternative to always opening
 //! the built-in inline editor or a hardcoded `$EDITOR`.
 
+// Only used by `desktop_exec_command` below, which is Linux-only — a
+// pre-existing unconditional import here was unused (and thus a clippy
+// error under `-D warnings`) on every other target; caught once CI's
+// `fmt-and-clippy` job actually started running on macOS/Windows too,
+// instead of only ubuntu-latest.
+#[cfg(target_os = "linux")]
 use std::path::PathBuf;
 
 /// Resolves the editor to launch, in priority order:

--- a/shiki-core/src/editor.rs
+++ b/shiki-core/src/editor.rs
@@ -82,6 +82,35 @@ fn macos_default_editor() -> Option<String> {
     Some("open -W -t".to_string())
 }
 
+/// Splits an editor command string into tokens, honoring `"..."`/`'...'`
+/// quoting around a single token — needed for a program path that itself
+/// contains a space (common on Windows, e.g. `"C:\Program Files\Editor\
+/// editor.exe" --wait`), which a plain `split_whitespace` would otherwise
+/// tear into bogus argv pieces. Deliberately minimal: no escape sequences,
+/// no nested quotes — just enough to keep one quoted path together.
+fn split_command(input: &str) -> Vec<String> {
+    let mut tokens = Vec::new();
+    let mut current = String::new();
+    let mut in_quotes: Option<char> = None;
+    for c in input.chars() {
+        match in_quotes {
+            Some(q) if c == q => in_quotes = None,
+            Some(_) => current.push(c),
+            None if c == '"' || c == '\'' => in_quotes = Some(c),
+            None if c.is_whitespace() => {
+                if !current.is_empty() {
+                    tokens.push(std::mem::take(&mut current));
+                }
+            }
+            None => current.push(c),
+        }
+    }
+    if !current.is_empty() {
+        tokens.push(current);
+    }
+    tokens
+}
+
 /// Splits an editor command string (e.g. `"code --wait"` or `"open -W -t"`)
 /// into a program + base args, then builds a ready-to-run `Command` with
 /// `path` appended as the final argument. Editor strings are single words
@@ -89,10 +118,51 @@ fn macos_default_editor() -> Option<String> {
 /// user configs produce multi-word commands, so callers should always go
 /// through this instead of `Command::new(editor)` directly.
 pub fn command_for(editor: &str, path: &std::path::Path) -> std::process::Command {
-    let mut parts = editor.split_whitespace();
-    let program = parts.next().unwrap_or(editor);
+    let mut parts = split_command(editor);
+    if parts.is_empty() {
+        parts.push(editor.to_string());
+    }
+    let program = parts.remove(0);
     let mut command = std::process::Command::new(program);
     command.args(parts);
     command.arg(path);
     command
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn split_command_splits_plain_whitespace() {
+        assert_eq!(split_command("code --wait"), vec!["code", "--wait"]);
+    }
+
+    #[test]
+    fn split_command_keeps_a_quoted_path_with_spaces_together() {
+        assert_eq!(
+            split_command(r#""C:\Program Files\Editor\editor.exe" --wait"#),
+            vec![r"C:\Program Files\Editor\editor.exe", "--wait"]
+        );
+    }
+
+    #[test]
+    fn split_command_supports_single_quotes_too() {
+        assert_eq!(
+            split_command("'my editor' --flag"),
+            vec!["my editor", "--flag"]
+        );
+    }
+
+    #[test]
+    fn command_for_uses_quoted_program_as_a_single_argv0() {
+        let command = command_for(
+            r#""C:\Program Files\Editor\editor.exe" --wait"#,
+            std::path::Path::new("note.md"),
+        );
+        assert_eq!(
+            command.get_program().to_string_lossy(),
+            r"C:\Program Files\Editor\editor.exe"
+        );
+    }
 }

--- a/shiki-core/src/git.rs
+++ b/shiki-core/src/git.rs
@@ -111,6 +111,12 @@ pub struct GitStatus {
     /// reflects what was fetched at the last `pull`/`pull_all` — computing
     /// this doesn't itself talk to the network.
     pub behind: usize,
+    /// Set when `repo.statuses(None)` itself failed (locked index,
+    /// permission issue, corrupted repo) — `dirty_count` falls back to `0`
+    /// in that case (see `status()`), which used to be indistinguishable
+    /// from a genuinely clean notebook. `None` means the check actually
+    /// succeeded, regardless of what it found.
+    pub status_error: Option<String>,
 }
 
 /// Initializes a git repo at `path` if one doesn't already exist.
@@ -369,16 +375,35 @@ pub fn pull(path: &Path, remote: &str, branch: &str) -> Result<String> {
 /// them — a plain SSH `git@host:path` loses its (non-secret) "git" prefix
 /// this way too, which is an acceptable trade for never accidentally
 /// leaving a real token unredacted.
+/// Redacts userinfo (`user[:password]@`) from a `scheme://...` URL, or the
+/// whole `user@` from an scp-style `user@host:path` remote — never a bare
+/// `@` search over the *entire* string. A self-hosted remote can legitimately
+/// have an `@` in its path (e.g. `https://git.example.com/repos/notes@backup.git`);
+/// searching the whole string for the first `@` would treat that as
+/// userinfo and redact straight through the real host/path, not just hide a
+/// credential. The userinfo `@`, if any, only ever appears in the authority
+/// component — between `://` and the first `/` that starts the path — so
+/// only that slice is searched.
 pub fn redact_credentials(url: &str) -> String {
-    let Some(at_idx) = url.find('@') else {
-        return url.to_string();
-    };
     match url.find("://") {
-        Some(scheme_end) if scheme_end < at_idx => {
-            format!("{}***@{}", &url[..scheme_end + 3], &url[at_idx + 1..])
+        Some(scheme_end) => {
+            let authority_start = scheme_end + 3;
+            let authority_end = url[authority_start..]
+                .find('/')
+                .map(|i| authority_start + i)
+                .unwrap_or(url.len());
+            match url[authority_start..authority_end].find('@') {
+                Some(rel_at) => {
+                    let at_idx = authority_start + rel_at;
+                    format!("{}***@{}", &url[..authority_start], &url[at_idx + 1..])
+                }
+                None => url.to_string(),
+            }
         }
-        Some(_) => url.to_string(), // '@' appears before any "://" — not userinfo
-        None => format!("***@{}", &url[at_idx + 1..]), // scp-style, no scheme
+        None => match url.find('@') {
+            Some(at_idx) => format!("***@{}", &url[at_idx + 1..]), // scp-style, no scheme
+            None => url.to_string(),
+        },
     }
 }
 
@@ -494,7 +519,10 @@ pub fn status(path: &Path, remote: &str) -> GitStatus {
         Ok(r) => r,
         Err(_) => return GitStatus::default(),
     };
-    let dirty_count = repo.statuses(None).map(|s| s.len()).unwrap_or(0);
+    let (dirty_count, status_error) = match repo.statuses(None) {
+        Ok(statuses) => (statuses.len(), None),
+        Err(e) => (0, Some(e.to_string())),
+    };
     let branch = repo
         .head()
         .ok()
@@ -516,6 +544,7 @@ pub fn status(path: &Path, remote: &str) -> GitStatus {
         branch,
         ahead,
         behind,
+        status_error,
     }
 }
 
@@ -561,6 +590,17 @@ mod tests {
         assert_eq!(
             redact_credentials("/home/omar/bare-repos/notes.git"),
             "/home/omar/bare-repos/notes.git"
+        );
+    }
+
+    #[test]
+    fn leaves_a_legitimate_at_sign_in_the_path_untouched() {
+        // The '@' here is part of the repo path, not userinfo — it comes
+        // after the first '/' that starts the path, past the authority
+        // component entirely.
+        assert_eq!(
+            redact_credentials("https://git.example.com/repos/notes@backup.git"),
+            "https://git.example.com/repos/notes@backup.git"
         );
     }
 }

--- a/shiki-core/src/lib.rs
+++ b/shiki-core/src/lib.rs
@@ -43,6 +43,12 @@ pub enum Error {
     /// already there.
     #[error("already exists: {0}")]
     DestinationExists(String),
+    /// A folder move/copy whose destination is the source itself, or nested
+    /// inside it — copying a folder into its own subtree would otherwise
+    /// recurse forever (the freshly created destination becomes one of the
+    /// source's own children by the time the walk reaches it).
+    #[error("cannot move/copy '{0}' into itself or one of its own subfolders")]
+    DestinationInsideSource(String),
 }
 
 pub type Result<T> = std::result::Result<T, Error>;

--- a/shiki-core/src/note.rs
+++ b/shiki-core/src/note.rs
@@ -5,6 +5,19 @@ use serde::{Deserialize, Serialize};
 
 use crate::Result;
 
+/// Normalizes CRLF/CR line endings to plain `\n` before frontmatter parsing.
+/// A file round-tripped through an external editor on Windows (or just
+/// saved with CRLF endings) otherwise fails `try_parse_frontmatter`'s exact
+/// `"---\n"`/`"\n---"` match entirely and silently loses its frontmatter,
+/// falling through to `synthesize_frontmatter` as if the file had none.
+fn normalize_line_endings(contents: String) -> String {
+    if contents.contains('\r') {
+        contents.replace("\r\n", "\n").replace('\r', "\n")
+    } else {
+        contents
+    }
+}
+
 /// YAML frontmatter at the top of every note.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Frontmatter {
@@ -81,7 +94,7 @@ impl Note {
     /// `synthesize_frontmatter` and `from_file_in_notebook` for the
     /// notebook-aware variant. The only real failure mode left is I/O.
     pub fn from_file(path: &Path) -> Result<Self> {
-        let contents = std::fs::read_to_string(path)?;
+        let contents = normalize_line_endings(std::fs::read_to_string(path)?);
         let (frontmatter, body) = Self::split(path, &contents, None);
         Ok(Self {
             path: path.to_path_buf(),
@@ -97,7 +110,7 @@ impl Note {
     /// from `path.parent().file_name()`, which would pick up an
     /// intermediate folder name instead of the notebook itself.
     pub fn from_file_in_notebook(path: &Path, notebook_name: &str) -> Result<Self> {
-        let contents = std::fs::read_to_string(path)?;
+        let contents = normalize_line_endings(std::fs::read_to_string(path)?);
         let (frontmatter, body) = Self::split(path, &contents, Some(notebook_name));
         Ok(Self {
             path: path.to_path_buf(),
@@ -115,11 +128,27 @@ impl Note {
         })
     }
 
+    /// The closing delimiter must be a *line* consisting of exactly `---`,
+    /// not just the first literal occurrence of that substring — a YAML
+    /// block scalar (e.g. `title: |`) can legitimately contain a line that
+    /// reads `---` as part of its text, and the old `rest.find("\n---")`
+    /// would truncate the frontmatter right there, silently losing every
+    /// field after it (and failing the parse entirely if that left invalid
+    /// YAML behind).
     fn try_parse_frontmatter(contents: &str) -> Option<(Frontmatter, String)> {
         let rest = contents.strip_prefix("---\n")?;
-        let end = rest.find("\n---")?;
+        let mut offset = 0;
+        let mut end = None;
+        for line in rest.split_inclusive('\n') {
+            if line.trim_end_matches('\n') == "---" {
+                end = Some(offset);
+                break;
+            }
+            offset += line.len();
+        }
+        let end = end?;
         let yaml = &rest[..end];
-        let body = rest[end + 4..].trim_start_matches('\n').to_string();
+        let body = rest[end + 3..].trim_start_matches('\n').to_string();
         let frontmatter: Frontmatter = serde_yaml::from_str(yaml).ok()?;
         Some((frontmatter, body))
     }
@@ -179,5 +208,95 @@ impl Note {
         }
         std::fs::write(&self.path, self.to_file_contents()?)?;
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn slugify_lowercases_and_dashes_special_characters() {
+        assert_eq!(Note::slugify("Hello, World!"), "hello-world");
+        assert_eq!(Note::slugify("  spaced  out  "), "spaced-out");
+        assert_eq!(Note::slugify("Q3 Report"), "q3-report");
+    }
+
+    #[test]
+    fn slugify_of_symbols_only_title_is_empty() {
+        assert_eq!(Note::slugify("!!!"), "");
+        assert_eq!(Note::slugify("🎉🎉"), "");
+    }
+
+    #[test]
+    fn round_trips_frontmatter_and_body_through_to_file_contents() {
+        let note = Note::new(
+            PathBuf::from("/tmp/does-not-matter.md"),
+            Frontmatter::new("My Title", "personal"),
+            "Some body text.".to_string(),
+        );
+        let contents = note.to_file_contents().unwrap();
+        let (parsed, body) = Note::try_parse_frontmatter(&contents).unwrap();
+        assert_eq!(parsed.title, "My Title");
+        assert_eq!(parsed.notebook, "personal");
+        assert_eq!(body, "Some body text.");
+    }
+
+    #[test]
+    fn try_parse_frontmatter_rejects_content_with_no_leading_delimiter() {
+        assert!(Note::try_parse_frontmatter("# Just a heading\n\nbody").is_none());
+    }
+
+    #[test]
+    fn try_parse_frontmatter_does_not_truncate_on_a_literal_dashes_line_inside_yaml() {
+        // A YAML block scalar can legitimately contain a line that reads
+        // exactly "---" — the closing delimiter search must skip past it
+        // and find the real closing "---" line instead of stopping early.
+        let contents = "---\ntitle: |\n  Section\n  ---\n  more text\ndate: 2024-01-01\nnotebook: personal\n---\n\nbody here";
+        let (fm, body) = Note::try_parse_frontmatter(contents).unwrap();
+        assert_eq!(fm.title, "Section\n---\nmore text\n");
+        assert_eq!(fm.notebook, "personal");
+        assert_eq!(body, "body here");
+    }
+
+    #[test]
+    fn from_file_normalizes_crlf_before_parsing_frontmatter() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("note.md");
+        std::fs::write(
+            &path,
+            "---\r\ntitle: CRLF Note\r\ndate: 2024-01-01\r\nnotebook: personal\r\n---\r\n\r\nbody line\r\n",
+        )
+        .unwrap();
+
+        let note = Note::from_file(&path).unwrap();
+
+        assert_eq!(note.frontmatter.title, "CRLF Note");
+        assert_eq!(note.frontmatter.notebook, "personal");
+        assert_eq!(note.body, "body line\n");
+    }
+
+    #[test]
+    fn from_file_synthesizes_frontmatter_for_a_plain_markdown_file() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("plain.md");
+        std::fs::write(&path, "# A Real Heading\n\nSome content.").unwrap();
+
+        let note = Note::from_file_in_notebook(&path, "work").unwrap();
+
+        assert_eq!(note.frontmatter.title, "A Real Heading");
+        assert_eq!(note.frontmatter.notebook, "work");
+        assert_eq!(note.body, "# A Real Heading\n\nSome content.");
+    }
+
+    #[test]
+    fn from_file_falls_back_to_filename_when_no_heading_present() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("my-plain-note.md");
+        std::fs::write(&path, "no heading here").unwrap();
+
+        let note = Note::from_file_in_notebook(&path, "work").unwrap();
+
+        assert_eq!(note.frontmatter.title, "my plain note");
     }
 }

--- a/shiki-core/src/notebook.rs
+++ b/shiki-core/src/notebook.rs
@@ -1,8 +1,83 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
 
 use crate::note::{Frontmatter, Note};
 use crate::{git, Error, Result};
+
+/// Slug for a new note in `dir`, guaranteed to not collide with an existing
+/// file there. Falls back to a timestamp-based slug when `title` slugifies
+/// to an empty string (symbol/emoji-only titles), then appends `-2`, `-3`,
+/// etc. if that slug (or the timestamp fallback) is already taken — two
+/// titles that slugify the same, e.g. "Q3 Report" and "Q3, Report!", must
+/// not silently overwrite each other.
+fn unique_slug(dir: &Path, title: &str) -> String {
+    let base = Note::slugify(title);
+    let base = if base.is_empty() {
+        format!("untitled-{}", chrono::Local::now().timestamp())
+    } else {
+        base
+    };
+    let mut candidate = base.clone();
+    let mut n = 2;
+    while dir.join(format!("{candidate}.md")).exists() {
+        candidate = format!("{base}-{n}");
+        n += 1;
+    }
+    candidate
+}
+
+/// Same as `unique_slug`, but a collision with `ignore` (the note's own
+/// current path, mid-rename) doesn't count — renaming a note to the title
+/// it already effectively has shouldn't be blocked by itself.
+fn unique_slug_excluding(dir: &Path, title: &str, ignore: &Path) -> String {
+    let base = Note::slugify(title);
+    let base = if base.is_empty() {
+        format!("untitled-{}", chrono::Local::now().timestamp())
+    } else {
+        base
+    };
+    let mut candidate = base.clone();
+    let mut n = 2;
+    loop {
+        let path = dir.join(format!("{candidate}.md"));
+        if !path.exists() || path == *ignore {
+            return candidate;
+        }
+        candidate = format!("{base}-{n}");
+        n += 1;
+    }
+}
+
+/// Whether `dest` is `source` itself, or nested anywhere inside it —
+/// checked via canonicalized path components (`Path::starts_with`), not a
+/// naive string prefix, so e.g. `projects` vs `projects-archive` don't
+/// false-positive. `dest` typically doesn't exist yet (the caller only
+/// calls this once it's confirmed nothing already sits there), so this
+/// walks up to the nearest existing ancestor to canonicalize, then
+/// re-appends the not-yet-created suffix components before comparing.
+fn is_same_or_nested(source: &Path, dest: &Path) -> bool {
+    let source = source
+        .canonicalize()
+        .unwrap_or_else(|_| source.to_path_buf());
+    let mut existing_ancestor = dest;
+    let mut pending: Vec<&std::ffi::OsStr> = Vec::new();
+    while !existing_ancestor.exists() {
+        match (existing_ancestor.file_name(), existing_ancestor.parent()) {
+            (Some(name), Some(parent)) => {
+                pending.push(name);
+                existing_ancestor = parent;
+            }
+            _ => break,
+        }
+    }
+    let mut dest_resolved = existing_ancestor
+        .canonicalize()
+        .unwrap_or_else(|_| existing_ancestor.to_path_buf());
+    for part in pending.into_iter().rev() {
+        dest_resolved.push(part);
+    }
+    dest_resolved == source || dest_resolved.starts_with(&source)
+}
 
 /// A notebook is a directory with its own git repo, containing `.md` notes.
 #[derive(Debug, Clone)]
@@ -72,10 +147,31 @@ impl Notebook {
     }
 
     fn collect_notes(&self, relative: &Path, out: &mut Vec<Note>) -> Result<()> {
+        let mut visited = HashSet::new();
+        self.collect_notes_guarded(relative, out, &mut visited)
+    }
+
+    /// `visited` holds the canonicalized path of every directory already
+    /// walked — a self-referential symlink inside a notebook would otherwise
+    /// recurse forever and stack-overflow global search. A directory that
+    /// can't be canonicalized (rare I/O race) is walked anyway rather than
+    /// skipped, matching this function's existing "best effort" behavior.
+    fn collect_notes_guarded(
+        &self,
+        relative: &Path,
+        out: &mut Vec<Note>,
+        visited: &mut HashSet<PathBuf>,
+    ) -> Result<()> {
+        let dir = self.path.join(relative);
+        if let Ok(real) = dir.canonicalize() {
+            if !visited.insert(real) {
+                return Ok(());
+            }
+        }
         let (folders, notes) = self.list_dir(relative)?;
         out.extend(notes);
         for folder in folders {
-            self.collect_notes(&relative.join(folder), out)?;
+            self.collect_notes_guarded(&relative.join(folder), out, visited)?;
         }
         Ok(())
     }
@@ -90,7 +186,7 @@ impl Notebook {
     ) -> Result<Note> {
         let dir = self.path.join(relative);
         std::fs::create_dir_all(&dir)?;
-        let slug = Note::slugify(title);
+        let slug = unique_slug(&dir, title);
         let path = dir.join(format!("{slug}.md"));
         let note = Note::new(path, Frontmatter::new(title, &self.name), body.into());
         note.save()?;
@@ -134,7 +230,8 @@ impl Notebook {
     pub fn rename_note_at(&self, path: &Path, new_title: &str) -> Result<Note> {
         let mut note = Note::from_file_in_notebook(path, &self.name)?;
         let dir = path.parent().unwrap_or(&self.path);
-        let new_path = dir.join(format!("{}.md", Note::slugify(new_title)));
+        let slug = unique_slug_excluding(dir, new_title, path);
+        let new_path = dir.join(format!("{slug}.md"));
         note.frontmatter.title = new_title.to_string();
         note.path = new_path;
         note.save()?;
@@ -225,6 +322,18 @@ impl Notebook {
         let dest_dir = dest_notebook.path.join(&dest_relative);
         if dest_dir.exists() {
             return Err(Error::DestinationExists(dest_dir.display().to_string()));
+        }
+        // A destination equal to (or nested inside) the source folder would
+        // otherwise recurse forever: `dest_dir` gets created *before* this
+        // walks the source's own children, so once the walk reaches that
+        // freshly created directory it recurses into itself indefinitely —
+        // reachable in practice through the `m` (move) prompt, which
+        // prefills the item's current address; appending a segment to that
+        // prefill targets a subpath of the source itself.
+        if is_same_or_nested(&source_dir, &dest_dir) {
+            return Err(Error::DestinationInsideSource(
+                source_dir.display().to_string(),
+            ));
         }
         std::fs::create_dir_all(&dest_dir)?;
         let (folders, notes) = self.list_dir(relative)?;
@@ -526,6 +635,33 @@ mod tests {
 
         let result = a.copy_folder_to(Path::new("projects"), &b, Path::new(""));
         assert!(matches!(result, Err(Error::DestinationExists(_))));
+    }
+
+    #[test]
+    fn copy_folder_to_rejects_a_destination_nested_inside_the_source() {
+        let tmp = tempfile::tempdir().unwrap();
+        let a = test_notebook(tmp.path(), "a");
+        a.create_folder_in(Path::new(""), "projects").unwrap();
+
+        // Same notebook, destination is a subpath of the source itself —
+        // this used to create `projects/projects/projects/...` forever.
+        let result = a.copy_folder_to(Path::new("projects"), &a, Path::new("projects/nested"));
+
+        assert!(matches!(result, Err(Error::DestinationInsideSource(_))));
+    }
+
+    #[test]
+    fn copy_folder_to_rejects_copying_a_folder_onto_itself() {
+        let tmp = tempfile::tempdir().unwrap();
+        let a = test_notebook(tmp.path(), "a");
+        a.create_folder_in(Path::new(""), "projects").unwrap();
+
+        let result = a.copy_folder_to(Path::new("projects"), &a, Path::new(""));
+
+        assert!(matches!(
+            result,
+            Err(Error::DestinationExists(_)) | Err(Error::DestinationInsideSource(_))
+        ));
     }
 
     #[test]

--- a/shiki-core/src/search.rs
+++ b/shiki-core/src/search.rs
@@ -44,11 +44,17 @@ impl SearchEngine {
                 .collect();
         }
         let pattern = Pattern::parse(query, CaseMatching::Smart, Normalization::Smart);
+        // One scratch buffer reused across every haystack (`.clear()` keeps
+        // its allocated capacity instead of freeing it) rather than a fresh
+        // `Vec::new()` per haystack inside the loop — global search re-runs
+        // this on every keystroke across every note in the notebook, so a
+        // per-note allocation here is a real, avoidable cost at scale.
+        let mut buf = Vec::new();
         let mut hits: Vec<SearchHit> = haystacks
             .iter()
             .enumerate()
             .filter_map(|(index, text)| {
-                let mut buf = Vec::new();
+                buf.clear();
                 let utf32 = nucleo_matcher::Utf32Str::new(text, &mut buf);
                 pattern
                     .score(utf32, &mut self.matcher)

--- a/shiki-core/src/tags.rs
+++ b/shiki-core/src/tags.rs
@@ -39,3 +39,56 @@ impl TagIndex {
         self.index.is_empty()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::note::Frontmatter;
+
+    fn note_with_tags(path: &str, tags: &[&str]) -> Note {
+        let mut fm = Frontmatter::new("Title", "test");
+        fm.tags = tags.iter().map(|t| t.to_string()).collect();
+        Note::new(PathBuf::from(path), fm, String::new())
+    }
+
+    #[test]
+    fn build_indexes_notes_by_every_tag_they_carry() {
+        let notes = vec![
+            note_with_tags("a.md", &["work", "urgent"]),
+            note_with_tags("b.md", &["work"]),
+            note_with_tags("c.md", &[]),
+        ];
+
+        let index = TagIndex::build(&notes);
+
+        assert_eq!(index.len(), 2);
+        assert_eq!(
+            index.notes_for("work"),
+            &[PathBuf::from("a.md"), PathBuf::from("b.md")]
+        );
+        assert_eq!(index.notes_for("urgent"), &[PathBuf::from("a.md")]);
+    }
+
+    #[test]
+    fn notes_for_unknown_tag_is_empty() {
+        let notes = vec![note_with_tags("a.md", &["work"])];
+        let index = TagIndex::build(&notes);
+        assert!(index.notes_for("nonexistent").is_empty());
+    }
+
+    #[test]
+    fn build_of_no_tags_at_all_is_empty() {
+        let notes = vec![note_with_tags("a.md", &[])];
+        let index = TagIndex::build(&notes);
+        assert!(index.is_empty());
+        assert_eq!(index.tags().count(), 0);
+    }
+
+    #[test]
+    fn tags_are_returned_in_sorted_order() {
+        let notes = vec![note_with_tags("a.md", &["zeta", "alpha", "mid"])];
+        let index = TagIndex::build(&notes);
+        let tags: Vec<&String> = index.tags().collect();
+        assert_eq!(tags, vec!["alpha", "mid", "zeta"]);
+    }
+}

--- a/shiki-core/src/templates.rs
+++ b/shiki-core/src/templates.rs
@@ -23,12 +23,38 @@ impl Template {
         })
     }
 
-    /// Substitutes `{{key}}` placeholders with the given values.
+    /// Substitutes `{{key}}` placeholders with the given values, in a
+    /// single left-to-right pass over `self.contents`. Deliberately not a
+    /// sequential `String::replace` per key: that approach rescans the
+    /// *already-substituted* output on every subsequent key, so a value
+    /// that happens to contain another placeholder's literal text (e.g.
+    /// a title of `Meeting {{date}} notes`) gets that text substituted
+    /// again on the next iteration instead of being left alone.
     pub fn render(&self, vars: &HashMap<&str, String>) -> String {
-        let mut out = self.contents.clone();
-        for (key, value) in vars {
-            out = out.replace(&format!("{{{{{key}}}}}"), value);
+        let contents = self.contents.as_str();
+        let mut out = String::with_capacity(contents.len());
+        let mut rest = contents;
+        while let Some(start) = rest.find("{{") {
+            out.push_str(&rest[..start]);
+            let after_open = &rest[start + 2..];
+            match after_open.find("}}") {
+                Some(end) => {
+                    let key = &after_open[..end];
+                    match vars.get(key) {
+                        Some(value) => out.push_str(value),
+                        None => out.push_str(&rest[start..start + 4 + end]),
+                    }
+                    rest = &after_open[end + 2..];
+                }
+                None => {
+                    // Unterminated `{{` — emit it literally and stop scanning.
+                    out.push_str(&rest[start..]);
+                    rest = "";
+                    break;
+                }
+            }
         }
+        out.push_str(rest);
         out
     }
 }
@@ -77,4 +103,36 @@ pub fn ensure_defaults(templates_dir: &Path) -> Result<()> {
         }
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn render_does_not_resubstitute_a_value_containing_placeholder_text() {
+        let template = Template {
+            name: "t".to_string(),
+            contents: "# {{title}}\n\nDate: {{date}}\n".to_string(),
+        };
+        let mut vars = HashMap::new();
+        vars.insert("title", "Meeting {{date}} notes".to_string());
+        vars.insert("date", "2026-08-02".to_string());
+
+        let out = template.render(&vars);
+
+        assert_eq!(out, "# Meeting {{date}} notes\n\nDate: 2026-08-02\n");
+    }
+
+    #[test]
+    fn render_leaves_unknown_placeholders_untouched() {
+        let template = Template {
+            name: "t".to_string(),
+            contents: "{{title}} / {{unknown}}".to_string(),
+        };
+        let mut vars = HashMap::new();
+        vars.insert("title", "Todo".to_string());
+
+        assert_eq!(template.render(&vars), "Todo / {{unknown}}");
+    }
 }

--- a/shiki-core/src/update.rs
+++ b/shiki-core/src/update.rs
@@ -1,7 +1,9 @@
 //! Self-update against GitHub Releases. Two explicit phases — `check_latest`
-//! (a cheap API call, safe to run on every launch) and `install_latest` (the
-//! real download + integrity check + binary replace) — so a caller can show
-//! "update available" and only actually touch disk once the user confirms.
+//! (a cheap API call, safe to run on every launch) and `install_version` (the
+//! real download + integrity check + binary replace, pinned to whatever
+//! version `check_latest` reported rather than re-resolving "latest" a
+//! second time) — so a caller can show "update available" and only
+//! actually touch disk once the user confirms.
 //!
 //! Archive layout must match `.github/workflows/release.yml`'s packaging:
 //! `shiki-v{version}-{target}/shiki` (or `shiki.exe` on Windows), which is
@@ -34,6 +36,19 @@ fn configured(current_version: &str) -> Result<self_update::backends::github::Up
     Ok(builder)
 }
 
+/// Same as `configured`, but pinned to a specific release tag
+/// (`self_update`'s `release_tag` builder option) rather than whatever
+/// happens to be "latest" by the time this runs — see `install_version`'s
+/// doc comment for why that distinction matters.
+fn configured_for_version(
+    current_version: &str,
+    target_version: &str,
+) -> Result<self_update::backends::github::UpdateBuilder> {
+    let mut builder = configured(current_version)?;
+    builder.release_tag(format!("v{target_version}"));
+    Ok(builder)
+}
+
 /// Checks GitHub Releases for a version newer than `current_version`, without
 /// downloading anything. `Ok(None)` means already up to date.
 pub fn check_latest(current_version: &str) -> Result<Option<String>> {
@@ -46,11 +61,22 @@ pub fn check_latest(current_version: &str) -> Result<Option<String>> {
     Ok(newer.map(|release| release.version().to_string()))
 }
 
-/// Downloads, verifies, and installs the latest release in place of the
-/// currently running binary. Returns the installed version on success.
-/// Does *not* relaunch the process — the caller decides whether/how to.
-pub fn install_latest(current_version: &str) -> Result<String> {
-    let updater = configured(current_version)?
+/// Downloads, verifies, and installs a *specific* release (`target_version`,
+/// a bare semver string like `"0.8.11"`, e.g. what `check_latest` just
+/// returned) in place of the currently running binary. Returns the
+/// installed version on success. Does *not* relaunch the process — the
+/// caller decides whether/how to.
+///
+/// Deliberately pinned to `target_version` rather than re-resolving
+/// "whatever's latest right now": `check_latest` and this function used to
+/// each independently ask GitHub for the newest release, so a new release
+/// landing between the user seeing "update available" in the confirm
+/// dialog and actually confirming it could install a *different* version
+/// than what was shown — installing exactly the version that was checked
+/// is the only way the confirm dialog's version number is guaranteed to
+/// match what actually lands on disk.
+pub fn install_version(current_version: &str, target_version: &str) -> Result<String> {
+    let updater = configured_for_version(current_version, target_version)?
         .build()
         .map_err(|e| Error::Update(e.to_string()))?;
     let status = updater.update().map_err(|e| Error::Update(e.to_string()))?;

--- a/shiki-core/src/wikilinks.rs
+++ b/shiki-core/src/wikilinks.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 use std::path::PathBuf;
 
 use regex::Regex;
@@ -33,14 +34,35 @@ pub fn resolve_one(link: &str, notes: &[Note]) -> Option<PathBuf> {
 /// `[[wikilink]]` that resolves to `target` — the reverse of `extract` +
 /// `resolve_one`, used to answer "what links here?" without every note
 /// needing to maintain its own back-reference list.
+///
+/// Builds a title/slug -> path index once up front rather than calling
+/// `resolve_one` (a linear scan + `slugify` over every note) once per link
+/// per note — that combination made this function cost O(notes × total
+/// links in the notebook), visibly slow on a notebook with a few thousand
+/// notes even though each note only has a handful of links.
 pub fn backlinks<'a>(target: &std::path::Path, notes: &'a [Note]) -> Vec<&'a Note> {
+    let mut by_title: HashMap<String, &std::path::Path> = HashMap::with_capacity(notes.len());
+    let mut by_slug: HashMap<String, &std::path::Path> = HashMap::with_capacity(notes.len());
+    for n in notes {
+        by_title
+            .entry(n.frontmatter.title.to_ascii_lowercase())
+            .or_insert(&n.path);
+        by_slug.entry(n.file_stem()).or_insert(&n.path);
+    }
+    let resolve = |link: &str| -> Option<&std::path::Path> {
+        let link = link.trim();
+        by_title
+            .get(&link.to_ascii_lowercase())
+            .or_else(|| by_slug.get(&Note::slugify(link)))
+            .copied()
+    };
     notes
         .iter()
         .filter(|n| {
             n.path != target
                 && extract(&n.body)
                     .iter()
-                    .any(|link| resolve_one(link, notes).as_deref() == Some(target))
+                    .any(|link| resolve(link) == Some(target))
         })
         .collect()
 }

--- a/shiki-tui/src/app.rs
+++ b/shiki-tui/src/app.rs
@@ -708,6 +708,14 @@ pub struct App {
     /// `note_preview_source_line`, which click-to-edit uses to jump into
     /// `Mode::Edit` at the right raw source line.
     pub(crate) note_preview_cache: Option<NotePreviewCache>,
+    /// Cache for the tags modal's `TagIndex::build(&self.notes)` — rebuilt
+    /// (`refresh_tag_index_cache`) only when the modal is open and the cache
+    /// is empty; `reload_notes`/`refresh_notes_preserve_selection` clear it
+    /// to `None` whenever `self.notes` actually changes underneath it, the
+    /// same invalidation trigger `note_preview_cache`/`folder_preview_cache`
+    /// already use. `None` whenever the modal is closed, so it doesn't hold
+    /// a stale index in memory for no reason.
+    pub(crate) tag_index_cache: Option<shiki_core::TagIndex>,
     pub show_update: bool,
     pub update_state: Option<UpdateState>,
     /// Set while a background thread is checking/installing, so `run()`'s
@@ -744,11 +752,15 @@ pub struct App {
     /// something's running; `None` means idle.
     pub sync_in_flight: Option<String>,
     pub(crate) sync_rx: Option<std::sync::mpsc::Receiver<crate::sync::GitOpResult>>,
-    /// Advanced once per `run()` iteration while `sync_in_flight` (or the
-    /// self-updater's own in-flight state) is set — indexes into a small
-    /// Braille frame set for the footer's spinner. Not reset when idle:
-    /// picking back up from wherever it left off is fine, nobody's
-    /// watching for an exact starting frame.
+    /// Advanced once per `run()` iteration while `sync_in_flight` is set —
+    /// indexes into a small Braille frame set for the footer's spinner. Not
+    /// reset when idle: picking back up from wherever it left off is fine,
+    /// nobody's watching for an exact starting frame. The self-updater's own
+    /// in-flight state (`update_state: Checking`/`Downloading`) does *not*
+    /// advance this today — nothing in the update-check UI renders a
+    /// spinner glyph from it yet. If one is ever wired in there, extend the
+    /// gating in `run()` (`if app.sync_in_flight.is_some() { ... }`) to
+    /// cover that case too rather than assuming this field already does.
     pub spinner_frame: usize,
 }
 
@@ -961,6 +973,7 @@ impl App {
             history_count_cache: None,
             folder_preview_cache: None,
             note_preview_cache: None,
+            tag_index_cache: None,
             show_update: false,
             update_state: None,
             update_rx: None,
@@ -1545,6 +1558,16 @@ impl App {
         self.keymaps = KeyMaps::from_config(&new_config.keybindings);
         self.favorite_editor = shiki_core::editor::detect_favorite_editor();
         self.config = new_config;
+        // Both caches key on the theme's colors too, so a reload that
+        // doesn't actually change the theme would still hit correctly even
+        // without this — but that's an accident of the cache key, not a
+        // documented exemption, and a future cache keyed differently would
+        // silently break on a config reload. Clear both unconditionally,
+        // same as every other place that can change what PREVIEW should
+        // show underneath an unchanged path (`reload_notes`/
+        // `refresh_notes_preserve_selection`).
+        self.folder_preview_cache = None;
+        self.note_preview_cache = None;
     }
 
     /// Resolves the selected note's path relative to its notebook's root —
@@ -1689,6 +1712,44 @@ impl App {
         self.note_preview_cache = Some((path, colors, width, lines, sources));
     }
 
+    /// Keeps the tags modal's `TagIndex` up to date without rebuilding it on
+    /// every draw tick while the modal is open — same "compute once, not per
+    /// draw" discipline as `refresh_history_cache`/`refresh_folder_preview_cache`/
+    /// `refresh_note_preview_cache`. A no-op while the modal is closed
+    /// (`tag_index_cache` stays `None`, cleared by `reload_notes`/
+    /// `refresh_notes_preserve_selection` whenever the underlying note list
+    /// changes); rebuilt exactly once per "modal opened or notes changed"
+    /// event, not per keystroke while browsing it.
+    fn refresh_tag_index_cache(&mut self) {
+        if !self.show_tags {
+            self.tag_index_cache = None;
+            return;
+        }
+        if self.tag_index_cache.is_some() {
+            return;
+        }
+        self.tag_index_cache = Some(TagIndex::build(&self.notes));
+    }
+
+    /// The tags modal's tag index — always up to date by the time this is
+    /// called, since `refresh_tag_index_cache` runs once per `run()`
+    /// iteration before drawing, same spot as the other caches. Returns a
+    /// borrowed reference rather than a clone: `panel_tags::render` and
+    /// `draw()` both call this on every single draw tick while the modal is
+    /// open, and cloning the whole `TagIndex` (a `BTreeMap<String,
+    /// Vec<PathBuf>>`) on every one of those calls would silently reintroduce
+    /// the exact per-draw-tick cost the cache exists to avoid, just one
+    /// indirection later. The `unwrap_or_else` fallback (a shared empty
+    /// index, not a rebuild) only matters if this is ever called before
+    /// `refresh_tag_index_cache` has run at all — it never legitimately is,
+    /// since both callers are gated on `show_tags`.
+    pub(crate) fn tag_index(&self) -> &TagIndex {
+        static EMPTY: std::sync::OnceLock<TagIndex> = std::sync::OnceLock::new();
+        self.tag_index_cache
+            .as_ref()
+            .unwrap_or_else(|| EMPTY.get_or_init(TagIndex::default))
+    }
+
     /// The cached, pre-wrapped formatted lines for whichever note is
     /// currently selected, for the PREVIEW panel — `None` if no note is
     /// selected or the cache hasn't caught up yet (the very next draw tick
@@ -1752,7 +1813,7 @@ impl App {
     /// a `BTreeMap`, so this order is stable across redraws without storing
     /// the list on `App` itself.
     pub(crate) fn current_tags(&self) -> Vec<String> {
-        TagIndex::build(&self.notes).tags().cloned().collect()
+        self.tag_index().tags().cloned().collect()
     }
 
     /// Notes in the current directory carrying `tag` — every match is
@@ -1954,6 +2015,7 @@ pub fn run<B: Backend<Error = io::Error>>(
         app.refresh_history_cache();
         app.refresh_folder_preview_cache();
         app.refresh_note_preview_cache();
+        app.refresh_tag_index_cache();
         app.expire_status_message();
         app.poll_update_channel();
         app.poll_sync_channel();

--- a/shiki-tui/src/draw.rs
+++ b/shiki-tui/src/draw.rs
@@ -14,7 +14,6 @@ use ratatui::text::Line;
 use ratatui::text::Span;
 use ratatui::widgets::{Clear, List, ListItem, ListState, Paragraph, Wrap};
 use ratatui::Frame;
-use shiki_core::TagIndex;
 
 pub fn draw(frame: &mut Frame, app: &App) {
     let background = ratatui::widgets::Block::default()
@@ -136,7 +135,7 @@ pub fn draw(frame: &mut Frame, app: &App) {
 
     if app.show_tags {
         let rows = match &app.tags_viewing {
-            None => TagIndex::build(&app.notes).len(),
+            None => app.tag_index().len(),
             Some(tag) => app
                 .notes
                 .iter()

--- a/shiki-tui/src/key_handlers.rs
+++ b/shiki-tui/src/key_handlers.rs
@@ -11,7 +11,7 @@ use crate::app::{
 use crate::editor::InlineEditor;
 use crate::icons;
 use crate::input::InputBox;
-use crate::keybindings::{action_label, Action};
+use crate::keybindings::{Action, WhichKeyRow};
 use crate::render::{hex_to_color, panel_block};
 use crate::{confirm, layout, panel_drawer, panel_preview, slash_menu, status_bar};
 
@@ -738,8 +738,15 @@ impl App {
     }
 
     /// Only reachable once the check reported an available version — starts
-    /// the real download+verify+install on a background thread.
+    /// the real download+verify+install on a background thread, pinned to
+    /// the exact version the confirm dialog showed (`UpdateState::Available`'s
+    /// own string) rather than re-resolving "latest" a second time — a new
+    /// release landing in the gap between the check and this confirmation
+    /// must not silently install a different version than what was shown.
     fn start_update_install(&mut self) {
+        let Some(UpdateState::Available(target_version)) = self.update_state.clone() else {
+            return;
+        };
         self.update_state = Some(UpdateState::Downloading);
         // Captured now, before the replace happens — see the field doc on
         // `relaunch_exe_path` for why this can't just be re-queried later.
@@ -747,7 +754,8 @@ impl App {
         let (tx, rx) = std::sync::mpsc::channel();
         let current = env!("CARGO_PKG_VERSION").to_string();
         std::thread::spawn(move || {
-            let result = shiki_core::update::install_latest(&current).map_err(|e| e.to_string());
+            let result = shiki_core::update::install_version(&current, &target_version)
+                .map_err(|e| e.to_string());
             let _ = tx.send(UpdateMsg::InstallResult(result));
         });
         self.update_rx = Some(rx);
@@ -832,16 +840,25 @@ impl App {
     /// Every keybinding entry whose key, action label, or scope name
     /// contains the current query (case-insensitive) — all of them if the
     /// query is empty. Backs both rendering and `Enter`'s execute-in-place.
-    pub fn which_key_filtered_entries(&self) -> Vec<(&'static str, String, Action)> {
+    pub fn which_key_filtered_entries(&self) -> Vec<WhichKeyRow> {
         let query = self.which_key_input.value.to_lowercase();
-        self.keymaps
+        let bound = self
+            .keymaps
             .entries()
             .into_iter()
-            .filter(|(scope, key, action)| {
+            .map(|(scope, key, action)| WhichKeyRow::Bound { scope, key, action });
+        let nav = self
+            .keymaps
+            .nav_rows()
+            .into_iter()
+            .map(|(scope, key, label)| WhichKeyRow::Nav { scope, key, label });
+        bound
+            .chain(nav)
+            .filter(|row| {
                 query.is_empty()
-                    || key.to_lowercase().contains(&query)
-                    || action_label(*action).to_lowercase().contains(&query)
-                    || scope.to_lowercase().contains(&query)
+                    || row.key().to_lowercase().contains(&query)
+                    || row.label().to_lowercase().contains(&query)
+                    || row.scope().to_lowercase().contains(&query)
             })
             .collect()
     }
@@ -856,7 +873,10 @@ impl App {
                 let action = self
                     .which_key_filtered_entries()
                     .get(self.which_key_selected)
-                    .map(|(_, _, action)| *action);
+                    .and_then(|row| match row {
+                        WhichKeyRow::Bound { action, .. } => Some(*action),
+                        WhichKeyRow::Nav { .. } => None,
+                    });
                 if let Some(action) = action {
                     self.show_which_key = false;
                     self.handle_action(action);
@@ -2058,7 +2078,12 @@ impl App {
             }
         };
         let today = chrono::Local::now().date_naive();
-        match shiki_core::daily::create_or_open(&nb, today, &templates_dir) {
+        match shiki_core::daily::create_or_open(
+            &nb,
+            today,
+            &templates_dir,
+            &self.config.general.daily_template,
+        ) {
             Ok(note) => {
                 // Daily notes always live at the notebook root — jump the
                 // breadcrumb back there so the new note is visible.
@@ -3453,6 +3478,16 @@ impl App {
     /// `]]` — same "delete the exact range that was being typed, then
     /// insert the resolved text" shape as `apply_slash_command`.
     fn apply_wikilink_selection(&mut self, title: &str) {
+        // The typed "[[query" itself gets replayed across every secondary
+        // cursor (the generic per-keystroke path in `replay_keystroke`
+        // handles that fine), but applying the actual selection below only
+        // ever edits the primary cursor's `textarea` — a secondary cursor
+        // would be left with its own unconsumed literal "[[query" text and
+        // a now-stale `(row, col)` once the primary's edit shifts things
+        // out from under it. Collapsing to a single cursor first is the
+        // same "not a meaningful multi-cursor state" call already made for
+        // Ctrl+A/select-all above.
+        self.editor_secondary_cursors.clear();
         let Some(editor) = &mut self.editor else {
             return;
         };
@@ -3974,6 +4009,13 @@ impl App {
     /// A `{{cursor}}` marker in the body is resolved to an absolute
     /// `CursorMove::Jump` afterward instead of being inserted literally.
     fn apply_slash_command(&mut self, cmd: &slash_menu::SlashCommand) {
+        // Same reasoning as `apply_wikilink_selection`: this only edits the
+        // primary cursor's `textarea`, and a snippet body can be multi-line
+        // — leaving secondary cursors in place after this would desync
+        // their row/col against the rows the primary's insertion just
+        // shifted, on top of each one still holding its own unconsumed
+        // literal "/command" text.
+        self.editor_secondary_cursors.clear();
         let title = self
             .selected_note()
             .map(|n| n.frontmatter.title.clone())
@@ -4064,6 +4106,16 @@ impl App {
                     // accidental-notebook-deletion footgun.
                     if is_notebook_git_action(action) {
                         self.handle_action(action);
+                    } else {
+                        // Notebook new/rename/delete deliberately isn't
+                        // included in the fallback above (see the comment
+                        // there) — but silently doing nothing at all reads
+                        // as a dead key, indistinguishable from one that's
+                        // just unbound in this scope. Say so instead.
+                        self.set_status(
+                            "no action bound here — switch to NOTEBOOKS to manage notebooks"
+                                .to_string(),
+                        );
                     }
                 }
             }

--- a/shiki-tui/src/keybindings.rs
+++ b/shiki-tui/src/keybindings.rs
@@ -233,6 +233,83 @@ impl KeyMaps {
         out.sort_by(|a, b| a.0.cmp(b.0).then_with(|| a.1.cmp(&b.1)));
         out
     }
+
+    /// Core navigation/quit rows for the which-key popup — `hjkl`/arrows/
+    /// `Tab`/`Enter`/`?`/quit are hardcoded in `handle_normal_key` (they
+    /// behave identically in every scope, so they were never given `Action`
+    /// entries of their own), which meant `entries()` — and therefore the
+    /// one built-in help screen — omitted the most-used keys in the app
+    /// entirely. These aren't real `Action`s (nothing to dispatch — `Enter`
+    /// on one of these rows in the which-key modal is a no-op, see
+    /// `WhichKeyRow`), just documentation of keys that already work.
+    pub fn nav_rows(&self) -> Vec<(&'static str, String, &'static str)> {
+        vec![
+            ("NAVIGATION", "j / ↓".into(), "move down"),
+            ("NAVIGATION", "k / ↑".into(), "move up"),
+            ("NAVIGATION", "PageDown".into(), "move down a page"),
+            ("NAVIGATION", "PageUp".into(), "move up a page"),
+            ("NAVIGATION", "Home".into(), "jump to the top"),
+            ("NAVIGATION", "End".into(), "jump to the bottom"),
+            (
+                "NAVIGATION",
+                "l / → / enter".into(),
+                "open (a folder, or the next panel)",
+            ),
+            (
+                "NAVIGATION",
+                "h / ←".into(),
+                "back (up a folder, or the previous panel)",
+            ),
+            ("NAVIGATION", "Tab".into(), "switch panel"),
+            ("NAVIGATION", "?".into(), "this help / command palette"),
+            ("NAVIGATION", describe_key(self.quit), "quit shiki"),
+        ]
+    }
+}
+
+/// A row in the which-key popup: either a real, dispatchable `Action`, or a
+/// purely informational hardcoded navigation key (see `KeyMaps::nav_rows`)
+/// that `Enter` can't act on since there's no `Action` behind it.
+#[derive(Debug, Clone)]
+pub enum WhichKeyRow {
+    Bound {
+        scope: &'static str,
+        key: String,
+        action: Action,
+    },
+    Nav {
+        scope: &'static str,
+        key: String,
+        label: &'static str,
+    },
+}
+
+impl WhichKeyRow {
+    pub fn scope(&self) -> &'static str {
+        match self {
+            WhichKeyRow::Bound { scope, .. } | WhichKeyRow::Nav { scope, .. } => scope,
+        }
+    }
+
+    pub fn key(&self) -> &str {
+        match self {
+            WhichKeyRow::Bound { key, .. } | WhichKeyRow::Nav { key, .. } => key,
+        }
+    }
+
+    pub fn label(&self) -> &str {
+        match self {
+            WhichKeyRow::Bound { action, .. } => action_label(*action),
+            WhichKeyRow::Nav { label, .. } => label,
+        }
+    }
+
+    pub fn icon(&self) -> char {
+        match self {
+            WhichKeyRow::Bound { action, .. } => action_icon(*action),
+            WhichKeyRow::Nav { .. } => crate::icons::ARROW,
+        }
+    }
 }
 
 pub fn describe_key(code: KeyCode) -> String {

--- a/shiki-tui/src/panel_notebooks.rs
+++ b/shiki-tui/src/panel_notebooks.rs
@@ -13,7 +13,7 @@ pub fn render(frame: &mut Frame, area: Rect, app: &App) {
     let fg = hex_to_color(&app.theme.fg);
 
     let items: Vec<ListItem> = if app.notebooks.is_empty() {
-        vec![ListItem::new("  press `A` to create one")
+        vec![ListItem::new("  press `a` to create one")
             .style(Style::default().fg(hex_to_color(&app.theme.muted)))]
     } else {
         app.notebooks

--- a/shiki-tui/src/panel_tags.rs
+++ b/shiki-tui/src/panel_tags.rs
@@ -3,7 +3,6 @@ use ratatui::style::{Modifier, Style};
 use ratatui::text::Line;
 use ratatui::widgets::{List, ListItem, ListState};
 use ratatui::Frame;
-use shiki_core::TagIndex;
 
 use crate::app::App;
 use crate::icons;
@@ -20,7 +19,7 @@ pub fn render(frame: &mut Frame, area: Rect, app: &App) {
 
     let (title, items, selected): (String, Vec<ListItem>, usize) = match &app.tags_viewing {
         None => {
-            let tags = TagIndex::build(&app.notes);
+            let tags = app.tag_index();
             let items = tags
                 .tags()
                 .map(|tag| {

--- a/shiki-tui/src/render.rs
+++ b/shiki-tui/src/render.rs
@@ -13,7 +13,9 @@ use shiki_config::Theme;
 /// on before this was pulled out into a shared helper: dirty is more
 /// urgent than "just needs a push/pull", and clean is the good case.
 pub fn git_status_color(theme: &Theme, gs: &shiki_core::git::GitStatus) -> Color {
-    if gs.dirty_count > 0 {
+    if gs.status_error.is_some() {
+        hex_to_color(&theme.error)
+    } else if gs.dirty_count > 0 {
         hex_to_color(&theme.warning)
     } else if gs.ahead > 0 || gs.behind > 0 {
         hex_to_color(&theme.accent)
@@ -27,6 +29,13 @@ pub fn git_status_color(theme: &Theme, gs: &shiki_core::git::GitStatus) -> Color
 /// and the notebook drawer so the same notebook never shows different
 /// numbers in two places because one of them drifted from the other.
 pub fn git_status_suffix(gs: &shiki_core::git::GitStatus) -> String {
+    if gs.status_error.is_some() {
+        // The status check itself failed (locked index, permission issue,
+        // corrupted repo) — showing "+0" here would silently read as
+        // "clean", which is exactly the wrong signal when the real state
+        // is genuinely unknown.
+        return " status?".to_string();
+    }
     let mut extras = String::new();
     if gs.dirty_count > 0 {
         extras.push_str(&format!(" +{}", gs.dirty_count));

--- a/shiki-tui/src/sync.rs
+++ b/shiki-tui/src/sync.rs
@@ -66,6 +66,7 @@ impl App {
         self.preview_scroll = 0;
         self.folder_preview_cache = None;
         self.note_preview_cache = None;
+        self.tag_index_cache = None;
         self.refresh_git_status();
     }
 
@@ -93,6 +94,7 @@ impl App {
         // every caller of this function). The colors-in-the-key check alone
         // wouldn't catch that, since neither the path nor the theme changed.
         self.note_preview_cache = None;
+        self.tag_index_cache = None;
         self.refresh_git_status();
     }
 
@@ -383,10 +385,25 @@ impl App {
             }
             GitOpKind::Pull { notebook } => {
                 if self.selected_notebook().map(|n| n.name.as_str()) == Some(notebook.as_str()) {
-                    self.reload_notes();
+                    // Same fix as `PullAll` below: re-list from disk without
+                    // resetting the selection/scroll the user may have since
+                    // moved to a different note/folder *within this same
+                    // notebook* while the pull was in flight.
+                    self.refresh_notes_preserve_selection();
                 }
             }
-            GitOpKind::PullAll => self.reload_notes(),
+            // Unlike `Sync`/`Pull`, this doesn't know which specific
+            // notebook(s) actually changed (just an aggregate ok/failed
+            // count) — so it can't skip refreshing outright the way those
+            // two do when the background op wasn't about the currently
+            // selected notebook. But it still shouldn't *reset* the
+            // selection: `reload_notes` always jumps back to index 0 and
+            // clears scroll position, which used to fire unconditionally
+            // here even when the user had since navigated to a different
+            // note/folder entirely while the pull was in flight.
+            // `refresh_notes_preserve_selection` re-lists from disk the same
+            // way but keeps the same note selected (by slug) instead.
+            GitOpKind::PullAll => self.refresh_notes_preserve_selection(),
         }
         if self.show_drawer {
             self.refresh_drawer_statuses();

--- a/shiki-tui/src/which.rs
+++ b/shiki-tui/src/which.rs
@@ -6,7 +6,7 @@ use ratatui::Frame;
 
 use crate::app::App;
 use crate::icons;
-use crate::keybindings::{action_icon, action_label, describe_key};
+use crate::keybindings::describe_key;
 use crate::render::{hex_to_color, panel_block};
 
 /// Near-full-screen popup listing every keybinding, grouped by scope
@@ -50,7 +50,8 @@ pub fn render(frame: &mut Frame, area: Rect, app: &App) {
     // header lines are interspersed — `ListState::select` needs a row
     // index, not an entry index.
     let mut selected_row = 0usize;
-    for (i, (scope, key, action)) in entries.iter().enumerate() {
+    for (i, row) in entries.iter().enumerate() {
+        let scope = row.scope();
         if last_scope != Some(scope) {
             items.push(ListItem::new(Line::from(Span::styled(
                 format!("── {scope} ──"),
@@ -63,14 +64,11 @@ pub fn render(frame: &mut Frame, area: Rect, app: &App) {
         }
         items.push(ListItem::new(Line::from(vec![
             Span::styled(
-                format!("{key:>8} "),
+                format!("{:>8} ", row.key()),
                 Style::default().fg(accent).add_modifier(Modifier::BOLD),
             ),
-            Span::styled(
-                format!("{} ", action_icon(*action)),
-                Style::default().fg(accent),
-            ),
-            Span::styled(action_label(*action), Style::default().fg(fg)),
+            Span::styled(format!("{} ", row.icon()), Style::default().fg(accent)),
+            Span::styled(row.label().to_string(), Style::default().fg(fg)),
         ])));
     }
 


### PR DESCRIPTION
## Summary

Three rounds of deep review across the whole workspace, fixing real bugs, DX/perf issues, CI gaps, and a mobile-site accessibility issue. See `CHANGELOG.md`'s `[Unreleased]` section for the full itemized list (grouped Added/Changed/Fixed). Highlights:

**Correctness**
- Frontmatter parser no longer truncates on a literal `---` line inside a YAML block scalar, and now handles CRLF.
- `copy_folder_to`/`move_folder_to` reject a destination nested inside the source (used to recurse forever).
- Multi-cursor state no longer corrupts when applying a slash-command or wikilink selection.
- `git::status()` surfaces a failed status check instead of silently reporting "clean".
- Session-restored `notes_path` is sanitized against path traversal.
- `find_note` detects (rather than silently resolving) an ambiguous title/slug match across folders.
- Single-notebook `Pull` (`p`) no longer resets your selection/scroll (matches the earlier `PullAll` fix).
- Self-updater installs the exact version its confirm dialog showed, not whatever's "latest" a second query later.

**CLI/DX**
- New `shiki notebook delete <name> --yes`.
- `shiki sync` matches the TUI's per-notebook config and commit-message behavior.
- `shiki new`/`edit`/`daily` respect `use_favorite_editor`.
- `shiki doctor` gained 6 new checks (unrecognized config keys, `default_notebook` validity, notebook path collisions, `remote_template` placeholder, `sign_commits` key, `data_dir` type).

**Performance**
- `wikilinks::backlinks` no longer rescans every note per link (was O(notes × links)).
- `TagIndex` caching actually avoids rebuild/clone on every draw tick now.
- `search_text` reuses one scratch buffer instead of allocating per note per keystroke.

**CI**
- Added `cargo test` and `cargo audit` jobs (neither existed before).
- `fmt-and-clippy` matrixed across all 3 OSes; redundant `build` job folded into `test`.
- Every job has a `timeout-minutes`; `release.yml`'s `contents: write` scoped to just the job that needs it.

**Site**
- Working mobile hamburger menu with a real focus trap (nav used to just vanish below 900px).
- Gallery screenshots no longer double-download the wrong theme before the right one.
- TOC/search jumps no longer land headings under the sticky bars.

## Testing

- `cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace` all pass locally (130 tests, 20 new).
- Manually exercised: `shiki notebook create/list/delete`, `shiki doctor` against both a clean and a deliberately-typo'd `config.toml`, `shiki sync` with/without a remote.
- `node --check` on `docs/js/main.js`; workflow YAML and `sitemap.xml` validated with `yaml`/`xml.etree`.

## Test plan

- [ ] CI green on this PR (fmt, clippy ×3 OS, test ×3 OS, audit, build artifacts if release-adjacent)
- [ ] Spot-check `shiki doctor` output against a real `~/.config/shiki/config.toml`
- [ ] Try the mobile nav on an actual narrow viewport (not just read the CSS)

🤖 Generated with [Claude Code](https://claude.com/claude-code)