### PR TITLE
Syntax highlighting, scriptable CLI, export command, multi-format notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,30 @@ semver yet (pre-1.0), but version bumps are still meaningful and tracked here.
   creation, and session-path sanitization.
 - CI: a `cargo audit` job (with a `.cargo/audit.toml` ignore-list mechanism for a known,
   not-yet-fixable transitive advisory) and a real `cargo test --workspace` job, both missing before.
+- Real syntax highlighting for fenced code blocks in the PREVIEW panel (`shiki-tui/src/syntax.rs`),
+  via `syntect` — a workspace dependency that, until now, wasn't actually used anywhere. Every code
+  fence used to render as flat dimmed text regardless of its language tag; ` ```lang ` fences with a
+  language `syntect`'s bundled syntax defs recognize now get real per-token coloring, picked to match
+  the active theme's light/dark bias (`render::is_dark_color`) so a light theme like
+  catppuccin-latte doesn't get a dark-on-dark syntect theme. ` ```mermaid ` fences render in a
+  distinct accent color (a terminal can't render an actual diagram) instead of being visually
+  indistinguishable from a blockquote.
+- `shiki list`/`shiki search`/`shiki show`/`shiki notebook list` all gained a `--json` flag, emitting
+  structured output instead of plain text — none of the CLI's read commands had a machine-readable
+  format before, which made them unusable from scripts/other programs without fragile text parsing.
+- `shiki new` gained `--body <text>`/`--stdin` (reads the note body from stdin) and `--tags`, so a
+  note can be created fully non-interactively — every content-producing CLI command used to
+  unconditionally spawn `$EDITOR` and block on it, with no way to script note creation at all.
+- `shiki export --notebook <name> --out <path> --format html|md` — a new command bundling every note
+  in a notebook into a single file. `--format html` (the default) is real Markdown-to-HTML via
+  `pulldown-cmark` (another previously-declared-but-unused workspace dependency) with a small
+  embedded stylesheet (light/dark aware, no external assets); `--format md` is a plain concatenated
+  Markdown bundle. There was previously no export path of any kind.
+- Notebooks now tolerate `.txt` and `.mdx` files alongside `.md` when listing/reading notes
+  (`Notebook::list_dir`'s `NOTE_EXTENSIONS`) — a notebook pointed at an existing Obsidian vault
+  commonly has both, and they used to be silently invisible to shiki (not deleted, just never
+  listed). New notes are still always created as `.md`; renaming a `.txt`/`.mdx` note now preserves
+  its original extension instead of silently converting it to `.md`.
 
 ### Changed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1096,6 +1096,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "getopts"
+version = "0.2.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfe4fbac503b8d1f88e6676011885f34b7174f46e59956bba534ba83abded4df"
+dependencies = [
+ "unicode-width",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2287,6 +2296,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "pulldown-cmark"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f86ba2052aebccc42cbbb3ed234b8b13ce76f75c3551a303cb2bcffcff12bb14"
+dependencies = [
+ "bitflags 2.13.1",
+ "getopts",
+ "memchr",
+ "pulldown-cmark-escape",
+ "unicase",
+]
+
+[[package]]
+name = "pulldown-cmark-escape"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "007d8adb5ddab6f8e3f491ac63566a7d5002cc7ed73901f72057943fa71ae1ae"
+
+[[package]]
 name = "quick-xml"
 version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2950,7 +2978,9 @@ dependencies = [
  "chrono",
  "clap",
  "crossterm",
+ "pulldown-cmark",
  "ratatui",
+ "serde_json",
  "shiki-config",
  "shiki-core",
  "shiki-tui",
@@ -3691,6 +3721,12 @@ name = "ucd-trie"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
+
+[[package]]
+name = "unicase"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
 
 [[package]]
 name = "unicode-ident"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ syntect = "5"
 ratatui-textarea = "0.9"
 nucleo-matcher = "0.3"
 serde = { version = "1", features = ["derive"] }
+serde_json = "1"
 toml = "1.1"
 clap = { version = "4", features = ["derive"] }
 chrono = { version = "0.4", features = ["serde"] }

--- a/shiki-cli/Cargo.toml
+++ b/shiki-cli/Cargo.toml
@@ -27,3 +27,5 @@ tracing.workspace = true
 tracing-subscriber.workspace = true
 chrono.workspace = true
 toml.workspace = true
+serde_json.workspace = true
+pulldown-cmark.workspace = true

--- a/shiki-cli/src/commands/export.rs
+++ b/shiki-cli/src/commands/export.rs
@@ -1,0 +1,142 @@
+use anyhow::{Context, Result};
+use clap::ValueEnum;
+use pulldown_cmark::{html, Options, Parser};
+use shiki_core::{Note, NotebookStore};
+use std::path::Path;
+
+#[derive(Clone, Copy, ValueEnum)]
+pub enum ExportFormat {
+    /// A single self-contained HTML file — real Markdown-to-HTML via
+    /// `pulldown-cmark` (a workspace dependency that, before this command,
+    /// wasn't actually used anywhere in the codebase), styled with a small
+    /// embedded stylesheet so it's readable on its own with no external
+    /// assets to ship alongside it.
+    Html,
+    /// A single plain-Markdown bundle — every note concatenated in order,
+    /// each preceded by its title/date/tags as a heading. No HTML/CSS,
+    /// just Markdown a note-taking tool (or a human) can read directly.
+    Md,
+}
+
+/// Exports every note in `notebook` (recursively, so nested folders are
+/// included) into one file at `out`, sorted by date then title so the
+/// output reads chronologically. `all_notes_recursive` already loads
+/// everything shiki considers a note; anything that failed to parse at all
+/// is already excluded upstream (`Notebook::list_notes`'s own tolerance for
+/// non-shiki `.md` files), so there's nothing extra to filter out here.
+pub fn run(store: &NotebookStore, notebook: &str, out: &Path, format: ExportFormat) -> Result<()> {
+    let nb = store.get(notebook).with_context(|| {
+        format!("notebook '{notebook}' not found \u{2014} see `shiki notebook list`")
+    })?;
+    let mut notes = nb.all_notes_recursive()?;
+    notes.sort_by(|a, b| {
+        a.frontmatter
+            .date
+            .cmp(&b.frontmatter.date)
+            .then_with(|| a.frontmatter.title.cmp(&b.frontmatter.title))
+    });
+
+    let content = match format {
+        ExportFormat::Html => render_html(notebook, &notes),
+        ExportFormat::Md => render_markdown(notebook, &notes),
+    };
+    std::fs::write(out, content).with_context(|| format!("failed to write '{}'", out.display()))?;
+    println!("exported {} notes to {}", notes.len(), out.display());
+    Ok(())
+}
+
+fn render_markdown(notebook: &str, notes: &[Note]) -> String {
+    let mut buf = format!("# {notebook}\n\n");
+    for note in notes {
+        buf.push_str(&format!("## {}\n\n", note.frontmatter.title));
+        buf.push_str(&format!("*{}*", note.frontmatter.date));
+        if !note.frontmatter.tags.is_empty() {
+            buf.push_str(&format!(
+                " \u{2014} tags: {}",
+                note.frontmatter.tags.join(", ")
+            ));
+        }
+        buf.push_str("\n\n");
+        buf.push_str(&note.body);
+        buf.push_str("\n\n---\n\n");
+    }
+    buf
+}
+
+/// Bare `&`/`<`/`>` escaping for the metadata (title/tags) that gets
+/// interpolated straight into the HTML shell rather than run through
+/// `pulldown-cmark` — the note body itself doesn't need this, since
+/// `html::push_html` already escapes it as part of normal Markdown
+/// rendering.
+fn escape_html(s: &str) -> String {
+    s.replace('&', "&amp;")
+        .replace('<', "&lt;")
+        .replace('>', "&gt;")
+}
+
+fn render_html(notebook: &str, notes: &[Note]) -> String {
+    let mut articles = String::new();
+    for note in notes {
+        articles.push_str("<article>\n<h2>");
+        articles.push_str(&escape_html(&note.frontmatter.title));
+        articles.push_str("</h2>\n<p class=\"meta\">");
+        articles.push_str(&note.frontmatter.date.to_string());
+        if !note.frontmatter.tags.is_empty() {
+            articles.push_str(" &mdash; ");
+            articles.push_str(
+                &note
+                    .frontmatter
+                    .tags
+                    .iter()
+                    .map(|t| format!("<span class=\"tag\">{}</span>", escape_html(t)))
+                    .collect::<Vec<_>>()
+                    .join(" "),
+            );
+        }
+        articles.push_str("</p>\n");
+        let mut body_html = String::new();
+        html::push_html(&mut body_html, Parser::new_ext(&note.body, Options::all()));
+        articles.push_str(&body_html);
+        articles.push_str("</article>\n<hr>\n");
+    }
+
+    format!(
+        r#"<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>{title}</title>
+<style>
+  body {{ max-width: 46rem; margin: 2rem auto; padding: 0 1rem;
+          font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+          line-height: 1.6; color: #222; }}
+  h1 {{ border-bottom: 2px solid #ccc; padding-bottom: 0.3rem; }}
+  article h2 {{ margin-bottom: 0.2rem; }}
+  .meta {{ color: #777; font-size: 0.85rem; margin-top: 0; }}
+  .tag {{ background: #eee; border-radius: 0.3rem; padding: 0.1rem 0.4rem; font-size: 0.8rem; }}
+  pre {{ background: #f5f5f5; padding: 0.8rem; overflow-x: auto; border-radius: 0.3rem; }}
+  code {{ background: #f5f5f5; padding: 0.1rem 0.3rem; border-radius: 0.2rem; }}
+  pre code {{ background: none; padding: 0; }}
+  blockquote {{ border-left: 3px solid #ccc; margin-left: 0; padding-left: 1rem; color: #555; }}
+  hr {{ border: none; border-top: 1px solid #eee; margin: 2rem 0; }}
+  @media (prefers-color-scheme: dark) {{
+    body {{ background: #1a1a1a; color: #ddd; }}
+    h1 {{ border-color: #444; }}
+    .meta {{ color: #999; }}
+    .tag {{ background: #333; }}
+    pre, code {{ background: #262626; }}
+    blockquote {{ border-color: #444; color: #aaa; }}
+    hr {{ border-color: #333; }}
+  }}
+</style>
+</head>
+<body>
+<h1>{title}</h1>
+{articles}
+</body>
+</html>
+"#,
+        title = escape_html(notebook),
+        articles = articles,
+    )
+}

--- a/shiki-cli/src/commands/list.rs
+++ b/shiki-cli/src/commands/list.rs
@@ -1,11 +1,29 @@
 use anyhow::{Context, Result};
 use shiki_core::NotebookStore;
 
-pub fn run(store: &NotebookStore, notebook: &str) -> Result<()> {
+pub fn run(store: &NotebookStore, notebook: &str, json: bool) -> Result<()> {
     let nb = store.get(notebook).with_context(|| {
         format!("notebook '{notebook}' not found \u{2014} see `shiki notebook list`")
     })?;
     let notes = nb.all_notes_recursive()?;
+
+    if json {
+        let items: Vec<serde_json::Value> = notes
+            .iter()
+            .map(|note| {
+                serde_json::json!({
+                    "title": note.frontmatter.title,
+                    "date": note.frontmatter.date.to_string(),
+                    "tags": note.frontmatter.tags,
+                    "slug": note.file_stem(),
+                    "path": note.path,
+                })
+            })
+            .collect();
+        println!("{}", serde_json::to_string_pretty(&items)?);
+        return Ok(());
+    }
+
     if notes.is_empty() {
         println!("({notebook} is empty)");
         return Ok(());

--- a/shiki-cli/src/commands/mod.rs
+++ b/shiki-cli/src/commands/mod.rs
@@ -2,6 +2,7 @@ pub mod config;
 pub mod daily;
 pub mod doctor;
 pub mod edit;
+pub mod export;
 pub mod list;
 pub mod new;
 pub mod notebook;

--- a/shiki-cli/src/commands/new.rs
+++ b/shiki-cli/src/commands/new.rs
@@ -3,14 +3,36 @@ use shiki_core::NotebookStore;
 
 use super::open_in_editor;
 
-pub fn run(store: &NotebookStore, notebook: &str, title: &str, editor: &str) -> Result<()> {
+/// Creates a note. When `body` is `Some` (from `--body`/`--stdin`), the note
+/// is written with that content and `$EDITOR` is never spawned — the
+/// non-interactive path needed for scripting/automation (e.g. another
+/// program piping generated content in). `tags` is applied either way; an
+/// empty slice is a no-op, so the interactive path (still the default) is
+/// unaffected when neither flag is passed.
+pub fn run(
+    store: &NotebookStore,
+    notebook: &str,
+    title: &str,
+    editor: &str,
+    body: Option<&str>,
+    tags: &[String],
+) -> Result<()> {
     let nb = match store.get(notebook) {
         Ok(nb) => nb,
         Err(_) => store
             .create(notebook)
             .with_context(|| format!("could not create notebook '{notebook}'"))?,
     };
-    let note = nb.create_note(title, "")?;
+    let mut note = nb.create_note(title, body.unwrap_or(""))?;
     println!("created: {}", note.path.display());
+
+    if !tags.is_empty() {
+        note.frontmatter.tags = tags.to_vec();
+        note.save()?;
+    }
+
+    if body.is_some() {
+        return Ok(());
+    }
     open_in_editor(editor, &note.path)
 }

--- a/shiki-cli/src/commands/notebook.rs
+++ b/shiki-cli/src/commands/notebook.rs
@@ -7,8 +7,31 @@ pub fn create(store: &NotebookStore, name: &str) -> Result<()> {
     Ok(())
 }
 
-pub fn list(store: &NotebookStore) -> Result<()> {
+pub fn list(store: &NotebookStore, json: bool) -> Result<()> {
     let notebooks = store.list()?;
+
+    if json {
+        let items: Vec<serde_json::Value> = notebooks
+            .iter()
+            .map(|nb| match nb.all_notes_recursive() {
+                Ok(notes) => serde_json::json!({
+                    "name": nb.name,
+                    "path": nb.path,
+                    "note_count": notes.len(),
+                    "error": null,
+                }),
+                Err(e) => serde_json::json!({
+                    "name": nb.name,
+                    "path": nb.path,
+                    "note_count": null,
+                    "error": e.to_string(),
+                }),
+            })
+            .collect();
+        println!("{}", serde_json::to_string_pretty(&items)?);
+        return Ok(());
+    }
+
     if notebooks.is_empty() {
         println!("(no notebooks)");
         return Ok(());

--- a/shiki-cli/src/commands/search.rs
+++ b/shiki-cli/src/commands/search.rs
@@ -1,13 +1,33 @@
 use anyhow::{Context, Result};
 use shiki_core::{NotebookStore, SearchEngine};
 
-pub fn run(store: &NotebookStore, notebook: &str, query: &str) -> Result<()> {
+pub fn run(store: &NotebookStore, notebook: &str, query: &str, json: bool) -> Result<()> {
     let nb = store.get(notebook).with_context(|| {
         format!("notebook '{notebook}' not found \u{2014} see `shiki notebook list`")
     })?;
     let notes = nb.all_notes_recursive()?;
     let mut engine = SearchEngine::new();
     let hits = engine.search(query, &notes);
+
+    if json {
+        let items: Vec<serde_json::Value> = hits
+            .iter()
+            .map(|hit| {
+                let note = &notes[hit.index];
+                serde_json::json!({
+                    "title": note.frontmatter.title,
+                    "date": note.frontmatter.date.to_string(),
+                    "tags": note.frontmatter.tags,
+                    "slug": note.file_stem(),
+                    "path": note.path,
+                    "score": hit.score,
+                })
+            })
+            .collect();
+        println!("{}", serde_json::to_string_pretty(&items)?);
+        return Ok(());
+    }
+
     if hits.is_empty() {
         println!("(no results)");
         return Ok(());

--- a/shiki-cli/src/commands/show.rs
+++ b/shiki-cli/src/commands/show.rs
@@ -3,8 +3,22 @@ use shiki_core::NotebookStore;
 
 use super::find_note;
 
-pub fn run(store: &NotebookStore, notebook: &str, note: &str) -> Result<()> {
+pub fn run(store: &NotebookStore, notebook: &str, note: &str, json: bool) -> Result<()> {
     let note = find_note(store, notebook, note)?;
+
+    if json {
+        let value = serde_json::json!({
+            "title": note.frontmatter.title,
+            "date": note.frontmatter.date.to_string(),
+            "tags": note.frontmatter.tags,
+            "slug": note.file_stem(),
+            "path": note.path,
+            "body": note.body,
+        });
+        println!("{}", serde_json::to_string_pretty(&value)?);
+        return Ok(());
+    }
+
     println!("# {}", note.frontmatter.title);
     println!("date: {}", note.frontmatter.date);
     if !note.frontmatter.tags.is_empty() {

--- a/shiki-cli/src/main.rs
+++ b/shiki-cli/src/main.rs
@@ -20,16 +20,31 @@ struct Cli {
 
 #[derive(Subcommand)]
 enum Commands {
-    /// Creates a new note and opens $EDITOR
+    /// Creates a new note. Opens $EDITOR unless `--body`/`--stdin` is given,
+    /// in which case the note is created non-interactively — for scripting/
+    /// automation (piping generated content in from another program).
     New {
         title: String,
         #[arg(short, long)]
         notebook: Option<String>,
+        /// Note body text, given directly instead of opening $EDITOR.
+        #[arg(long, conflicts_with = "stdin")]
+        body: Option<String>,
+        /// Reads the note body from stdin instead of opening $EDITOR —
+        /// e.g. `echo "content" | shiki new "title" --stdin`.
+        #[arg(long)]
+        stdin: bool,
+        /// Comma-separated tags, e.g. `--tags work,idea`.
+        #[arg(long, value_delimiter = ',')]
+        tags: Vec<String>,
     },
     /// Lists the notes in a notebook
     List {
         #[arg(short = 'n', long)]
         notebook: Option<String>,
+        /// Emits a JSON array instead of plain text — for scripting.
+        #[arg(long)]
+        json: bool,
     },
     /// Edits a note with $EDITOR
     Edit {
@@ -42,12 +57,18 @@ enum Commands {
         note: String,
         #[arg(short, long)]
         notebook: Option<String>,
+        /// Emits a JSON object instead of plain text — for scripting.
+        #[arg(long)]
+        json: bool,
     },
     /// Searches notes by title (fuzzy)
     Search {
         query: String,
         #[arg(short, long)]
         notebook: Option<String>,
+        /// Emits a JSON array instead of plain text — for scripting.
+        #[arg(long)]
+        json: bool,
     },
     /// Creates or opens today's daily note
     Daily {
@@ -58,6 +79,17 @@ enum Commands {
     Sync {
         #[arg(short = 'n', long)]
         notebook: Option<String>,
+    },
+    /// Exports every note in a notebook to a single HTML or Markdown file
+    Export {
+        #[arg(short = 'n', long)]
+        notebook: Option<String>,
+        /// Output file path.
+        #[arg(short, long)]
+        out: PathBuf,
+        /// Output format — defaults to a self-contained HTML file.
+        #[arg(long, value_enum, default_value = "html")]
+        format: commands::export::ExportFormat,
     },
     /// Shows the path to the config file
     Config,
@@ -80,7 +112,11 @@ enum NotebookAction {
     Create {
         name: String,
     },
-    List,
+    List {
+        /// Emits a JSON array instead of plain text — for scripting.
+        #[arg(long)]
+        json: bool,
+    },
     Rename {
         old: String,
         new: String,
@@ -171,27 +207,58 @@ fn main() -> Result<()> {
 
     match cli.command {
         None => tui::launch(ctx.config, ctx.store),
-        Some(Commands::New { title, notebook }) => {
+        Some(Commands::New {
+            title,
+            notebook,
+            body,
+            stdin,
+            tags,
+        }) => {
             let notebook = ctx.notebook_name(notebook);
             let editor = ctx.resolve_editor();
-            commands::new::run(&ctx.store, &notebook, &title, &editor)
+            let non_interactive_body = if stdin {
+                use std::io::Read as _;
+                let mut buf = String::new();
+                std::io::stdin()
+                    .read_to_string(&mut buf)
+                    .context("failed to read note body from stdin")?;
+                Some(buf)
+            } else {
+                body
+            };
+            commands::new::run(
+                &ctx.store,
+                &notebook,
+                &title,
+                &editor,
+                non_interactive_body.as_deref(),
+                &tags,
+            )
         }
-        Some(Commands::List { notebook }) => {
+        Some(Commands::List { notebook, json }) => {
             let notebook = ctx.notebook_name(notebook);
-            commands::list::run(&ctx.store, &notebook)
+            commands::list::run(&ctx.store, &notebook, json)
         }
         Some(Commands::Edit { note, notebook }) => {
             let notebook = ctx.notebook_name(notebook);
             let editor = ctx.resolve_editor();
             commands::edit::run(&ctx.store, &notebook, &note, &editor)
         }
-        Some(Commands::Show { note, notebook }) => {
+        Some(Commands::Show {
+            note,
+            notebook,
+            json,
+        }) => {
             let notebook = ctx.notebook_name(notebook);
-            commands::show::run(&ctx.store, &notebook, &note)
+            commands::show::run(&ctx.store, &notebook, &note, json)
         }
-        Some(Commands::Search { query, notebook }) => {
+        Some(Commands::Search {
+            query,
+            notebook,
+            json,
+        }) => {
             let notebook = ctx.notebook_name(notebook);
-            commands::search::run(&ctx.store, &notebook, &query)
+            commands::search::run(&ctx.store, &notebook, &query, json)
         }
         Some(Commands::Daily { notebook }) => {
             let notebook = ctx.notebook_name(notebook);
@@ -209,11 +276,19 @@ fn main() -> Result<()> {
             let notebook = ctx.notebook_name(notebook);
             commands::sync::run(&ctx.store, &notebook, &ctx.config)
         }
+        Some(Commands::Export {
+            notebook,
+            out,
+            format,
+        }) => {
+            let notebook = ctx.notebook_name(notebook);
+            commands::export::run(&ctx.store, &notebook, &out, format)
+        }
         Some(Commands::Config) => commands::config::run(),
         Some(Commands::Doctor) => unreachable!("handled before Context::load() above"),
         Some(Commands::Notebook { action }) => match action {
             NotebookAction::Create { name } => commands::notebook::create(&ctx.store, &name),
-            NotebookAction::List => commands::notebook::list(&ctx.store),
+            NotebookAction::List { json } => commands::notebook::list(&ctx.store, json),
             NotebookAction::Rename { old, new } => {
                 commands::notebook::rename(&ctx.store, &old, &new)
             }

--- a/shiki-core/src/notebook.rs
+++ b/shiki-core/src/notebook.rs
@@ -28,8 +28,11 @@ fn unique_slug(dir: &Path, title: &str) -> String {
 
 /// Same as `unique_slug`, but a collision with `ignore` (the note's own
 /// current path, mid-rename) doesn't count — renaming a note to the title
-/// it already effectively has shouldn't be blocked by itself.
-fn unique_slug_excluding(dir: &Path, title: &str, ignore: &Path) -> String {
+/// it already effectively has shouldn't be blocked by itself. `ext` is the
+/// note's own extension (`rename_note_at` preserves it rather than always
+/// renaming onto `.md` — see there), so the collision check looks for the
+/// same file type the rename is actually producing.
+fn unique_slug_excluding(dir: &Path, title: &str, ignore: &Path, ext: &str) -> String {
     let base = Note::slugify(title);
     let base = if base.is_empty() {
         format!("untitled-{}", chrono::Local::now().timestamp())
@@ -39,7 +42,7 @@ fn unique_slug_excluding(dir: &Path, title: &str, ignore: &Path) -> String {
     let mut candidate = base.clone();
     let mut n = 2;
     loop {
-        let path = dir.join(format!("{candidate}.md"));
+        let path = dir.join(format!("{candidate}.{ext}"));
         if !path.exists() || path == *ignore {
             return candidate;
         }
@@ -79,7 +82,19 @@ fn is_same_or_nested(source: &Path, dest: &Path) -> bool {
     dest_resolved == source || dest_resolved.starts_with(&source)
 }
 
-/// A notebook is a directory with its own git repo, containing `.md` notes.
+/// File extensions shiki treats as a note when listing a notebook's
+/// contents — `.md` (what shiki itself always creates), plus `.mdx` and
+/// `.txt` so a notebook pointed at an existing Obsidian vault (which
+/// commonly has both) shows those files too instead of silently hiding
+/// them. This only affects *reading/listing* — new notes are always
+/// created as `.md` (`create_note_in`); an existing `.mdx`/`.txt` file kept
+/// its own extension through rename/move/copy (see `rename_note_at`),
+/// rather than being silently converted to `.md` the first time it's
+/// touched from inside shiki.
+const NOTE_EXTENSIONS: [&str; 3] = ["md", "mdx", "txt"];
+
+/// A notebook is a directory with its own git repo, containing notes with
+/// one of `NOTE_EXTENSIONS`' extensions (in practice, almost always `.md`).
 #[derive(Debug, Clone)]
 pub struct Notebook {
     pub name: String,
@@ -100,10 +115,11 @@ impl Notebook {
     /// as `nb`, and the caller (the Notes panel) walks one level at a time.
     /// Folders are sorted alphabetically; `.git` is never listed as a folder.
     ///
-    /// `.md` files that don't parse as a shiki note (no `---` frontmatter —
-    /// common in an imported/pre-existing repo, or one from `nb`) still show
-    /// up: `Note::from_file` synthesizes metadata for those rather than
-    /// failing, so nothing here needs to skip them.
+    /// A note file (any of `NOTE_EXTENSIONS`) that doesn't parse as a shiki
+    /// note (no `---` frontmatter — common in an imported/pre-existing
+    /// repo, one from `nb`, or a plain `.txt`/`.mdx` file from an Obsidian
+    /// vault) still shows up: `Note::from_file` synthesizes metadata for
+    /// those rather than failing, so nothing here needs to skip them.
     pub fn list_dir(&self, relative: &Path) -> Result<(Vec<String>, Vec<Note>)> {
         let dir = self.path.join(relative);
         if !dir.exists() {
@@ -125,7 +141,11 @@ impl Notebook {
                 if let Some(name) = path.file_name() {
                     folders.push(name.to_string_lossy().to_string());
                 }
-            } else if path.extension().is_some_and(|ext| ext == "md") {
+            } else if path
+                .extension()
+                .and_then(|ext| ext.to_str())
+                .is_some_and(|ext| NOTE_EXTENSIONS.contains(&ext))
+            {
                 notes.push(Note::from_file_in_notebook(&path, &self.name)?);
             }
         }
@@ -226,12 +246,17 @@ impl Notebook {
         Ok(())
     }
 
-    /// Renames the note at `path`, keeping it in the same folder.
+    /// Renames the note at `path`, keeping it in the same folder and the
+    /// same file extension — a `.txt`/`.mdx` note (see `NOTE_EXTENSIONS`)
+    /// renamed from inside shiki stays a `.txt`/`.mdx` file rather than
+    /// being silently converted to `.md`, the one extension shiki itself
+    /// ever creates new notes with.
     pub fn rename_note_at(&self, path: &Path, new_title: &str) -> Result<Note> {
         let mut note = Note::from_file_in_notebook(path, &self.name)?;
         let dir = path.parent().unwrap_or(&self.path);
-        let slug = unique_slug_excluding(dir, new_title, path);
-        let new_path = dir.join(format!("{slug}.md"));
+        let ext = path.extension().and_then(|e| e.to_str()).unwrap_or("md");
+        let slug = unique_slug_excluding(dir, new_title, path, ext);
+        let new_path = dir.join(format!("{slug}.{ext}"));
         note.frontmatter.title = new_title.to_string();
         note.path = new_path;
         note.save()?;
@@ -587,6 +612,42 @@ mod tests {
 
         let result = a.copy_note_to(&note.path, &b, Path::new(""));
         assert!(matches!(result, Err(Error::DestinationExists(_))));
+    }
+
+    #[test]
+    fn list_dir_includes_txt_and_mdx_files_alongside_md() {
+        let tmp = tempfile::tempdir().unwrap();
+        let nb = test_notebook(tmp.path(), "vault");
+        nb.create_note("Shiki note", "body").unwrap();
+        std::fs::write(nb.path.join("plain.txt"), "just text").unwrap();
+        std::fs::write(nb.path.join("obsidian.mdx"), "# mdx content").unwrap();
+        std::fs::write(nb.path.join("ignored.png"), []).unwrap();
+
+        let (_, notes) = nb.list_dir(Path::new("")).unwrap();
+        let stems: Vec<String> = notes.iter().map(|n| n.file_stem()).collect();
+
+        assert!(stems.contains(&"shiki-note".to_string()));
+        assert!(stems.contains(&"plain".to_string()));
+        assert!(stems.contains(&"obsidian".to_string()));
+        assert_eq!(
+            notes.len(),
+            3,
+            "non-note extensions must be excluded: {stems:?}"
+        );
+    }
+
+    #[test]
+    fn rename_note_at_preserves_a_non_md_extension() {
+        let tmp = tempfile::tempdir().unwrap();
+        let nb = test_notebook(tmp.path(), "vault");
+        let path = nb.path.join("old-name.txt");
+        std::fs::write(&path, "content").unwrap();
+
+        let renamed = nb.rename_note_at(&path, "New Name").unwrap();
+
+        assert_eq!(renamed.path.extension().unwrap(), "txt");
+        assert!(!path.exists());
+        assert!(renamed.path.exists());
     }
 
     #[test]

--- a/shiki-tui/src/app.rs
+++ b/shiki-tui/src/app.rs
@@ -315,14 +315,17 @@ pub(crate) enum DeleteTarget {
     Notebook,
 }
 
-/// `(note path, [fg, accent, muted, link], content width, formatted lines,
-/// source-line-per-row)` — see `App::note_preview_cache`'s own doc comment
-/// for what each element means. Named only to keep clippy's
-/// `type_complexity` lint quiet; still just a plain tuple everywhere it's
-/// used.
+/// `(note path, [fg, accent, muted, link, bg], content width, formatted
+/// lines, source-line-per-row)` — see `App::note_preview_cache`'s own doc
+/// comment for what each element means. `bg` rides along in the same array
+/// purely so it participates in the cache-key equality check (it drives
+/// `render::is_dark_color`, which picks the syntect syntax-highlighting
+/// theme for code fences) without a whole extra tuple field. Named only to
+/// keep clippy's `type_complexity` lint quiet; still just a plain tuple
+/// everywhere it's used.
 type NotePreviewCache = (
     std::path::PathBuf,
-    [Color; 4],
+    [Color; 5],
     u16,
     Vec<Line<'static>>,
     Vec<usize>,
@@ -1684,6 +1687,7 @@ impl App {
             hex_to_color(&self.theme.accent),
             hex_to_color(&self.theme.muted),
             hex_to_color(&self.theme.link),
+            hex_to_color(&self.theme.bg),
         ];
         let width = layout::split(self.last_frame_area, self.focus)
             .preview
@@ -1697,8 +1701,9 @@ impl App {
             return;
         }
         let body = note.body.clone();
+        let dark = crate::render::is_dark_color(colors[4]);
         let indexed = crate::render::markdown_to_lines_indexed(
-            &body, colors[0], colors[1], colors[2], colors[3],
+            &body, colors[0], colors[1], colors[2], colors[3], dark,
         );
         let (source_indices, plain_lines): (Vec<usize>, Vec<Line<'static>>) =
             indexed.into_iter().unzip();

--- a/shiki-tui/src/lib.rs
+++ b/shiki-tui/src/lib.rs
@@ -21,6 +21,7 @@ pub mod render;
 pub mod slash_menu;
 pub mod status_bar;
 pub(crate) mod sync;
+pub(crate) mod syntax;
 pub mod tree;
 pub mod which;
 pub mod wrap;

--- a/shiki-tui/src/render.rs
+++ b/shiki-tui/src/render.rs
@@ -49,6 +49,25 @@ pub fn git_status_suffix(gs: &shiki_core::git::GitStatus) -> String {
     extras
 }
 
+/// Whether a resolved theme color reads as "dark" (perceptual luminance
+/// under half) — used to pick a syntect syntax-highlighting theme
+/// (`syntax::CodeHighlighter`) that won't clash with the active shiki theme
+/// (e.g. a light-on-light syntect theme under catppuccin-latte). `Reset`
+/// (the "default" theme's un-set background) defaults to `true` — most
+/// terminals default to a dark background, and a wrong guess here only
+/// affects code-fence coloring, not correctness.
+pub fn is_dark_color(color: Color) -> bool {
+    match color {
+        Color::Rgb(r, g, b) => {
+            let luminance = 0.299 * r as f32 + 0.587 * g as f32 + 0.114 * b as f32;
+            luminance < 128.0
+        }
+        Color::Black | Color::DarkGray => true,
+        Color::White | Color::Gray => false,
+        _ => true,
+    }
+}
+
 /// Converts a theme color slot to `ratatui::Color`. Accepts `#rrggbb` hex
 /// (every built-in palette), the terminal's native ANSI names, or `"reset"`
 /// to inherit whatever the terminal's own default color is — that's what
@@ -365,8 +384,9 @@ pub fn markdown_to_lines(
     accent: Color,
     muted: Color,
     link: Color,
+    dark: bool,
 ) -> Vec<Line<'static>> {
-    markdown_to_lines_indexed(body, fg, accent, muted, link)
+    markdown_to_lines_indexed(body, fg, accent, muted, link, dark)
         .into_iter()
         .map(|(_, line)| line)
         .collect()
@@ -388,6 +408,7 @@ pub fn markdown_to_lines_indexed(
     accent: Color,
     muted: Color,
     link: Color,
+    dark: bool,
 ) -> Vec<(usize, Line<'static>)> {
     let heading = Style::default().fg(accent).add_modifier(Modifier::BOLD);
     let text = Style::default().fg(fg);
@@ -401,17 +422,56 @@ pub fn markdown_to_lines_indexed(
 
     let mut in_code_block = false;
     let mut in_math_block = false;
+    let mut code_lang: Option<String> = None;
+    let mut code_highlighter: Option<crate::syntax::CodeHighlighter> = None;
     let mut lines: Vec<(usize, Line<'static>)> = Vec::new();
 
     let mut source = body.lines().enumerate().peekable();
     while let Some((idx, line)) = source.next() {
         if line.trim_start().starts_with("```") {
             in_code_block = !in_code_block;
-            lines.push((idx, Line::from(Span::styled(line.to_string(), dim))));
+            if in_code_block {
+                let lang = line
+                    .trim_start()
+                    .trim_start_matches("```")
+                    .trim()
+                    .to_ascii_lowercase();
+                code_highlighter = if lang.is_empty() || lang == "mermaid" {
+                    None
+                } else {
+                    crate::syntax::CodeHighlighter::new(&lang, dark)
+                };
+                // The opening fence line itself gets a distinct style when
+                // the language is recognized (real highlighting follows) or
+                // is a mermaid diagram (styled like the math-block accent
+                // below, not the flat code dim — a terminal can't render an
+                // actual diagram, but at least the fence reads as "special"
+                // rather than indistinguishable from an unrecognized one).
+                let fence_style = if lang == "mermaid" {
+                    math
+                } else if crate::syntax::is_known_language(&lang) {
+                    heading
+                } else {
+                    dim
+                };
+                code_lang = Some(lang);
+                lines.push((idx, Line::from(Span::styled(line.to_string(), fence_style))));
+            } else {
+                code_highlighter = None;
+                code_lang = None;
+                lines.push((idx, Line::from(Span::styled(line.to_string(), dim))));
+            }
             continue;
         }
         if in_code_block {
-            lines.push((idx, Line::from(Span::styled(line.to_string(), dim))));
+            let rendered = if code_lang.as_deref() == Some("mermaid") {
+                Line::from(Span::styled(line.to_string(), math))
+            } else if let Some(hl) = code_highlighter.as_mut() {
+                Line::from(hl.highlight(line))
+            } else {
+                Line::from(Span::styled(line.to_string(), dim))
+            };
+            lines.push((idx, rendered));
             continue;
         }
         if line.trim_start().starts_with("$$") {
@@ -623,7 +683,7 @@ mod tests {
 
     #[test]
     fn bold_inside_a_blockquote_is_still_bold_not_literal_asterisks() {
-        let lines = markdown_to_lines("> **Warning:** be careful", FG, ACCENT, MUTED, LINK);
+        let lines = markdown_to_lines("> **Warning:** be careful", FG, ACCENT, MUTED, LINK, true);
         assert_eq!(lines.len(), 1);
         let full = line_text(&lines[0]);
         assert!(!full.contains('*'), "asterisks must not survive: {full:?}");
@@ -655,14 +715,14 @@ mod tests {
 
     #[test]
     fn horizontal_rule_renders_as_a_visible_divider() {
-        let lines = markdown_to_lines("above\n---\nbelow", FG, ACCENT, MUTED, LINK);
+        let lines = markdown_to_lines("above\n---\nbelow", FG, ACCENT, MUTED, LINK, true);
         assert_eq!(line_text(&lines[1]), "─".repeat(40));
     }
 
     #[test]
     fn table_renders_aligned_columns_with_a_header_rule() {
         let body = "| Name | Age |\n| --- | --- |\n| Alice | 30 |\n| Bo | 7 |";
-        let lines = markdown_to_lines(body, FG, ACCENT, MUTED, LINK);
+        let lines = markdown_to_lines(body, FG, ACCENT, MUTED, LINK, true);
         // header row + divider row + 2 body rows = 4 lines, no leftover
         // raw `|---|` separator line rendered literally.
         assert_eq!(lines.len(), 4);
@@ -682,7 +742,7 @@ mod tests {
     fn table_like_prose_without_a_real_separator_is_left_alone() {
         // A single line with pipes (e.g. a shell example) but no valid
         // `---`-only separator row after it must not trigger table mode.
-        let lines = markdown_to_lines("ls | grep foo | wc -l", FG, ACCENT, MUTED, LINK);
+        let lines = markdown_to_lines("ls | grep foo | wc -l", FG, ACCENT, MUTED, LINK, true);
         assert_eq!(lines.len(), 1);
         assert_eq!(line_text(&lines[0]), "ls | grep foo | wc -l");
     }
@@ -690,7 +750,7 @@ mod tests {
     #[test]
     fn details_summary_is_shown_expanded_with_tags_stripped() {
         let body = "<details>\n<summary>Click to expand</summary>\nhidden content\n</details>";
-        let lines = markdown_to_lines(body, FG, ACCENT, MUTED, LINK);
+        let lines = markdown_to_lines(body, FG, ACCENT, MUTED, LINK, true);
         // <details>/</details> themselves produce no line; summary becomes
         // a styled header; the body content still renders normally.
         assert_eq!(lines.len(), 2);
@@ -701,7 +761,7 @@ mod tests {
     #[test]
     fn math_block_is_styled_distinctly_from_code_block() {
         let body = "$$\nx = y\n$$";
-        let lines = markdown_to_lines(body, FG, ACCENT, MUTED, LINK);
+        let lines = markdown_to_lines(body, FG, ACCENT, MUTED, LINK, true);
         assert_eq!(lines.len(), 3);
         // Content line inside the math block uses `accent`, not `muted`
         // (which code fences use) — the whole point of the distinction.

--- a/shiki-tui/src/syntax.rs
+++ b/shiki-tui/src/syntax.rs
@@ -1,0 +1,139 @@
+//! Real syntax highlighting for fenced code blocks in the PREVIEW panel,
+//! via `syntect`. Before this existed, every code fence rendered as flat
+//! dimmed text (see `render.rs`'s `markdown_to_lines_indexed`) — the same
+//! visual treatment as a blockquote, with no per-token color at all despite
+//! `syntect` already being a workspace dependency.
+//!
+//! `SyntaxSet`/`ThemeSet` are process-wide, loaded once behind `OnceLock`
+//! (both are non-trivial to build — they parse a bundle of `.sublime-syntax`/
+//! `.tmTheme` files) and never rebuilt, same "expensive walk once" discipline
+//! as `App`'s various `refresh_*_cache` methods.
+
+use std::sync::OnceLock;
+
+use ratatui::style::{Color, Modifier, Style};
+use ratatui::text::Span;
+use syntect::easy::HighlightLines;
+use syntect::highlighting::{FontStyle, ThemeSet};
+use syntect::parsing::{SyntaxReference, SyntaxSet};
+
+fn syntax_set() -> &'static SyntaxSet {
+    static SET: OnceLock<SyntaxSet> = OnceLock::new();
+    SET.get_or_init(SyntaxSet::load_defaults_newlines)
+}
+
+fn theme_set() -> &'static ThemeSet {
+    static SET: OnceLock<ThemeSet> = OnceLock::new();
+    SET.get_or_init(ThemeSet::load_defaults)
+}
+
+/// Picks a bundled syntect theme by the *app* theme's own background
+/// luminance, so a code block reads as dark-on-dark or light-on-light
+/// consistent with whichever shiki theme is active (e.g. catppuccin-latte)
+/// rather than a single fixed syntect theme clashing with a light palette.
+fn syntect_theme_name(dark: bool) -> &'static str {
+    if dark {
+        "base16-ocean.dark"
+    } else {
+        "InspiredGitHub"
+    }
+}
+
+fn find_syntax<'a>(set: &'a SyntaxSet, lang: &str) -> Option<&'a SyntaxReference> {
+    set.find_syntax_by_token(lang)
+        .or_else(|| set.find_syntax_by_extension(lang))
+}
+
+/// Whether `lang` (a fence's info-string language tag, already lowercased)
+/// is one `syntect`'s bundled syntax defs actually recognize — checked
+/// up front so the fence-language line itself can be styled to signal
+/// "this will be highlighted" vs. "this falls back to plain dimmed text".
+pub(crate) fn is_known_language(lang: &str) -> bool {
+    !lang.is_empty() && find_syntax(syntax_set(), lang).is_some()
+}
+
+/// One code fence's worth of incremental highlighter state: created when a
+/// ` ```lang ` fence with a recognized language opens, fed one source line
+/// at a time in order, dropped the moment the fence closes. `syntect`'s
+/// `HighlightLines` keeps internal parse-stack state across lines (needed
+/// for correct highlighting of multi-line constructs like block comments),
+/// so it can't be recreated per-line — this struct exists specifically to
+/// carry that state across `markdown_to_lines_indexed`'s line-by-line loop.
+pub(crate) struct CodeHighlighter {
+    highlighter: HighlightLines<'static>,
+}
+
+impl CodeHighlighter {
+    /// `None` if `lang` isn't recognized — the caller falls back to the
+    /// plain dimmed-text style code fences always used before this existed.
+    pub(crate) fn new(lang: &str, dark: bool) -> Option<Self> {
+        let set = syntax_set();
+        let syntax = find_syntax(set, lang)?;
+        let theme = theme_set().themes.get(syntect_theme_name(dark))?;
+        Some(Self {
+            highlighter: HighlightLines::new(syntax, theme),
+        })
+    }
+
+    /// Tokenizes one source line (no trailing newline) into styled spans.
+    /// `syntect` expects a trailing `\n` for some syntaxes to parse
+    /// correctly (multi-line comments, doc strings), so one is appended
+    /// before highlighting and stripped back off the last span afterward.
+    pub(crate) fn highlight(&mut self, line: &str) -> Vec<Span<'static>> {
+        let with_newline = format!("{line}\n");
+        let Ok(ranges) = self.highlighter.highlight_line(&with_newline, syntax_set()) else {
+            return vec![Span::styled(line.to_string(), Style::default())];
+        };
+        ranges
+            .into_iter()
+            .map(|(style, text)| {
+                let text = text.strip_suffix('\n').unwrap_or(text);
+                let fg = Color::Rgb(style.foreground.r, style.foreground.g, style.foreground.b);
+                let mut modifier = Modifier::empty();
+                if style.font_style.contains(FontStyle::BOLD) {
+                    modifier |= Modifier::BOLD;
+                }
+                if style.font_style.contains(FontStyle::ITALIC) {
+                    modifier |= Modifier::ITALIC;
+                }
+                if style.font_style.contains(FontStyle::UNDERLINE) {
+                    modifier |= Modifier::UNDERLINED;
+                }
+                Span::styled(
+                    text.to_string(),
+                    Style::default().fg(fg).add_modifier(modifier),
+                )
+            })
+            .collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn known_language_is_recognized() {
+        assert!(is_known_language("rust"));
+        assert!(is_known_language("rs"));
+        assert!(is_known_language("python"));
+    }
+
+    #[test]
+    fn unknown_language_falls_back() {
+        assert!(!is_known_language(""));
+        assert!(!is_known_language("not-a-real-language"));
+    }
+
+    #[test]
+    fn highlighter_tokenizes_a_rust_line_into_multiple_styled_spans() {
+        let mut hl = CodeHighlighter::new("rust", true).expect("rust is a known language");
+        let spans = hl.highlight("fn main() {}");
+        let full: String = spans.iter().map(|s| s.content.as_ref()).collect();
+        assert_eq!(full, "fn main() {}");
+        // A keyword and a plain identifier should not share the exact same
+        // color — that's the whole point of real syntax highlighting vs.
+        // the old flat-dim rendering.
+        assert!(spans.len() > 1, "expected more than one styled span");
+    }
+}


### PR DESCRIPTION
## Summary

- **Real syntax highlighting** for fenced code blocks in the PREVIEW panel (`shiki-tui/src/syntax.rs`), via `syntect` (a workspace dependency that was declared but never actually used). Highlighting is keyed off the fence's language tag and picks a syntect theme matching the active shiki theme's light/dark bias. ` ```mermaid ` fences get a distinct accent style instead of blending into plain dimmed text (no in-terminal diagram rendering — out of scope).
- **Scriptable CLI**: `shiki list`/`search`/`show`/`notebook list` gain `--json`. `shiki new` gains `--body`/`--stdin`/`--tags` for fully non-interactive note creation (previously every content-producing command unconditionally spawned `$EDITOR`).
- **New `shiki export`** command (`--format html|md`) bundles a notebook into a single file — HTML via `pulldown-cmark` (another previously-unused workspace dependency) with an embedded light/dark-aware stylesheet, or a plain concatenated Markdown bundle.
- **Multi-format notes**: notebooks now also list/read `.txt` and `.mdx` files, not just `.md` (`Notebook::list_dir`'s `NOTE_EXTENSIONS`) — for compatibility with existing Obsidian vaults. New notes are still always created as `.md`; renaming a `.txt`/`.mdx` note preserves its original extension instead of silently converting it to `.md`.

See `CHANGELOG.md`'s `[Unreleased]` section for the full writeup.

## Test plan

- [x] `cargo fmt --all` — clean
- [x] `cargo clippy --workspace --all-targets` — no warnings
- [x] `cargo test --workspace` — 138 passed, 0 failed
- [x] Manual smoke test: `shiki new --body/--stdin/--tags`, `shiki list/search/show --json`, `shiki notebook list --json`, `shiki export --format html/md` against a real notebook (verified output content)
- [x] Manual smoke test: dropped `.txt`/`.mdx`/`.png` files into a notebook dir, confirmed `.txt`/`.mdx` are listed and `.png` is excluded
- [ ] Manual visual check of syntax-highlighted code blocks in the actual TUI (not yet done in this session — recommend a quick look before merging)

🤖 Generated with [Claude Code](https://claude.com/claude-code)