### PR TITLE
Global tasks (TUI + CLI), terminal link graph, unlinked mentions, and daily agenda

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,44 @@ semver yet (pre-1.0), but version bumps are still meaningful and tracked here.
 
 ### Added
 
+- `shiki tasks` — the tasks view as a scriptable CLI command: pending tasks across every notebook,
+  urgency-sorted, with `--overdue`/`--today`/`--all`/`--notebook` filters, `--json` for scripting,
+  and `--count` (just the number) made for waybar/polybar/tmux status modules — e.g.
+  `shiki tasks --overdue --count` as a "2 overdue" bar widget.
+- `shiki graph` — the `[[wikilink]]` connection graph drawn right in the terminal: a deterministic
+  force-directed layout (Fruchterman–Reingold on a char canvas) where hubs (`◉`) pull their linked
+  notes around them, edges render as `╱╲─│` lines, and orphans (`○`, notes with no links in or
+  out) drift free and are listed below. `--notebook` scopes it, `--width` overrides the canvas,
+  `--json` emits nodes/edges/orphans for graphviz/d3/gephi, and graphs past 60 notes show the
+  most-connected ones rather than an unreadable hairball.
+- Daily notes now open with today's agenda: on first creation each day, a "## Due today" section
+  is appended after the template listing every pending task due today or overdue across every
+  notebook — plain bullets with a `[[wikilink]]` back to each task's source note (deliberately not
+  checkbox copies, which would double-count in the tasks view). Reopening an existing daily never
+  re-injects or duplicates it. Works in both the TUI (`t`) and `shiki daily`.
+- Relative due dates: `@due(tomorrow)`, `@due(+3d)`, `@due(+2w)`, `@due(fri)` (next such weekday)
+  are pinned to their resolved `@due(YYYY-MM-DD)` form the moment the note is saved — inline or
+  external editor — since a relative spec is relative to the day it was written. ISO dates and
+  unrecognized specs are left byte-for-byte untouched.
+- `c` in the links modal on a "Mentions (unlinked)" row repairs the missed link: the mentioning
+  note's plain-text mention is wrapped into a real `[[wikilink]]` in place (preserving its casing,
+  skipping text already inside links), and the row visibly migrates to Backlinks.
+
+- Global tasks view (leader+`t`): every `- [ ]` checkbox task across every notebook in one modal,
+  sorted by urgency (overdue first, then due today, then future, then undated), each row showing
+  its location (`notebook/folders…/note title`) muted alongside the task so it's never lost while
+  scrolling. `Enter`/`space` toggles a task directly in its source file (the edit flows through
+  the same git/auto-sync machinery as any other note change), `l`/`o` jumps to the note it lives
+  in, `a` also shows already-completed tasks. Tasks support an optional `@due(YYYY-MM-DD)` tag —
+  overdue dates render in the theme's error color, today's in warning, future ones muted.
+- `shiki doctor` now includes the new `links`/`tasks_panel` global keybindings in its collision
+  check — a config that customized `theme_picker = "t"` (colliding with the new tasks default)
+  gets flagged instead of one of the two actions silently not working.
+- Unlinked mentions in the links modal: notes that mention the current note's title in plain text
+  without actually `[[linking]]` to it get their own "Mentions (unlinked)" section under
+  Backlinks — candidate links you probably meant to make, jumpable like any backlink.
+- The links modal is now reachable globally via leader+`B` from any panel, not only through
+  PREVIEW's own `L` binding.
 - `shiki notebook delete <name> --yes` — the CLI had no way to delete a notebook at all, despite
   the TUI supporting it; `--yes` is required (mirrors the TUI's own confirm dialog) since this
   permanently removes the notebook's directory and every note in it.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -688,6 +688,105 @@ the links modal's (`leader+L`) existing jump handler specifically so this featur
 it — an unresolved link (no matching note) reports that in the status message rather than jumping
 anywhere or erroring.
 
+**The links modal has a third section, "Mentions (unlinked)" (`wikilinks::unlinked_mentions` +
+`LinkRow::Mention`), and is reachable globally via leader+`B`, not only PREVIEW's `L`.** A mention
+is a note whose body contains the current note's title as plain text (case-insensitive substring)
+without actually `[[linking]]` to it — notes that already link are excluded even if they *also*
+mention the title elsewhere, since they're backlinks, not missed links. The global binding is the
+same `Action::ShowLinks` bound in both the `global` and `preview` scope maps (two entries in
+which-key, one handler) — `open_links` already guards on "select a note first", so resolving it
+from any focus was free. Mentions render muted with a search icon, deliberately weaker-looking
+than a real backlink, because they're candidates, not facts.
+
+**The global tasks view (leader+`t`, `shiki-core/src/tasks.rs` + `shiki-tui/src/panel_tasks.rs` +
+`App::open_tasks`/`handle_tasks_key`) toggles checkboxes in the source file by *content address*,
+never by line index.** `tasks::extract(body)` is a pure function (unit-tested without I/O) finding
+`- [ ]`/`- [x]` lines plus an optional `@due(YYYY-MM-DD)` tag (malformed dates are just text, not
+errors); each `Task` carries its exact `raw_line` and its `occurrence` index among *identical*
+lines, and `tasks::toggle(path, raw_line, occurrence)` re-reads the file fresh and matches on
+those — a stored line number would be invalidated by any edit between building the list and
+toggling (the modal sits open indefinitely while background syncs/external edits can rewrite the
+file; a vanished line is a clear `Error::TaskNotFound`, not a flip of whatever line ended up at
+that index). Lines inside the leading `---` frontmatter block are excluded from occurrence
+counting on both sides, so YAML that happens to look like a checkbox can't shift the count.
+`toggle` returns `Toggled { done, raw_line, occurrence }` — the flipped line's *new* address, which
+the TUI writes back into the row so a second toggle of the same row matches the file's new content
+(the returned occurrence matters in the edge where the flip makes the line identical to a
+pre-existing twin). Toggling updates the row **in place**, deliberately not a rebuild: with the
+default pending-only filter a rebuild would make a just-checked task vanish out from under the
+cursor with no way to immediately un-toggle it. Each toggle is a real note edit and is routed
+through `refresh_notes_preserve_selection()` + `note_changed(notebook)` so panels/caches refresh
+and auto_sync counts it like any other save. `panel_tasks::TaskRow` is a **flat list, not the
+header-interspersed shape links/tree use** — it started as the `LinkRow`-style
+headers-plus-`selected_row`-mapping design, and was flattened after Omar asked for each task to
+say where it lives: a per-note header scrolls out of view while its tasks are still on screen, so
+every row carries its own muted `location` (`"{notebook}/{folders…}/{note title}"`, human title
+not file slug, matching the NOTES panel) instead. Rows are sorted by urgency —
+`sort_by_key(|r| (due.is_none(), due))`, dated-ascending first then undated in walk order (the
+`is_none` flip matters: `Option`'s derived ordering would otherwise float `None` *above* overdue) —
+built from the same `NotebookStore::all_notes` walk global search uses; the cross-notebook jump
+(`l`/`o`, `jump_to_task_note`) mirrors `jump_to_global_hit`. Due dates color by urgency (overdue →
+`theme.error`, today → `theme.warning`, else muted; a *done* task's date is always muted — no
+longer actionable). Note the default keys don't collide despite both being `t`: leader+`t` (tasks)
+resolves against the `global` map, NOTES-scope `t` (daily note) against the `notes` map. But a
+*user's own* config can collide — Omar's real config had `theme_picker = "t"` (a personal
+customization; the shipped default was always `"c"`), which silently lost to `tasks_panel`'s new
+default since `KeyMaps::from_config` binds into a plain `HashMap` where the last insert wins.
+**`shiki doctor`'s keybinding-collision check is a hardcoded field list
+(`doctor.rs`'s `scopes` array), not derived from the config struct — any new keybinding field must
+be added there by hand or collisions on it are invisible to doctor**, which is exactly how the
+`theme_picker`/`tasks_panel` clash went undetected until it was hit live (fixed: both `links` and
+`tasks_panel` are in the list now, and doctor flags that config with "are all bound to the same
+key — only one of them actually works").
+
+**`shiki tasks`/`shiki graph` (CLI) and the TUI tasks modal share their formatting through
+shiki-core, not by parallel implementations.** `tasks::location_of` is the single source of the
+`"{notebook}/{folders…}/{title}"` string both show (same extraction as `git_status_color` being
+shared by footer+drawer — two surfaces describing the same thing must go through one function).
+`shiki tasks --count` exists specifically for status bars (waybar/polybar/tmux) and prints *only*
+a number; `--json` includes a precomputed `overdue` bool per task so a bar script doesn't need to
+re-derive date math. `shiki graph` (`shiki-cli/src/commands/graph.rs`) renders
+`wikilinks::edges`/`orphans` via a **deterministic** Fruchterman–Reingold layout — seeded by a
+golden-angle spiral, no RNG, so the same notebook draws the same picture every run (a graph that
+reshuffles per invocation reads as noise). Y-distances are weighted 2× during force calculation to
+compensate for terminal cells being ~2:1 tall:wide, else clusters render vertically squashed.
+Edges draw first and only into `Cell::Empty`; node markers and labels always win. Graphs past
+`MAX_NODES` (60) keep only the most-connected notes and say so. Links never resolve across
+notebooks (title resolution is per-notebook by construction), so the all-notebooks graph is
+naturally disjoint clusters — don't "fix" that by resolving titles globally; two notebooks can
+legitimately have different notes with the same title.
+
+**Relative `@due` specs are pinned at save time, never at read time** —
+`tasks::parse_relative_due`/`normalize_due_tags` (`tomorrow`/`tom`, `+N`/`+Nd`/`+Nw`, weekday
+names meaning *next* such weekday, never today). A relative spec is relative to the day it was
+written, so read-time interpretation would silently shift the date every day the note stays open.
+Both save paths normalize: `save_and_exit_edit`'s note branch (body only) and the external-edit
+finalize in `run()` (re-reads the file, rewrites only if something actually normalized). `extract`
+itself stays ISO-only on purpose — a file edited outside shiki keeps its relative spec as plain
+text (due=None) until some shiki save path touches it, rather than shiki guessing a base date.
+ISO dates and unrecognized junk are left byte-for-byte untouched: normalization only resolves,
+never invents.
+
+**The daily note's "## Due today" agenda (`tasks::agenda_section`) is injected only on creation,
+and deliberately as plain bullets + `[[wikilinks]]`, not checkbox copies** — a `- [ ]` copy would
+be extracted as a second, independent task (double-counted in the tasks view, and checking the
+copy wouldn't complete the original). `daily::create_or_open` takes `agenda: Option<&str>` and
+ignores it entirely when the daily already exists, so reopening later in the day can't duplicate
+the section or clobber edits. Both callers (TUI `create_daily_note`, CLI `commands/daily.rs`)
+build it from `store.all_notes()` — the agenda spans every notebook, not just the daily's own.
+Known accepted wart: a cross-notebook task's `[[link]]` won't resolve from the daily's notebook
+(resolution is notebook-scoped); the bullet still names the note.
+
+**`c` in the links modal (`link_selected_mention` → `wikilinks::link_mention`) repairs a mention
+into a real link, editing the *mentioning* note's file in place.** `link_mention` wraps the first
+plain-text occurrence outside existing `[[...]]` spans (skipping frontmatter), preserving the
+mention's own casing — the resolver is case-insensitive so `[[proyecto shiki]]` still resolves to
+"Proyecto shiki". Byte offsets found on a lowercased copy are re-verified against the original
+before use (`find_unlinked`'s doc comment explains the exotic-codepoint shift risk). After a
+successful link the modal rebuilds via `open_links`, so the row visibly migrates from Mentions to
+Backlinks; `Ok(false)` ("nothing linkable left") is a status message, not an error — it means the
+file changed since the mention was detected.
+
 **The theme picker's `Enter` (and `shiki theme set`) only reset `config.theme.overrides` when the
 base theme name is actually *changing*, not on every confirm/set.** Both used to zero out
 `ThemeOverrides` unconditionally — even re-confirming the theme that was already active with no

--- a/IDEA.md
+++ b/IDEA.md
@@ -206,6 +206,8 @@ search, tree view) using the same list/selection they already navigate with `j`/
 | `b` | Notebook drawer — left-side sidebar, every notebook's git status in color (dirty/ahead/behind); `j`/`k` or click a row to jump to it, `n`/click "New" to create a notebook, `i`/click "Import" to clone from a pasted URL, `Esc`/`b` again closes |
 | `e` | Toggle `general.use_favorite_editor` on/off and persist it immediately — no need to hand-edit config.toml. The footer always shows which mode is active: the resolved editor name (e.g. `nvim`) when on, `native` (the built-in inline editor) when off |
 | `p` | Scratchpad — open an in-memory editor; `Ctrl+S` saves its contents through the new-note title/template flow, while `Esc` discards it |
+| `B` | Links — the same modal as PREVIEW's `L` (outgoing wikilinks / backlinks / unlinked mentions for the selected note), reachable from any panel without focusing PREVIEW first |
+| `t` | Tasks — every `- [ ]` checkbox task across every notebook in one flat list, pending-only by default, sorted by urgency (overdue → due today → future → undated); every row carries its own muted location (`notebook/folders…/note title`) so where a task lives is always visible, even mid-scroll. `Enter`/`space` toggles the task directly in its source file (a normal note edit — flows through auto-sync like any other change) and updates the row in place so it can be immediately un-toggled; `l`/`o` jumps to the note; `a` also shows completed tasks. An optional `@due(YYYY-MM-DD)` tag anywhere in the task text renders the date next to it: overdue in the theme's error color, due today in warning, future in muted. Relative specs — `@due(tomorrow)`, `@due(+3d)`, `@due(+2w)`, `@due(fri)` — are pinned to the real date the moment the note is saved (inline or external editor), since they're relative to the day they were written. Also scriptable as `shiki tasks` (see CLI commands) |
 | `U` | Check for updates — modal; checks GitHub Releases in the background (never blocks the UI), shows "update available" if there's a newer version, and `Enter` downloads, verifies (against GitHub's own per-asset checksum), installs, and automatically relaunches into it |
 | `u` | Undo the last delete — restores the most recently deleted note/folder (or whole batch, from a Visual-mode delete) from the trash (`~/.config/shiki/trash/`) back to exactly where it came from. A single level of undo, not a full history: only the *most recent* delete is restorable this way; an older one is still on disk in the trash, just no longer reachable from here. With nothing to undo, reports that instead of doing anything |
 | `s` | Settings — near-full-screen, paged by tab (`←`/`→` switches GENERAL/THEME/GIT/EDITOR/NOTEBOOKS/SNIPPETS, `j`/`k` moves within one). Doesn't repeat the keybindings tables — `?` (which-key) already covers those live. Every tab is editable with `Enter`: GENERAL/GIT booleans (`use_favorite_editor`, `auto_commit`/`auto_push`/`sign_commits`/`auto_sync`) toggle in place and save immediately; every other GENERAL/GIT field opens a prompt prefilled with its current value; THEME's `name` opens the theme picker (live preview, same as leader+`c`) and `overrides` stays informational; EDITOR is six plain boolean toggles for the native note editor's UX (see `[editor]` below); NOTEBOOKS lists every notebook's actual git remote (redacted) and drills into one to edit its remote plus its `auto_push`/`auto_sync`/`auto_sync_every` overrides (booleans cycle inherit → true → false → inherit); SNIPPETS supports `a` (new snippet) and `d` (delete, with confirmation), and drilling into one edits its `label` and its full multi-line `body` through the same inline editor a note's own body uses. `i`/`E` still jump straight to editing `config.toml` itself for anything not covered above (inline or externally, same convention as editing a note); on save, the config is re-read, re-applied, and takes effect immediately (no restart) — an invalid edit is reported and neither written nor applied, keeping the previous config running. `h`/`Esc`/`Backspace` backs out of a drilled-into notebook/snippet a level; `Esc`/`q` at the top level closes |
@@ -243,7 +245,7 @@ sync attempt (manual or automatic) just tries the push again.
 | `i` | Edit inline (or the OS favorite editor if `general.use_favorite_editor`) |
 | `E` | Edit externally ($EDITOR) |
 | `/` | Fuzzy-jump to a note by title anywhere in the current notebook (any folder depth) |
-| `t` | New/open today's daily note |
+| `t` | New/open today's daily note. On first creation each day, a "## Due today" section is appended after the template with every pending task due today or overdue, across every notebook — plain bullets with a `[[wikilink]]` back to each task's source note (deliberately not checkbox copies, which would double-count in the tasks view). Reopening later never re-injects or duplicates it |
 | `m` | Move the selected note *or* folder — prompts for a `notebook/path/within/it` target, prefilled with the current one; edit the trailing segments to move within the same notebook (missing folders are created), or replace the first segment to move to a different (existing) notebook. In `v` select mode, moves every selected item at once |
 | `o` | Cycle sort order (filename / title A-Z / date newest-first) |
 | `T` | Tree view — every folder and note in the notebook, fully expanded, in one scrollable overview; `j`/`k` move, `enter`/`l` jumps straight to the selected note, `esc`/`q` closes |
@@ -258,7 +260,7 @@ sync attempt (manual or automatic) just tries the push again.
 | `i` | Edit inline (or the OS favorite editor if `general.use_favorite_editor`) |
 | `E` | Edit externally ($EDITOR) |
 | `H` | Note history — every commit that changed this specific note, newest first, real git history (not a separate versioning system). `j`/`k`/`PageUp`/`PageDown`/`Home`/`End` move, `Enter` views a revision's full content (frontmatter included, since that's what's actually in the commit), `r` reverts to the highlighted (or currently-viewed) revision — behind a confirmation, since it overwrites the current content. The revert itself doesn't commit; it shows up as a normal pending change, picked up by `s`/`u`/`auto_sync` like any other edit. The footer shows the count while reading a note (`{n} changes`) |
-| `L` | Links — the selected note's outgoing `[[wikilinks]]` (resolved against every note in the notebook, any folder depth) plus every other note that links back to it ("Outgoing"/"Backlinks" sections; a section with nothing in it is omitted). `j`/`k`/`PageUp`/`PageDown`/`Home`/`End` move, `Enter` jumps to the selected note (an unresolved outgoing link reports that instead of jumping), `Esc`/`q` closes |
+| `L` | Links — the selected note's outgoing `[[wikilinks]]` (resolved against every note in the notebook, any folder depth), every other note that links back to it, and notes that *mention* this note's title in plain text without linking to it ("Outgoing"/"Backlinks"/"Mentions (unlinked)" sections; a section with nothing in it is omitted). `j`/`k`/`PageUp`/`PageDown`/`Home`/`End` move, `Enter` jumps to the selected note (an unresolved outgoing link reports that instead of jumping), `c` on a mention row *repairs* the missed link — it wraps that note's plain-text mention into a real `[[wikilink]]` (preserving its casing) and the row visibly migrates to Backlinks — and `Esc`/`q` closes. Also reachable globally via leader+`B` |
 
 Mouse: a plain click over a note's rendered body jumps straight into the inline editor with the
 cursor on the clicked line — a mouse-only alternative to `i`/vim motions. Click-and-drag instead
@@ -342,6 +344,11 @@ shiki list -n work        # list notes in "work"
 shiki show <note>         # show rendered content (ANSI)
 shiki edit <note>         # edit with $EDITOR
 shiki search <query>      # search and show results
+shiki tasks               # every pending checkbox task across notebooks, urgency-sorted
+shiki tasks --overdue --count  # just the number — made for waybar/polybar/tmux status modules
+shiki tasks --today --json     # machine-readable, with due/overdue/location per task
+shiki graph               # [[wikilink]] connection graph, force-directed, drawn in the terminal
+shiki graph -n work --json     # nodes/edges/orphans as JSON, for graphviz/d3/gephi
 shiki sync                # git commit+push default notebook
 shiki sync -n work        # git sync in "work"
 shiki config              # show config path
@@ -498,6 +505,11 @@ check_update = "U"
 drawer = "b"
 undo_delete = "u"
 settings = "s"
+scratchpad = "p"
+# Same links modal as [keybindings.preview]'s own binding, from any panel.
+links = "B"
+# Global tasks view — every checkbox task in every notebook.
+tasks_panel = "t"
 
 [keybindings.notebooks]
 new = "a"

--- a/docs/documentation.html
+++ b/docs/documentation.html
@@ -297,6 +297,9 @@
           <tr><td><code>U</code></td><td>Check for updates — modal; checks GitHub Releases in the background (never blocks the UI), shows "update available" if there's a newer version, and Enter downloads, verifies (against GitHub's own per-asset checksum), installs, and automatically relaunches into it</td></tr>
           <tr><td><code>u</code></td><td>Undo the last delete — restores the most recently deleted note/folder (or whole batch, from a Visual-mode delete) from the trash (<code>~/.config/shiki/trash/</code>) back to exactly where it came from. A single level of undo, not a full history: only the <em>most recent</em> delete is restorable this way; an older one is still on disk in the trash, just no longer reachable from here. With nothing to undo, reports that instead of doing anything</td></tr>
           <tr><td><code>s</code></td><td>Settings — near-full-screen, paged by tab. See <a href="#settings-deep-dive">the Settings deep dive</a> below</td></tr>
+          <tr><td><code>p</code></td><td>Scratchpad — open an in-memory editor; <code>Ctrl+S</code> saves its contents through the new-note title/template flow, while <code>Esc</code> discards it</td></tr>
+          <tr><td><code>B</code></td><td>Links — the same modal as PREVIEW's <code>L</code> (outgoing wikilinks / backlinks / unlinked mentions for the selected note), reachable from any panel without focusing PREVIEW first</td></tr>
+          <tr><td><code>t</code></td><td>Tasks — every <code>- [ ]</code> checkbox task across every notebook in one flat list, pending-only by default, sorted by urgency (overdue → due today → future → undated); every row carries its own muted location (<code>notebook/folders…/note title</code>) so where a task lives is always visible, even mid-scroll. <code>Enter</code>/<code>space</code> toggles the task directly in its source file and updates the row in place; <code>l</code>/<code>o</code> jumps to the note; <code>a</code> also shows completed tasks. An optional <code>@due(YYYY-MM-DD)</code> tag renders the date next to the task: overdue in the theme's error color, due today in warning, future in muted. Relative specs — <code>@due(tomorrow)</code>, <code>@due(+3d)</code>, <code>@due(+2w)</code>, <code>@due(fri)</code> — are pinned to the real date the moment the note is saved. Also scriptable as <code>shiki tasks</code> (see CLI commands)</td></tr>
         </tbody>
       </table>
 
@@ -372,7 +375,7 @@
           <tr><td><code>i</code></td><td>Edit inline (or the OS favorite editor if <code>general.use_favorite_editor</code>)</td></tr>
           <tr><td><code>E</code></td><td>Edit externally ($EDITOR)</td></tr>
           <tr><td><code>/</code></td><td>Fuzzy-jump to a note by title anywhere in the current notebook (any folder depth)</td></tr>
-          <tr><td><code>t</code></td><td>New/open today's daily note</td></tr>
+          <tr><td><code>t</code></td><td>New/open today's daily note. On first creation each day, a "Due today" section is appended after the template with every pending task due today or overdue, across every notebook — plain bullets linking back to each task's source note. Reopening later never re-injects or duplicates it</td></tr>
           <tr><td><code>m</code></td><td>Move the selected note <em>or</em> folder — prompts for a <code>notebook/path/within/it</code> target, prefilled with the current one; edit the trailing segments to move within the same notebook (missing folders are created), or replace the first segment to move to a different (existing) notebook. In <code>v</code> select mode, moves every selected item at once</td></tr>
           <tr><td><code>o</code></td><td>Cycle sort order (filename / title A-Z / date newest-first)</td></tr>
           <tr><td><code>T</code></td><td>Tree view — every folder and note in the notebook, fully expanded, in one scrollable overview; <code>j</code>/<code>k</code> move, <code>enter</code>/<code>l</code> jumps straight to the selected note, <code>esc</code>/<code>q</code> closes</td></tr>
@@ -393,7 +396,7 @@
           <tr><td><code>i</code></td><td>Edit inline (or the OS favorite editor if <code>general.use_favorite_editor</code>)</td></tr>
           <tr><td><code>E</code></td><td>Edit externally ($EDITOR)</td></tr>
           <tr><td><code>H</code></td><td>Note history — every commit that changed this specific note, newest first, real git history (not a separate versioning system). <code>j</code>/<code>k</code>/<code>PageUp</code>/<code>PageDown</code>/<code>Home</code>/<code>End</code> move, <code>Enter</code> views a revision's full content (frontmatter included, since that's what's actually in the commit), <code>r</code> reverts to the highlighted (or currently-viewed) revision — behind a confirmation, since it overwrites the current content. The revert itself doesn't commit; it shows up as a normal pending change, picked up by <code>s</code>/<code>u</code>/<code>auto_sync</code> like any other edit. The footer shows the count while reading a note (<code>{n} changes</code>)</td></tr>
-          <tr><td><code>L</code></td><td>Links — the selected note's outgoing <code>[[wikilinks]]</code> (resolved against every note in the notebook, any folder depth) plus every other note that links back to it ("Outgoing"/"Backlinks" sections; a section with nothing in it is omitted). <code>j</code>/<code>k</code>/<code>PageUp</code>/<code>PageDown</code>/<code>Home</code>/<code>End</code> move, <code>Enter</code> jumps to the selected note (an unresolved outgoing link reports that instead of jumping), <code>Esc</code>/<code>q</code> closes</td></tr>
+          <tr><td><code>L</code></td><td>Links — the selected note's outgoing <code>[[wikilinks]]</code> (resolved against every note in the notebook, any folder depth), every other note that links back to it, and notes that <em>mention</em> this note's title in plain text without linking to it ("Outgoing"/"Backlinks"/"Mentions (unlinked)" sections; a section with nothing in it is omitted). <code>j</code>/<code>k</code>/<code>PageUp</code>/<code>PageDown</code>/<code>Home</code>/<code>End</code> move, <code>Enter</code> jumps to the selected note (an unresolved outgoing link reports that instead of jumping), <code>c</code> on a mention row <em>repairs</em> the missed link — it wraps that note's plain-text mention into a real <code>[[wikilink]]</code> (preserving its casing) and the row visibly migrates to Backlinks — and <code>Esc</code>/<code>q</code> closes. Also reachable globally via leader+<code>B</code></td></tr>
           <tr><td><code>Ctrl</code>+click</td><td>Click a rendered <code>[[wikilink]]</code> to jump straight to the note it resolves to — a plain click still enters edit mode everywhere, including on top of a wikilink</td></tr>
         </tbody>
       </table>
@@ -469,6 +472,11 @@ shiki list -n work        # list notes in "work"
 shiki show &lt;note&gt;         # show rendered content (ANSI)
 shiki edit &lt;note&gt;         # edit with $EDITOR
 shiki search &lt;query&gt;      # search and show results
+shiki tasks               # every pending checkbox task across notebooks, urgency-sorted
+shiki tasks --overdue --count  # just the number — made for waybar/polybar/tmux status modules
+shiki tasks --today --json     # machine-readable, with due/overdue/location per task
+shiki graph               # [[wikilink]] connection graph, force-directed, drawn in the terminal
+shiki graph -n work --json     # nodes/edges/orphans as JSON, for graphviz/d3/gephi
 shiki sync                # git commit+push default notebook
 shiki sync -n work        # git sync in "work"
 shiki config              # show config path
@@ -898,6 +906,11 @@ check_update = "U"
 drawer = "b"
 undo_delete = "u"
 settings = "s"
+scratchpad = "p"
+# Same links modal as [keybindings.preview]'s own binding, from any panel.
+links = "B"
+# Global tasks view — every checkbox task in every notebook.
+tasks_panel = "t"
 
 [keybindings.notebooks]
 new = "a"

--- a/shiki-cli/src/commands/daily.rs
+++ b/shiki-cli/src/commands/daily.rs
@@ -19,7 +19,19 @@ pub fn run(
             .with_context(|| format!("could not create notebook '{notebook}'"))?,
     };
     let today = chrono::Local::now().date_naive();
-    let note = shiki_core::daily::create_or_open(&nb, today, templates_dir, daily_template)?;
+    // Same agenda injection as the TUI's `t` — today's due/overdue tasks
+    // across every notebook, only when the daily is newly created.
+    let agenda = store
+        .all_notes()
+        .ok()
+        .and_then(|pool| shiki_core::tasks::agenda_section(&pool, today));
+    let note = shiki_core::daily::create_or_open(
+        &nb,
+        today,
+        templates_dir,
+        daily_template,
+        agenda.as_deref(),
+    )?;
     println!("daily: {}", note.path.display());
     open_in_editor(editor, &note.path)
 }

--- a/shiki-cli/src/commands/doctor.rs
+++ b/shiki-cli/src/commands/doctor.rs
@@ -305,6 +305,8 @@ fn check_keybinding_health(config: &Config, r: &mut Report) {
                 ("undo_delete", kb.global.undo_delete.as_str()),
                 ("settings", kb.global.settings.as_str()),
                 ("scratchpad", kb.global.scratchpad.as_str()),
+                ("links", kb.global.links.as_str()),
+                ("tasks_panel", kb.global.tasks_panel.as_str()),
             ],
         ),
         (

--- a/shiki-cli/src/commands/graph.rs
+++ b/shiki-cli/src/commands/graph.rs
@@ -1,0 +1,345 @@
+//! `shiki graph` — the note-connection graph (real, resolved `[[wikilinks]]`
+//! via `wikilinks::edges`) rendered as a 2D force-directed layout straight
+//! in the terminal, Obsidian-graph-style: nodes settle into clusters, hubs
+//! pull their satellites around them, and orphans drift to the edges. The
+//! layout is classic Fruchterman–Reingold on a plain char canvas — no TUI,
+//! no alternate screen, just printed lines, so the output survives in
+//! scrollback and can be piped/screenshotted like any other CLI output.
+//!
+//! Links only resolve within a notebook (titles are notebook-scoped), so
+//! the graph of "all notebooks" is naturally a set of disjoint clusters —
+//! each notebook's notes are laid out together but never cross-linked.
+
+use anyhow::{Context, Result};
+use shiki_core::{wikilinks, Note, Notebook, NotebookStore};
+use std::io::IsTerminal;
+
+/// Above this many nodes, only the best-connected ones are drawn (plus a
+/// note saying so) — a 500-node hairball helps nobody in 40 rows.
+const MAX_NODES: usize = 60;
+const LABEL_MAX: usize = 18;
+
+struct GraphNode {
+    title: String,
+    notebook: String,
+    degree: usize,
+}
+
+pub fn run(
+    store: &NotebookStore,
+    notebook: Option<&str>,
+    width: Option<u16>,
+    json: bool,
+) -> Result<()> {
+    // Per-notebook pools, since links can't cross notebooks — edges are
+    // computed inside each pool, then merged with shifted indices.
+    let notebooks: Vec<Notebook> = match notebook {
+        Some(name) => vec![store.get(name).with_context(|| {
+            format!("notebook '{name}' not found \u{2014} see `shiki notebook list`")
+        })?],
+        None => store.list()?,
+    };
+    let mut nodes: Vec<GraphNode> = Vec::new();
+    let mut edges: Vec<(usize, usize)> = Vec::new();
+    let mut orphan_titles: Vec<String> = Vec::new();
+    for nb in &notebooks {
+        let notes: Vec<Note> = nb.all_notes_recursive()?;
+        let base = nodes.len();
+        let local_edges = wikilinks::edges(&notes);
+        for i in wikilinks::orphans(&notes) {
+            orphan_titles.push(format!("{}/{}", nb.name, notes[i].frontmatter.title));
+        }
+        let mut degree = vec![0usize; notes.len()];
+        for &(a, b) in &local_edges {
+            degree[a] += 1;
+            degree[b] += 1;
+        }
+        for (i, note) in notes.iter().enumerate() {
+            nodes.push(GraphNode {
+                title: note.frontmatter.title.clone(),
+                notebook: nb.name.clone(),
+                degree: degree[i],
+            });
+        }
+        edges.extend(local_edges.iter().map(|&(a, b)| (base + a, base + b)));
+    }
+
+    if json {
+        let out = serde_json::json!({
+            "nodes": nodes.iter().map(|n| serde_json::json!({
+                "title": n.title, "notebook": n.notebook, "degree": n.degree,
+            })).collect::<Vec<_>>(),
+            "edges": edges,
+            "orphans": orphan_titles,
+        });
+        println!("{}", serde_json::to_string_pretty(&out)?);
+        return Ok(());
+    }
+    if nodes.is_empty() {
+        println!("(no notes to graph)");
+        return Ok(());
+    }
+
+    // Keep only the best-connected nodes when the graph is too big to read.
+    let total = nodes.len();
+    if total > MAX_NODES {
+        let mut by_degree: Vec<usize> = (0..total).collect();
+        by_degree.sort_by_key(|&i| std::cmp::Reverse(nodes[i].degree));
+        let keep: std::collections::HashSet<usize> =
+            by_degree[..MAX_NODES].iter().copied().collect();
+        let mut remap = vec![usize::MAX; total];
+        let mut kept_nodes = Vec::with_capacity(MAX_NODES);
+        for i in 0..total {
+            if keep.contains(&i) {
+                remap[i] = kept_nodes.len();
+                kept_nodes.push(GraphNode {
+                    title: nodes[i].title.clone(),
+                    notebook: nodes[i].notebook.clone(),
+                    degree: nodes[i].degree,
+                });
+            }
+        }
+        edges.retain(|&(a, b)| remap[a] != usize::MAX && remap[b] != usize::MAX);
+        for e in &mut edges {
+            *e = (remap[e.0], remap[e.1]);
+        }
+        nodes = kept_nodes;
+    }
+
+    let width = width
+        .or_else(|| crossterm::terminal::size().ok().map(|(w, _)| w))
+        .unwrap_or(100)
+        .clamp(40, 240) as usize;
+    let height = (width / 3).clamp(16, 60);
+
+    let positions = layout(nodes.len(), &edges, width as f32, height as f32);
+    let canvas = draw(&nodes, &edges, &positions, width, height);
+    let color = std::io::stdout().is_terminal();
+    print!("{}", render_canvas(&canvas, color));
+
+    println!();
+    let scope = notebook
+        .map(|n| format!("notebook '{n}'"))
+        .unwrap_or_else(|| "all notebooks".into());
+    println!(
+        "{} notes \u{B7} {} links \u{B7} {scope}",
+        total,
+        edges.len()
+    );
+    if total > MAX_NODES {
+        println!("(showing the {MAX_NODES} most-connected notes of {total})");
+    }
+    if !orphan_titles.is_empty() {
+        println!("\norphans (no links in or out):");
+        for title in &orphan_titles {
+            println!("  \u{25CB} {title}");
+        }
+    }
+    Ok(())
+}
+
+/// Fruchterman–Reingold: repulsion between every pair, attraction along
+/// edges, cooling over iterations. Deterministic (seeded by index, no RNG)
+/// so the same notebook renders the same graph every run — a graph that
+/// reshuffles on every invocation reads as noise. Y distances are weighted
+/// 2× during force calculation to compensate for terminal cells being
+/// roughly twice as tall as wide, so clusters come out round-ish on
+/// screen instead of vertically squashed.
+fn layout(n: usize, edges: &[(usize, usize)], width: f32, height: f32) -> Vec<(f32, f32)> {
+    let mut pos: Vec<(f32, f32)> = (0..n)
+        .map(|i| {
+            // Deterministic golden-angle spiral as the starting state.
+            let a = i as f32 * 2.399_963;
+            let r = 0.35 * ((i + 1) as f32 / n as f32).sqrt();
+            (width * (0.5 + r * a.cos()), height * (0.5 + r * a.sin()))
+        })
+        .collect();
+    if n <= 1 {
+        return pos;
+    }
+    let area = width * height;
+    let k = (area / n as f32).sqrt() * 0.6;
+    let iterations = 250;
+    let mut temp = width.max(height) / 8.0;
+    let cool = temp / iterations as f32;
+
+    for _ in 0..iterations {
+        let mut disp = vec![(0f32, 0f32); n];
+        for i in 0..n {
+            for j in (i + 1)..n {
+                let dx = pos[i].0 - pos[j].0;
+                let dy = (pos[i].1 - pos[j].1) * 2.0;
+                let dist = (dx * dx + dy * dy).sqrt().max(0.01);
+                let force = k * k / dist;
+                let (ux, uy) = (dx / dist, dy / dist);
+                disp[i].0 += ux * force;
+                disp[i].1 += uy * force;
+                disp[j].0 -= ux * force;
+                disp[j].1 -= uy * force;
+            }
+        }
+        for &(a, b) in edges {
+            let dx = pos[a].0 - pos[b].0;
+            let dy = (pos[a].1 - pos[b].1) * 2.0;
+            let dist = (dx * dx + dy * dy).sqrt().max(0.01);
+            let force = dist * dist / k;
+            let (ux, uy) = (dx / dist, dy / dist);
+            disp[a].0 -= ux * force;
+            disp[a].1 -= uy * force;
+            disp[b].0 += ux * force;
+            disp[b].1 += uy * force;
+        }
+        for i in 0..n {
+            let (dx, dy) = disp[i];
+            let len = (dx * dx + dy * dy).sqrt().max(0.01);
+            let step = len.min(temp);
+            pos[i].0 = (pos[i].0 + dx / len * step).clamp(1.0, width - 2.0);
+            pos[i].1 = (pos[i].1 + dy / len * step).clamp(1.0, height - 2.0);
+        }
+        temp = (temp - cool).max(0.05);
+    }
+    pos
+}
+
+#[derive(Clone, Copy, PartialEq)]
+enum Cell {
+    Empty,
+    Edge(char),
+    Node(char),
+    Label(char),
+    Orphan(char),
+}
+
+fn draw(
+    nodes: &[GraphNode],
+    edges: &[(usize, usize)],
+    positions: &[(f32, f32)],
+    width: usize,
+    height: usize,
+) -> Vec<Vec<Cell>> {
+    let mut canvas = vec![vec![Cell::Empty; width]; height];
+    let cell_of = |p: (f32, f32)| -> (usize, usize) {
+        (
+            (p.0.round() as usize).min(width - 1),
+            (p.1.round() as usize).min(height - 1),
+        )
+    };
+
+    // Edges first — nodes and labels overwrite them, never the reverse.
+    for &(a, b) in edges {
+        let (x0, y0) = cell_of(positions[a]);
+        let (x1, y1) = cell_of(positions[b]);
+        for (x, y) in line_cells(x0 as i32, y0 as i32, x1 as i32, y1 as i32) {
+            let (x, y) = (x as usize, y as usize);
+            if matches!(canvas[y][x], Cell::Empty) {
+                canvas[y][x] = Cell::Edge(edge_char(x0 as i32, y0 as i32, x1 as i32, y1 as i32));
+            }
+        }
+    }
+
+    for (i, node) in nodes.iter().enumerate() {
+        let (x, y) = cell_of(positions[i]);
+        let marker = if node.degree >= 3 {
+            '\u{25C9}' // ◉ hub
+        } else if node.degree == 0 {
+            '\u{25CB}' // ○ orphan
+        } else {
+            '\u{25CF}' // ● regular
+        };
+        canvas[y][x] = if node.degree == 0 {
+            Cell::Orphan(marker)
+        } else {
+            Cell::Node(marker)
+        };
+        let mut label: String = node.title.chars().take(LABEL_MAX).collect();
+        if node.title.chars().count() > LABEL_MAX {
+            label.push('\u{2026}');
+        }
+        // Label to the right of the marker, or to the left when it would
+        // run off the canvas — stopping at another node/label so two close
+        // nodes truncate rather than overwrite each other.
+        let chars: Vec<char> = label.chars().collect();
+        if x + 2 + chars.len() <= width {
+            for (dx, ch) in chars.iter().enumerate() {
+                let cx = x + 2 + dx;
+                match canvas[y][cx] {
+                    Cell::Node(_) | Cell::Label(_) | Cell::Orphan(_) => break,
+                    _ => canvas[y][cx] = Cell::Label(*ch),
+                }
+            }
+        } else if x >= chars.len() + 2 {
+            for (dx, ch) in chars.iter().enumerate() {
+                let cx = x - 2 - chars.len() + 1 + dx;
+                match canvas[y][cx] {
+                    Cell::Node(_) | Cell::Label(_) | Cell::Orphan(_) => break,
+                    _ => canvas[y][cx] = Cell::Label(*ch),
+                }
+            }
+        }
+    }
+    canvas
+}
+
+/// Bresenham, excluding both endpoints (the node markers live there).
+fn line_cells(x0: i32, y0: i32, x1: i32, y1: i32) -> Vec<(i32, i32)> {
+    let mut cells = Vec::new();
+    let (dx, dy) = ((x1 - x0).abs(), -(y1 - y0).abs());
+    let (sx, sy) = (if x0 < x1 { 1 } else { -1 }, if y0 < y1 { 1 } else { -1 });
+    let mut err = dx + dy;
+    let (mut x, mut y) = (x0, y0);
+    loop {
+        if (x, y) != (x0, y0) && (x, y) != (x1, y1) {
+            cells.push((x, y));
+        }
+        if x == x1 && y == y1 {
+            break;
+        }
+        let e2 = 2 * err;
+        if e2 >= dy {
+            err += dy;
+            x += sx;
+        }
+        if e2 <= dx {
+            err += dx;
+            y += sy;
+        }
+    }
+    cells
+}
+
+fn edge_char(x0: i32, y0: i32, x1: i32, y1: i32) -> char {
+    let (dx, dy) = ((x1 - x0).abs(), (y1 - y0).abs());
+    if dy == 0 {
+        '\u{2500}' // ─
+    } else if dx == 0 {
+        '\u{2502}' // │
+    } else if (x1 > x0) == (y1 > y0) {
+        '\u{2572}' // ╲
+    } else {
+        '\u{2571}' // ╱
+    }
+}
+
+fn render_canvas(canvas: &[Vec<Cell>], color: bool) -> String {
+    const DIM: &str = "\x1b[2m";
+    const CYAN: &str = "\x1b[36m";
+    const YELLOW: &str = "\x1b[33m";
+    const RESET: &str = "\x1b[0m";
+    let mut out = String::new();
+    for row in canvas {
+        let mut line = String::new();
+        for cell in row {
+            match cell {
+                Cell::Empty => line.push(' '),
+                Cell::Edge(c) if color => line.push_str(&format!("{DIM}{c}{RESET}")),
+                Cell::Node(c) if color => line.push_str(&format!("{YELLOW}{c}{RESET}")),
+                Cell::Orphan(c) if color => line.push_str(&format!("{DIM}{c}{RESET}")),
+                Cell::Label(c) if color => line.push_str(&format!("{CYAN}{c}{RESET}")),
+                Cell::Edge(c) | Cell::Node(c) | Cell::Label(c) | Cell::Orphan(c) => line.push(*c),
+            }
+        }
+        out.push_str(line.trim_end());
+        out.push('\n');
+    }
+    out
+}

--- a/shiki-cli/src/commands/mod.rs
+++ b/shiki-cli/src/commands/mod.rs
@@ -3,12 +3,14 @@ pub mod daily;
 pub mod doctor;
 pub mod edit;
 pub mod export;
+pub mod graph;
 pub mod list;
 pub mod new;
 pub mod notebook;
 pub mod search;
 pub mod show;
 pub mod sync;
+pub mod tasks;
 pub mod theme;
 
 use anyhow::{Context, Result};

--- a/shiki-cli/src/commands/tasks.rs
+++ b/shiki-cli/src/commands/tasks.rs
@@ -1,0 +1,141 @@
+//! `shiki tasks` — the TUI's global tasks view (leader+`t`), scriptable.
+//! Same source of truth (`NotebookStore::all_notes` + `tasks::extract`),
+//! same urgency sort; `--json` and `--count` exist specifically for status
+//! bars (waybar/polybar/tmux) — e.g. `shiki tasks --overdue --count` as a
+//! "2 overdue" module — which is the whole point of exposing this outside
+//! the TUI.
+
+use std::io::IsTerminal;
+
+use anyhow::Result;
+use chrono::NaiveDate;
+use shiki_core::tasks::Task;
+use shiki_core::NotebookStore;
+
+pub struct Filters {
+    /// Only tasks due strictly before today (implies pending).
+    pub overdue: bool,
+    /// Only tasks due exactly today (implies pending). Combinable with
+    /// `overdue` — together they mean "due today or earlier".
+    pub today: bool,
+    /// Include already-done tasks (off by default — pending only).
+    pub all: bool,
+}
+
+struct Row {
+    task: Task,
+    location: String,
+    notebook: String,
+    note_title: String,
+    path: std::path::PathBuf,
+}
+
+pub fn run(
+    store: &NotebookStore,
+    notebook: Option<&str>,
+    filters: &Filters,
+    json: bool,
+    count: bool,
+) -> Result<()> {
+    let today = chrono::Local::now().date_naive();
+    let pool = store.all_notes()?;
+    let mut rows: Vec<Row> = pool
+        .iter()
+        .filter(|(nb, _)| notebook.is_none_or(|wanted| nb.name == wanted))
+        .flat_map(|(nb, note)| {
+            let location = shiki_core::tasks::location_of(nb, note);
+            shiki_core::tasks::extract(&note.body)
+                .into_iter()
+                .map(move |task| Row {
+                    task,
+                    location: location.clone(),
+                    notebook: nb.name.clone(),
+                    note_title: note.frontmatter.title.clone(),
+                    path: note.path.clone(),
+                })
+        })
+        .filter(|r| keep(r, filters, today))
+        .collect();
+    rows.sort_by_key(|r| (r.task.due.is_none(), r.task.due));
+
+    if count {
+        println!("{}", rows.len());
+        return Ok(());
+    }
+    if json {
+        let items: Vec<serde_json::Value> = rows
+            .iter()
+            .map(|r| {
+                serde_json::json!({
+                    "text": r.task.text,
+                    "done": r.task.done,
+                    "due": r.task.due.map(|d| d.to_string()),
+                    "overdue": is_overdue(&r.task, today),
+                    "notebook": r.notebook,
+                    "note": r.note_title,
+                    "location": r.location,
+                    "path": r.path,
+                })
+            })
+            .collect();
+        println!("{}", serde_json::to_string_pretty(&items)?);
+        return Ok(());
+    }
+
+    if rows.is_empty() {
+        println!("(no matching tasks)");
+        return Ok(());
+    }
+    let color = std::io::stdout().is_terminal();
+    for r in &rows {
+        println!("{}", format_row(r, today, color));
+    }
+    Ok(())
+}
+
+fn keep(row: &Row, filters: &Filters, today: NaiveDate) -> bool {
+    if !filters.all && row.task.done {
+        return false;
+    }
+    match (filters.overdue, filters.today) {
+        (false, false) => true,
+        (o, t) => row
+            .task
+            .due
+            .is_some_and(|d| (o && d < today) || (t && d == today)),
+    }
+}
+
+fn is_overdue(task: &Task, today: NaiveDate) -> bool {
+    !task.done && task.due.is_some_and(|d| d < today)
+}
+
+fn format_row(row: &Row, today: NaiveDate, color: bool) -> String {
+    const RED: &str = "\x1b[31m";
+    const YELLOW: &str = "\x1b[33m";
+    const DIM: &str = "\x1b[2m";
+    const RESET: &str = "\x1b[0m";
+    let marker = if row.task.done { "[x]" } else { "[ ]" };
+    let due = match row.task.due {
+        Some(d) if color => {
+            let paint = if row.task.done {
+                DIM
+            } else if d < today {
+                RED
+            } else if d == today {
+                YELLOW
+            } else {
+                DIM
+            };
+            format!("  {paint}{d}{RESET}")
+        }
+        Some(d) => format!("  {d}"),
+        None => String::new(),
+    };
+    let location = if color {
+        format!("  {DIM}{}{RESET}", row.location)
+    } else {
+        format!("  {}", row.location)
+    };
+    format!("{marker} {}{due}{location}", row.task.text)
+}

--- a/shiki-cli/src/main.rs
+++ b/shiki-cli/src/main.rs
@@ -91,6 +91,48 @@ enum Commands {
         #[arg(long, value_enum, default_value = "html")]
         format: commands::export::ExportFormat,
     },
+    /// Lists checkbox tasks (`- [ ]`) across notebooks — the TUI's tasks
+    /// view (leader+`t`), scriptable. `--count`/`--json` are made for
+    /// status bars: e.g. `shiki tasks --overdue --count` in a waybar/
+    /// polybar/tmux module.
+    Tasks {
+        /// Only tasks from this notebook (default: all notebooks).
+        #[arg(short = 'n', long)]
+        notebook: Option<String>,
+        /// Only overdue tasks (due before today). Combinable with
+        /// `--today` for "due today or earlier".
+        #[arg(long)]
+        overdue: bool,
+        /// Only tasks due exactly today.
+        #[arg(long)]
+        today: bool,
+        /// Include already-completed tasks too.
+        #[arg(long)]
+        all: bool,
+        /// Prints just the number of matching tasks — for status bars.
+        #[arg(long, conflicts_with = "json")]
+        count: bool,
+        /// Emits a JSON array instead of plain text — for scripting.
+        #[arg(long)]
+        json: bool,
+    },
+    /// Renders the `[[wikilink]]` connection graph of your notes as a
+    /// force-directed layout right in the terminal — hubs (`◉`) pull their
+    /// linked notes around them, orphans (`○`) drift free and are listed
+    /// below.
+    Graph {
+        /// Only this notebook's graph (default: all notebooks — links
+        /// never cross notebooks, so each renders as its own cluster).
+        #[arg(short = 'n', long)]
+        notebook: Option<String>,
+        /// Canvas width in columns (default: the terminal's own width).
+        #[arg(long)]
+        width: Option<u16>,
+        /// Emits nodes/edges/orphans as JSON instead of drawing — for
+        /// piping into real graph tooling (graphviz, gephi, d3).
+        #[arg(long)]
+        json: bool,
+    },
     /// Shows the path to the config file
     Config,
     /// Checks the environment (config, data dir, git, editor, terminal, notebooks)
@@ -284,6 +326,29 @@ fn main() -> Result<()> {
             let notebook = ctx.notebook_name(notebook);
             commands::export::run(&ctx.store, &notebook, &out, format)
         }
+        Some(Commands::Tasks {
+            notebook,
+            overdue,
+            today,
+            all,
+            count,
+            json,
+        }) => commands::tasks::run(
+            &ctx.store,
+            notebook.as_deref(),
+            &commands::tasks::Filters {
+                overdue,
+                today,
+                all,
+            },
+            json,
+            count,
+        ),
+        Some(Commands::Graph {
+            notebook,
+            width,
+            json,
+        }) => commands::graph::run(&ctx.store, notebook.as_deref(), width, json),
         Some(Commands::Config) => commands::config::run(),
         Some(Commands::Doctor) => unreachable!("handled before Context::load() above"),
         Some(Commands::Notebook { action }) => match action {

--- a/shiki-config/src/config.rs
+++ b/shiki-config/src/config.rs
@@ -195,6 +195,18 @@ pub struct GlobalKeybindings {
     pub settings: String,
     #[serde(default = "default_scratchpad_key")]
     pub scratchpad: String,
+    /// Opens the links modal for the selected note (outgoing wikilinks,
+    /// backlinks, and unlinked mentions) from anywhere — the same modal
+    /// PREVIEW's own `links` binding opens, reachable without having to
+    /// focus PREVIEW first. Field-level default for the same
+    /// backward-compatibility reason as `logs`/`toggle_favorite_editor`.
+    #[serde(default = "default_global_links_key")]
+    pub links: String,
+    /// Opens the global tasks view: every `- [ ]` checkbox across every
+    /// notebook, toggleable in place. Field-level default for the same
+    /// backward-compatibility reason as `logs`/`toggle_favorite_editor`.
+    #[serde(default = "default_tasks_panel_key")]
+    pub tasks_panel: String,
 }
 
 impl Default for GlobalKeybindings {
@@ -210,8 +222,18 @@ impl Default for GlobalKeybindings {
             undo_delete: default_undo_delete_key(),
             settings: default_settings_key(),
             scratchpad: default_scratchpad_key(),
+            links: default_global_links_key(),
+            tasks_panel: default_tasks_panel_key(),
         }
     }
+}
+
+fn default_global_links_key() -> String {
+    "B".into()
+}
+
+fn default_tasks_panel_key() -> String {
+    "t".into()
 }
 
 fn default_logs_key() -> String {

--- a/shiki-core/src/daily.rs
+++ b/shiki-core/src/daily.rs
@@ -20,19 +20,24 @@ pub fn daily_note_path(notebook: &Notebook, date: NaiveDate) -> std::path::PathB
 /// filename, without `.md`) — callers pass the configured value through
 /// rather than this function hardcoding `"daily"`, so customizing that
 /// setting (already editable in the Settings GENERAL tab) actually takes
-/// effect instead of being silently ignored.
+/// effect instead of being silently ignored. `agenda` (see
+/// `tasks::agenda_section` — today's due/overdue tasks) is appended after
+/// the template **only on creation**: an already-existing daily is opened
+/// untouched, so reopening it later in the day never duplicates the
+/// section or clobbers edits made to it.
 pub fn create_or_open(
     notebook: &Notebook,
     date: NaiveDate,
     templates_dir: &Path,
     template_name: &str,
+    agenda: Option<&str>,
 ) -> Result<Note> {
     let path = daily_note_path(notebook, date);
     if path.exists() {
         return Note::from_file_in_notebook(&path, &notebook.name);
     }
 
-    let body = match Template::load(templates_dir, template_name) {
+    let mut body = match Template::load(templates_dir, template_name) {
         Ok(template) => {
             let mut vars = HashMap::new();
             vars.insert("date", date.format("%Y-%m-%d").to_string());
@@ -43,6 +48,13 @@ pub fn create_or_open(
             date.format("%Y-%m-%d")
         ),
     };
+    if let Some(agenda) = agenda {
+        if !body.ends_with('\n') {
+            body.push('\n');
+        }
+        body.push('\n');
+        body.push_str(agenda);
+    }
 
     let mut frontmatter =
         Frontmatter::new(format!("{} Daily", date.format("%Y-%m-%d")), &notebook.name);
@@ -82,7 +94,7 @@ mod tests {
         let templates_dir = tmp.path().join("templates"); // deliberately never created
         let date = NaiveDate::from_ymd_opt(2024, 3, 7).unwrap();
 
-        let note = create_or_open(&nb, date, &templates_dir, "daily").unwrap();
+        let note = create_or_open(&nb, date, &templates_dir, "daily", None).unwrap();
 
         assert_eq!(note.frontmatter.title, "2024-03-07 Daily");
         assert_eq!(note.frontmatter.date, date);
@@ -98,7 +110,7 @@ mod tests {
         let templates_dir = tmp.path().join("templates");
         let date = NaiveDate::from_ymd_opt(2024, 3, 7).unwrap();
 
-        let first = create_or_open(&nb, date, &templates_dir, "daily").unwrap();
+        let first = create_or_open(&nb, date, &templates_dir, "daily", None).unwrap();
         std::fs::write(
             &first.path,
             format!(
@@ -108,8 +120,25 @@ mod tests {
         )
         .unwrap();
 
-        let second = create_or_open(&nb, date, &templates_dir, "daily").unwrap();
+        let second = create_or_open(&nb, date, &templates_dir, "daily", None).unwrap();
 
         assert_eq!(second.body, "custom edit");
+    }
+
+    #[test]
+    fn create_or_open_appends_the_agenda_only_on_creation() {
+        let tmp = tempfile::tempdir().unwrap();
+        let nb = test_notebook(tmp.path(), "personal");
+        let templates_dir = tmp.path().join("templates");
+        let date = NaiveDate::from_ymd_opt(2024, 3, 7).unwrap();
+        let agenda = "## Due today\n\n- pay rent \u{2192} [[Bills]]\n";
+
+        let first = create_or_open(&nb, date, &templates_dir, "daily", Some(agenda)).unwrap();
+        assert!(first.body.ends_with(agenda));
+
+        // Reopening with a (different) agenda must not touch the file.
+        let second =
+            create_or_open(&nb, date, &templates_dir, "daily", Some("## Other\n")).unwrap();
+        assert_eq!(second.body, first.body);
     }
 }

--- a/shiki-core/src/lib.rs
+++ b/shiki-core/src/lib.rs
@@ -6,6 +6,7 @@ pub mod note;
 pub mod notebook;
 pub mod search;
 pub mod tags;
+pub mod tasks;
 pub mod templates;
 pub mod trash;
 pub mod update;
@@ -43,6 +44,10 @@ pub enum Error {
     /// already there.
     #[error("already exists: {0}")]
     DestinationExists(String),
+    /// A task toggle whose target line no longer exists in the file — the
+    /// note changed on disk between building the task list and toggling.
+    #[error("task not found in {0} — the note changed since the list was built")]
+    TaskNotFound(String),
     /// A folder move/copy whose destination is the source itself, or nested
     /// inside it — copying a folder into its own subtree would otherwise
     /// recurse forever (the freshly created destination becomes one of the

--- a/shiki-core/src/tasks.rs
+++ b/shiki-core/src/tasks.rs
@@ -1,0 +1,451 @@
+//! Checkbox tasks (`- [ ]` / `- [x]`) extracted from note bodies, with an
+//! optional `@due(YYYY-MM-DD)` tag — the domain half of the TUI's global
+//! tasks view. `extract` is a pure function of a body string (unit-testable
+//! without any filesystem), and `toggle` is the one write path: it flips a
+//! single checkbox in the note's file on disk, leaving every other byte
+//! untouched, so the edit flows through the exact same git/auto-sync
+//! machinery as any other note change.
+
+use std::collections::HashMap;
+use std::path::Path;
+use std::sync::OnceLock;
+
+use chrono::NaiveDate;
+use regex::Regex;
+
+use crate::{Error, Result};
+
+/// One checkbox line found in a note's body.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Task {
+    /// The exact line as it appears in the body — what `toggle` matches on,
+    /// so the toggle still finds the right line even if other lines were
+    /// added/removed since extraction shifted every index.
+    pub raw_line: String,
+    /// 0-based index among body lines *identical* to `raw_line` — two
+    /// word-for-word duplicate tasks in one note stay distinguishable, so
+    /// toggling the second one can't flip the first.
+    pub occurrence: usize,
+    pub done: bool,
+    /// The task's own text, checkbox marker stripped (`@due(...)` kept as
+    /// typed — it's part of what the user wrote, not metadata to hide).
+    pub text: String,
+    /// Parsed from a `@due(YYYY-MM-DD)` tag anywhere in the text, if present
+    /// and well-formed — a malformed date is just text, not an error.
+    pub due: Option<NaiveDate>,
+}
+
+fn task_line_re() -> &'static Regex {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    RE.get_or_init(|| Regex::new(r"^(\s*[-*] \[)([ xX])(\] +)(.*)$").unwrap())
+}
+
+fn due_re() -> &'static Regex {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    RE.get_or_init(|| Regex::new(r"@due\((\d{4}-\d{2}-\d{2})\)").unwrap())
+}
+
+/// Every checkbox task in `body`, in the order they appear.
+pub fn extract(body: &str) -> Vec<Task> {
+    let mut seen: HashMap<&str, usize> = HashMap::new();
+    body.lines()
+        .filter_map(|line| {
+            let caps = task_line_re().captures(line)?;
+            let occurrence = {
+                let n = seen.entry(line).or_insert(0);
+                let current = *n;
+                *n += 1;
+                current
+            };
+            let text = caps[4].trim_end().to_string();
+            let due = due_re()
+                .captures(&text)
+                .and_then(|c| NaiveDate::parse_from_str(&c[1], "%Y-%m-%d").ok());
+            Some(Task {
+                raw_line: line.to_string(),
+                occurrence,
+                done: &caps[2] != " ",
+                text,
+                due,
+            })
+        })
+        .collect()
+}
+
+/// What `toggle` did: the task's new state plus its new address (`raw_line`
+/// changed on disk — the checkbox flipped — and with it, potentially, its
+/// occurrence index among now-identical lines). A caller keeping a `Task`
+/// alive across the toggle must adopt all three or the *next* toggle of the
+/// same row could match a different, coincidentally-identical line.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Toggled {
+    pub done: bool,
+    pub raw_line: String,
+    pub occurrence: usize,
+}
+
+/// Flips one task's checkbox in the file at `path` and writes it back.
+/// The target line is matched by exact content (`raw_line`) plus
+/// `occurrence` among identical lines — never by stored index, which the
+/// file drifting since extraction would invalidate. Lines inside the
+/// leading `---` frontmatter block are never candidates, so YAML that
+/// happens to look like a checkbox can't shift the count.
+pub fn toggle(path: &Path, raw_line: &str, occurrence: usize) -> Result<Toggled> {
+    let contents = std::fs::read_to_string(path)?;
+    let mut lines: Vec<String> = contents.split('\n').map(str::to_string).collect();
+
+    // Skip the frontmatter block, if any — mirrors `Note::split`'s
+    // delimiter format (`---` opener on the first line, `---` closer).
+    let mut start = 0;
+    if lines.first().map(|l| l.trim_end_matches('\r')) == Some("---") {
+        if let Some(close) = lines[1..]
+            .iter()
+            .position(|l| l.trim_end_matches('\r') == "---")
+        {
+            start = close + 2;
+        }
+    }
+
+    let target = lines[start..]
+        .iter()
+        .enumerate()
+        .filter(|(_, l)| l.trim_end_matches('\r') == raw_line)
+        .nth(occurrence)
+        .map(|(i, _)| start + i);
+    let Some(idx) = target else {
+        return Err(Error::TaskNotFound(path.display().to_string()));
+    };
+
+    let line = &lines[idx];
+    let caps = task_line_re()
+        .captures(line.trim_end_matches('\r'))
+        .ok_or_else(|| Error::TaskNotFound(path.display().to_string()))?;
+    let new_done = &caps[2] == " ";
+    let marker = if new_done { "x" } else { " " };
+    let new_raw = format!("{}{}{}{}", &caps[1], marker, &caps[3], &caps[4]);
+    let crlf = if line.ends_with('\r') { "\r" } else { "" };
+    lines[idx] = format!("{new_raw}{crlf}");
+
+    // The flipped line's occurrence among lines *now identical to it* —
+    // counted the same way `extract` numbers them (top-down, frontmatter
+    // excluded), so the returned address stays valid for a second toggle.
+    let new_occurrence = lines[start..idx]
+        .iter()
+        .filter(|l| l.trim_end_matches('\r') == new_raw)
+        .count();
+
+    std::fs::write(path, lines.join("\n"))?;
+    Ok(Toggled {
+        done: new_done,
+        raw_line: new_raw,
+        occurrence: new_occurrence,
+    })
+}
+
+fn any_due_re() -> &'static Regex {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    // Any `@due(...)` regardless of content — `normalize_due_tags` decides
+    // per capture whether the inside is already ISO, a known relative
+    // spec, or junk to leave untouched.
+    RE.get_or_init(|| Regex::new(r"@due\(([^)]*)\)").unwrap())
+}
+
+/// Parses a relative due spec against `today`: `today`, `tomorrow`/`tom`,
+/// `+N`/`+Nd` (days), `+Nw` (weeks), or a weekday name (`mon`/`monday`, …,
+/// meaning the *next* such weekday, never today). Case-insensitive. An
+/// already-ISO date or anything unrecognized returns `None` — the caller
+/// leaves those as-is rather than guessing.
+pub fn parse_relative_due(spec: &str, today: NaiveDate) -> Option<NaiveDate> {
+    let spec = spec.trim().to_ascii_lowercase();
+    if spec.is_empty() {
+        return None;
+    }
+    match spec.as_str() {
+        "today" => return Some(today),
+        "tomorrow" | "tom" => return today.succ_opt(),
+        _ => {}
+    }
+    if let Some(rest) = spec.strip_prefix('+') {
+        let (num, unit) = match rest.strip_suffix('d') {
+            Some(n) => (n, 1i64),
+            None => match rest.strip_suffix('w') {
+                Some(n) => (n, 7i64),
+                None => (rest, 1i64),
+            },
+        };
+        let n: i64 = num.parse().ok()?;
+        return today.checked_add_signed(chrono::Duration::days(n * unit));
+    }
+    if let Ok(weekday) = spec.parse::<chrono::Weekday>() {
+        let today_num = chrono::Datelike::weekday(&today).num_days_from_monday() as i64;
+        let target = weekday.num_days_from_monday() as i64;
+        let ahead = (target - today_num).rem_euclid(7);
+        let ahead = if ahead == 0 { 7 } else { ahead };
+        return today.checked_add_signed(chrono::Duration::days(ahead));
+    }
+    None
+}
+
+/// Rewrites every relative `@due(...)` in `body` to its resolved
+/// `@due(YYYY-MM-DD)` form — `Some(new body)` if anything changed, `None`
+/// if there was nothing to normalize. ISO dates and unrecognized specs are
+/// left byte-for-byte untouched: normalization only ever *resolves*, it
+/// never invents or deletes. Callers run this at save time (a relative
+/// spec is relative to the day it was written, so it must be pinned then,
+/// not re-interpreted at every later read).
+pub fn normalize_due_tags(body: &str, today: NaiveDate) -> Option<String> {
+    let mut changed = false;
+    let result = any_due_re().replace_all(body, |caps: &regex::Captures| {
+        let spec = &caps[1];
+        if NaiveDate::parse_from_str(spec.trim(), "%Y-%m-%d").is_ok() {
+            return caps[0].to_string();
+        }
+        match parse_relative_due(spec, today) {
+            Some(date) => {
+                changed = true;
+                format!("@due({date})")
+            }
+            None => caps[0].to_string(),
+        }
+    });
+    changed.then(|| result.into_owned())
+}
+
+/// `"{notebook}/{folders…}/{title}"` — where a task lives, shared by the
+/// TUI's tasks modal and `shiki tasks` so the two can't describe the same
+/// task differently. Folders come from the note's path relative to its
+/// notebook; the note itself goes by its human title rather than its
+/// slugged file stem, matching what the NOTES panel shows.
+pub fn location_of(nb: &crate::Notebook, note: &crate::Note) -> String {
+    let mut parts = vec![nb.name.clone()];
+    if let Ok(rel) = note.path.strip_prefix(&nb.path) {
+        if let Some(parent) = rel.parent() {
+            parts.extend(
+                parent
+                    .components()
+                    .map(|c| c.as_os_str().to_string_lossy().into_owned()),
+            );
+        }
+    }
+    parts.push(note.frontmatter.title.clone());
+    parts.join("/")
+}
+
+/// The "what's on for today" section injected into a freshly created daily
+/// note: every *pending* task due today or overdue, across the whole pool,
+/// sorted by due date (most overdue first). Deliberately plain bullets with
+/// a `[[wikilink]]` back to the source note, **not** checkboxes — a
+/// checkbox copy would show up in the tasks view as a second, independent
+/// task, and checking the copy wouldn't complete the original. `None` when
+/// nothing is due, so quiet days don't get an empty section.
+pub fn agenda_section(pool: &[(crate::Notebook, crate::Note)], today: NaiveDate) -> Option<String> {
+    let mut due: Vec<(&NaiveDate, &Task, &crate::Note)> = Vec::new();
+    let extracted: Vec<(Vec<Task>, &crate::Note)> = pool
+        .iter()
+        .map(|(_, note)| (extract(&note.body), note))
+        .collect();
+    for (tasks, note) in &extracted {
+        for task in tasks {
+            if let Some(d) = &task.due {
+                if !task.done && *d <= today {
+                    due.push((d, task, note));
+                }
+            }
+        }
+    }
+    if due.is_empty() {
+        return None;
+    }
+    due.sort_by_key(|(d, _, _)| **d);
+    let mut out = String::from("## Due today\n\n");
+    for (d, task, note) in due {
+        let overdue = if *d < today { " (overdue)" } else { "" };
+        out.push_str(&format!(
+            "- {}{overdue} \u{2192} [[{}]]\n",
+            task.text, note.frontmatter.title
+        ));
+    }
+    Some(out)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn extract_finds_pending_and_done_tasks() {
+        let body = "# Plan\n\n- [ ] buy milk\n- [x] call mom\n* [X] star style\nnot a task";
+        let tasks = extract(body);
+        assert_eq!(tasks.len(), 3);
+        assert!(!tasks[0].done);
+        assert_eq!(tasks[0].text, "buy milk");
+        assert!(tasks[1].done);
+        assert!(tasks[2].done);
+    }
+
+    #[test]
+    fn extract_ignores_lines_that_only_look_similar() {
+        // No space after the marker, no marker at all, checkbox mid-line.
+        let body = "-[ ] no space\n[ ] bare\ntext - [ ] mid-line";
+        assert!(extract(body).is_empty());
+    }
+
+    #[test]
+    fn extract_parses_due_tag_and_keeps_it_in_text() {
+        let body = "- [ ] pay rent @due(2026-08-10)\n- [ ] bad date @due(2026-13-99)";
+        let tasks = extract(body);
+        assert_eq!(
+            tasks[0].due,
+            Some(NaiveDate::from_ymd_opt(2026, 8, 10).unwrap())
+        );
+        assert!(tasks[0].text.contains("@due(2026-08-10)"));
+        assert_eq!(tasks[1].due, None);
+    }
+
+    #[test]
+    fn extract_numbers_identical_lines_by_occurrence() {
+        let body = "- [ ] repeat\n- [ ] repeat\n- [ ] other";
+        let tasks = extract(body);
+        assert_eq!(tasks[0].occurrence, 0);
+        assert_eq!(tasks[1].occurrence, 1);
+        assert_eq!(tasks[2].occurrence, 0);
+    }
+
+    #[test]
+    fn toggle_flips_only_the_addressed_occurrence() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("note.md");
+        std::fs::write(&path, "---\ntitle: t\n---\n\n- [ ] repeat\n- [ ] repeat\n").unwrap();
+
+        let toggled = toggle(&path, "- [ ] repeat", 1).unwrap();
+        assert!(toggled.done);
+        assert_eq!(toggled.raw_line, "- [x] repeat");
+        assert_eq!(toggled.occurrence, 0);
+        assert_eq!(
+            std::fs::read_to_string(&path).unwrap(),
+            "---\ntitle: t\n---\n\n- [ ] repeat\n- [x] repeat\n"
+        );
+    }
+
+    #[test]
+    fn toggle_unchecks_a_done_task() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("note.md");
+        std::fs::write(&path, "- [x] call mom\n").unwrap();
+        assert!(!toggle(&path, "- [x] call mom", 0).unwrap().done);
+        assert_eq!(std::fs::read_to_string(&path).unwrap(), "- [ ] call mom\n");
+    }
+
+    #[test]
+    fn toggle_returns_the_new_address_even_among_identical_done_lines() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("note.md");
+        // A done twin already sits above — after toggling, the flipped
+        // line becomes the *second* `- [x] repeat`, and the returned
+        // occurrence must say so or a follow-up untoggle would flip the
+        // wrong twin.
+        std::fs::write(&path, "- [x] repeat\n- [ ] repeat\n").unwrap();
+        let toggled = toggle(&path, "- [ ] repeat", 0).unwrap();
+        assert_eq!(toggled.raw_line, "- [x] repeat");
+        assert_eq!(toggled.occurrence, 1);
+    }
+
+    #[test]
+    fn toggle_skips_checkbox_lookalikes_inside_frontmatter() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("note.md");
+        // The frontmatter contains a line byte-identical to the task —
+        // occurrence 0 must still resolve to the body's line, not YAML's.
+        std::fs::write(&path, "---\n- [ ] task\n---\n- [ ] task\n").unwrap();
+        toggle(&path, "- [ ] task", 0).unwrap();
+        assert_eq!(
+            std::fs::read_to_string(&path).unwrap(),
+            "---\n- [ ] task\n---\n- [x] task\n"
+        );
+    }
+
+    #[test]
+    fn parse_relative_due_handles_every_supported_form() {
+        // 2026-08-04 is a Tuesday.
+        let today = NaiveDate::from_ymd_opt(2026, 8, 4).unwrap();
+        let d = |y, m, day| NaiveDate::from_ymd_opt(y, m, day).unwrap();
+        assert_eq!(parse_relative_due("today", today), Some(today));
+        assert_eq!(parse_relative_due("tomorrow", today), Some(d(2026, 8, 5)));
+        assert_eq!(parse_relative_due("tom", today), Some(d(2026, 8, 5)));
+        assert_eq!(parse_relative_due("+3", today), Some(d(2026, 8, 7)));
+        assert_eq!(parse_relative_due("+3d", today), Some(d(2026, 8, 7)));
+        assert_eq!(parse_relative_due("+2w", today), Some(d(2026, 8, 18)));
+        assert_eq!(parse_relative_due("fri", today), Some(d(2026, 8, 7)));
+        assert_eq!(parse_relative_due("Monday", today), Some(d(2026, 8, 10)));
+        // "The next such weekday" is never today — tue on a Tuesday is +7.
+        assert_eq!(parse_relative_due("tue", today), Some(d(2026, 8, 11)));
+        assert_eq!(parse_relative_due("2026-09-01", today), None);
+        assert_eq!(parse_relative_due("garbage", today), None);
+    }
+
+    #[test]
+    fn normalize_due_tags_rewrites_relative_and_leaves_iso_and_junk() {
+        let today = NaiveDate::from_ymd_opt(2026, 8, 4).unwrap();
+        let body = "- [ ] a @due(tomorrow)\n- [ ] b @due(2026-09-01)\n- [ ] c @due(???)";
+        let normalized = normalize_due_tags(body, today).unwrap();
+        assert_eq!(
+            normalized,
+            "- [ ] a @due(2026-08-05)\n- [ ] b @due(2026-09-01)\n- [ ] c @due(???)"
+        );
+        // Nothing relative left — a second pass has nothing to do.
+        assert_eq!(normalize_due_tags(&normalized, today), None);
+    }
+
+    #[test]
+    fn agenda_section_lists_due_and_overdue_pending_tasks_as_plain_bullets() {
+        use crate::note::Frontmatter;
+        use crate::{Note, Notebook};
+        let today = NaiveDate::from_ymd_opt(2026, 8, 4).unwrap();
+        let entry = |title: &str, body: &str| {
+            (
+                Notebook::new("nb", std::path::PathBuf::from("/tmp/nb")),
+                Note::new(
+                    std::path::PathBuf::from(format!("/tmp/nb/{title}.md")),
+                    Frontmatter::new(title, "nb"),
+                    body.to_string(),
+                ),
+            )
+        };
+        let pool = vec![
+            entry(
+                "Bills",
+                "- [ ] pay rent @due(2026-08-01)\n- [x] done one @due(2026-08-01)",
+            ),
+            entry(
+                "Plan",
+                "- [ ] standup @due(2026-08-04)\n- [ ] later @due(2026-12-01)",
+            ),
+        ];
+
+        let section = agenda_section(&pool, today).unwrap();
+
+        // Overdue first, plain bullets (no `- [ ]`), wikilink back to the
+        // source; done and future-dated tasks excluded.
+        assert_eq!(
+            section,
+            "## Due today\n\n- pay rent @due(2026-08-01) (overdue) \u{2192} [[Bills]]\n- standup @due(2026-08-04) \u{2192} [[Plan]]\n"
+        );
+    }
+
+    #[test]
+    fn agenda_section_is_none_when_nothing_is_due() {
+        let today = NaiveDate::from_ymd_opt(2026, 8, 4).unwrap();
+        assert_eq!(agenda_section(&[], today), None);
+    }
+
+    #[test]
+    fn toggle_errors_when_the_line_no_longer_exists() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("note.md");
+        std::fs::write(&path, "- [ ] something else\n").unwrap();
+        assert!(matches!(
+            toggle(&path, "- [ ] vanished task", 0),
+            Err(Error::TaskNotFound(_))
+        ));
+    }
+}

--- a/shiki-core/src/wikilinks.rs
+++ b/shiki-core/src/wikilinks.rs
@@ -67,6 +67,145 @@ pub fn backlinks<'a>(target: &std::path::Path, notes: &'a [Note]) -> Vec<&'a Not
         .collect()
 }
 
+/// Every note whose body *mentions* `target`'s title as plain text without
+/// actually linking to it — the notes `backlinks` deliberately doesn't
+/// return, surfaced so a link that "should" exist can be noticed. A note
+/// that already links to `target` is excluded even if it also mentions the
+/// title elsewhere (it's a backlink, not a missed one), and so is `target`
+/// itself. Matching is a case-insensitive substring search on the title;
+/// an empty title matches nothing rather than everything.
+pub fn unlinked_mentions<'a>(target: &Note, notes: &'a [Note]) -> Vec<&'a Note> {
+    let title = target.frontmatter.title.trim().to_lowercase();
+    if title.is_empty() {
+        return Vec::new();
+    }
+    let linked: std::collections::HashSet<&std::path::Path> = backlinks(&target.path, notes)
+        .into_iter()
+        .map(|n| n.path.as_path())
+        .collect();
+    notes
+        .iter()
+        .filter(|n| {
+            n.path != target.path
+                && !linked.contains(n.path.as_path())
+                && n.body.to_lowercase().contains(&title)
+        })
+        .collect()
+}
+
+/// Every resolved link between notes in `notes`, as deduplicated
+/// `(from, to)` index pairs — the adjacency list `shiki graph` renders and
+/// `orphans` derives connectivity from. Self-links are dropped (a note
+/// linking to itself isn't a connection). Uses the same title/slug index
+/// `backlinks` builds, for the same O(notes × links) reason.
+pub fn edges(notes: &[Note]) -> Vec<(usize, usize)> {
+    let mut index: HashMap<String, usize> = HashMap::with_capacity(notes.len() * 2);
+    for (i, n) in notes.iter().enumerate() {
+        index
+            .entry(n.frontmatter.title.to_ascii_lowercase())
+            .or_insert(i);
+        index.entry(n.file_stem()).or_insert(i);
+    }
+    let mut out = Vec::new();
+    let mut seen = std::collections::HashSet::new();
+    for (from, n) in notes.iter().enumerate() {
+        for link in extract(&n.body) {
+            let link = link.trim();
+            let to = index
+                .get(&link.to_ascii_lowercase())
+                .or_else(|| index.get(&Note::slugify(link)));
+            if let Some(&to) = to {
+                if to != from && seen.insert((from, to)) {
+                    out.push((from, to));
+                }
+            }
+        }
+    }
+    out
+}
+
+/// Notes with no connections at all — nothing links to them and they link
+/// to nothing (mentions don't count; only real, resolved `[[links]]` do).
+/// Returned as indices into `notes`, in order.
+pub fn orphans(notes: &[Note]) -> Vec<usize> {
+    let mut connected = vec![false; notes.len()];
+    for (from, to) in edges(notes) {
+        connected[from] = true;
+        connected[to] = true;
+    }
+    (0..notes.len()).filter(|&i| !connected[i]).collect()
+}
+
+/// Turns the first plain-text mention of `title` in the file at `path`
+/// into a real `[[wikilink]]`, preserving the mention's own casing (the
+/// resolver is case-insensitive, so `[[proyecto shiki]]` still resolves to
+/// "Proyecto shiki"). Occurrences already inside a `[[...]]` are skipped —
+/// double-wrapping an existing link would corrupt it — and so is the
+/// frontmatter block. `Ok(false)` means no linkable mention was found
+/// (e.g. the file changed since the mention was detected); an I/O failure
+/// is a real error.
+pub fn link_mention(path: &std::path::Path, title: &str) -> crate::Result<bool> {
+    let title = title.trim();
+    if title.is_empty() {
+        return Ok(false);
+    }
+    let contents = std::fs::read_to_string(path)?;
+    let mut lines: Vec<String> = contents.split('\n').map(str::to_string).collect();
+
+    let mut start = 0;
+    if lines.first().map(|l| l.trim_end_matches('\r')) == Some("---") {
+        if let Some(close) = lines[1..]
+            .iter()
+            .position(|l| l.trim_end_matches('\r') == "---")
+        {
+            start = close + 2;
+        }
+    }
+
+    let needle = title.to_lowercase();
+    for line in lines.iter_mut().skip(start) {
+        if let Some(pos) = find_unlinked(line, &needle) {
+            let end = pos + needle.len();
+            line.replace_range(pos..end, &format!("[[{}]]", &line[pos..end]));
+            std::fs::write(path, lines.join("\n"))?;
+            return Ok(true);
+        }
+    }
+    Ok(false)
+}
+
+/// Byte offset of the first case-insensitive occurrence of `needle` in
+/// `line` that isn't already inside a `[[...]]` span — `None` if every
+/// occurrence is linked (or there are none). Assumes `needle` is already
+/// lowercase. Offsets are computed on the lowercased copy and applied to
+/// the original; `to_lowercase` can shift byte offsets for a handful of
+/// exotic characters (e.g. İ), so the match is re-verified against the
+/// original before being trusted.
+fn find_unlinked(line: &str, needle: &str) -> Option<usize> {
+    let lower = line.to_lowercase();
+    let mut from = 0;
+    while let Some(rel) = lower[from..].find(needle) {
+        let pos = from + rel;
+        let inside_link = {
+            let before = &lower[..pos];
+            let open = before.rfind("[[");
+            let close = before.rfind("]]");
+            matches!((open, close), (Some(o), c) if c.is_none_or(|c| c < o))
+        };
+        let verifiable = line
+            .get(pos..pos + needle.len())
+            .is_some_and(|s| s.to_lowercase() == needle);
+        if !inside_link && verifiable {
+            return Some(pos);
+        }
+        from = pos + needle.len().max(1);
+        if from >= lower.len() {
+            break;
+        }
+    }
+    None
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -146,6 +285,109 @@ mod tests {
 
         assert_eq!(result.len(), 1);
         assert_eq!(result[0].path, linker.path);
+    }
+
+    #[test]
+    fn unlinked_mentions_finds_plain_text_mentions_only() {
+        let target = note("a/hiking.md", "Weekend Hiking Trip", "");
+        let linker = note(
+            "a/journal.md",
+            "Journal",
+            "Planning [[Weekend Hiking Trip]].",
+        );
+        // Mentions the title in plain text, case-insensitively, no link.
+        let mentioner = note("a/ideas.md", "Ideas", "that weekend hiking trip was great");
+        let unrelated = note("a/other.md", "Other", "nothing relevant");
+        let notes = vec![target.clone(), linker, mentioner.clone(), unrelated];
+
+        let result = unlinked_mentions(&target, &notes);
+
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].path, mentioner.path);
+    }
+
+    #[test]
+    fn unlinked_mentions_excludes_notes_that_already_link() {
+        let target = note("a/hiking.md", "Weekend Hiking Trip", "");
+        // Links AND separately mentions the title in plain text — already a
+        // backlink, so it must not also show up as a missed link.
+        let both = note(
+            "a/journal.md",
+            "Journal",
+            "[[Weekend Hiking Trip]] — best weekend hiking trip ever.",
+        );
+        let notes = vec![target.clone(), both];
+        assert!(unlinked_mentions(&target, &notes).is_empty());
+    }
+
+    #[test]
+    fn edges_resolves_links_dedupes_and_drops_self_links() {
+        let notes = vec![
+            note(
+                "a/hub.md",
+                "Hub",
+                "[[Spoke]] and [[Spoke]] again, plus [[Hub]] itself.",
+            ),
+            note("a/spoke.md", "Spoke", "back to [[Hub]], and [[Nowhere]]."),
+            note("a/loner.md", "Loner", "no links"),
+        ];
+        assert_eq!(edges(&notes), vec![(0, 1), (1, 0)]);
+    }
+
+    #[test]
+    fn orphans_are_notes_with_no_resolved_links_either_way() {
+        let notes = vec![
+            note("a/hub.md", "Hub", "[[Spoke]]"),
+            note("a/spoke.md", "Spoke", ""),
+            note("a/loner.md", "Loner", "mentions Hub in plain text only"),
+        ];
+        assert_eq!(orphans(&notes), vec![2]);
+    }
+
+    #[test]
+    fn link_mention_wraps_first_plain_occurrence_preserving_case() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("note.md");
+        std::fs::write(
+            &path,
+            "---\ntitle: Journal\n---\n\nthat weekend hiking trip was great\n",
+        )
+        .unwrap();
+
+        assert!(link_mention(&path, "Weekend Hiking Trip").unwrap());
+        assert_eq!(
+            std::fs::read_to_string(&path).unwrap(),
+            "---\ntitle: Journal\n---\n\nthat [[weekend hiking trip]] was great\n"
+        );
+    }
+
+    #[test]
+    fn link_mention_skips_occurrences_already_inside_a_link() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("note.md");
+        std::fs::write(&path, "[[Hub]] is linked; but hub in plain text isn't.\n").unwrap();
+
+        assert!(link_mention(&path, "Hub").unwrap());
+        assert_eq!(
+            std::fs::read_to_string(&path).unwrap(),
+            "[[Hub]] is linked; but [[hub]] in plain text isn't.\n"
+        );
+    }
+
+    #[test]
+    fn link_mention_reports_false_when_nothing_linkable_remains() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("note.md");
+        std::fs::write(&path, "only [[Hub]] as a link, no plain mention.\n").unwrap();
+        assert!(!link_mention(&path, "Hub").unwrap());
+    }
+
+    #[test]
+    fn unlinked_mentions_empty_title_matches_nothing() {
+        let target = note("a/blank.md", "  ", "");
+        let other = note("a/other.md", "Other", "any text at all");
+        let notes = vec![target.clone(), other];
+        assert!(unlinked_mentions(&target, &notes).is_empty());
     }
 
     #[test]

--- a/shiki-tui/src/app.rs
+++ b/shiki-tui/src/app.rs
@@ -615,6 +615,15 @@ pub struct App {
     /// Index into just the selectable rows of `link_rows` (section headers
     /// are display-only) — same shape as `tree_selected`.
     pub(crate) link_selected: usize,
+    pub show_tasks: bool,
+    pub(crate) task_rows: Vec<crate::panel_tasks::TaskRow>,
+    /// Index into just the selectable rows of `task_rows` (per-note headers
+    /// are display-only) — same shape as `link_selected`.
+    pub(crate) task_selected: usize,
+    /// Whether the tasks modal also shows already-done tasks (`a` inside
+    /// the modal flips it and rebuilds) — off on every open, same
+    /// reset-to-top convention as `toggle_tags`.
+    pub(crate) tasks_show_done: bool,
     /// True right after the leader key is pressed, waiting for the next key
     /// to resolve against the `global` scope.
     pub leader_pending: bool,
@@ -942,6 +951,10 @@ impl App {
             show_links: false,
             link_rows: Vec::new(),
             link_selected: 0,
+            show_tasks: false,
+            task_rows: Vec::new(),
+            task_selected: 0,
+            tasks_show_done: false,
             leader_pending: false,
             preview_scroll: 0,
             preview_selection: None,
@@ -2045,6 +2058,18 @@ pub fn run<B: Backend<Error = io::Error>>(
             } else {
                 let notebook_name = app.selected_notebook().map(|nb| nb.name.clone());
                 suspend_and_edit(terminal, &editor, &path)?;
+                // Same relative-`@due` pinning the inline editor's save
+                // does — an external edit lands on disk directly, so the
+                // file is re-read and rewritten only if something actually
+                // normalized.
+                if let Ok(contents) = std::fs::read_to_string(&path) {
+                    let today = chrono::Local::now().date_naive();
+                    if let Some(normalized) =
+                        shiki_core::tasks::normalize_due_tags(&contents, today)
+                    {
+                        let _ = std::fs::write(&path, normalized);
+                    }
+                }
                 app.refresh_notes_preserve_selection();
                 if let Some(notebook_name) = notebook_name {
                     app.note_changed(&notebook_name);

--- a/shiki-tui/src/draw.rs
+++ b/shiki-tui/src/draw.rs
@@ -6,7 +6,7 @@ use crate::icons;
 use crate::render::{hex_to_color, panel_block};
 use crate::{
     layout, panel_drawer, panel_notebooks, panel_notes, panel_preview, panel_settings, panel_tags,
-    status_bar, which,
+    panel_tasks, status_bar, which,
 };
 use ratatui::layout::{Constraint, Layout, Rect};
 use ratatui::style::{Modifier, Style};
@@ -176,6 +176,10 @@ pub fn draw(frame: &mut Frame, app: &App) {
 
     if app.show_links {
         render_links(frame, frame.area(), app);
+    }
+
+    if app.show_tasks {
+        panel_tasks::render(frame, frame.area(), app);
     }
 
     if app.show_history {
@@ -487,11 +491,19 @@ fn render_links(frame: &mut Frame, frame_area: Rect, app: &App) {
                     Style::default().fg(fg),
                 )))
             }
+            // A mention is a *candidate* link, not an existing one — muted
+            // so it reads as weaker than a real backlink at a glance.
+            crate::links_panel::LinkRow::Mention { note } => {
+                ListItem::new(Line::from(Span::styled(
+                    format!("  {} {}", icons::SEARCH, note.frontmatter.title),
+                    Style::default().fg(muted),
+                )))
+            }
         })
         .collect();
     let highlight_symbol = format!("{} ", icons::ARROW);
     let title = format!(
-        " {}  Links  \u{2014}  enter jump \u{B7} esc/q close ",
+        " {}  Links  \u{2014}  enter jump \u{B7} c link mention \u{B7} esc/q close ",
         icons::LINK
     );
     let list = List::new(items)

--- a/shiki-tui/src/key_handlers.rs
+++ b/shiki-tui/src/key_handlers.rs
@@ -1123,7 +1123,49 @@ impl App {
             KeyCode::Home => self.link_selected = 0,
             KeyCode::End => self.link_selected = self.link_selectable_count().saturating_sub(1),
             KeyCode::Enter | KeyCode::Char('l') | KeyCode::Right => self.jump_to_link_selection(),
+            KeyCode::Char('c') => self.link_selected_mention(),
             _ => {}
+        }
+    }
+    /// `c` on a "Mentions (unlinked)" row: turns that note's plain-text
+    /// mention into a real `[[wikilink]]` (`wikilinks::link_mention` — the
+    /// repair to the missed link the section exists to surface). The modal
+    /// is rebuilt afterwards, so the row visibly migrates from Mentions to
+    /// Backlinks. A no-op on any other row kind.
+    fn link_selected_mention(&mut self) {
+        let Some(row) = crate::links_panel::selected_row(&self.link_rows, self.link_selected)
+        else {
+            return;
+        };
+        let crate::links_panel::LinkRow::Mention { note } = &self.link_rows[row] else {
+            return;
+        };
+        let mention_path = note.path.clone();
+        let mention_title = note.frontmatter.title.clone();
+        let Some(target) = self.selected_note().cloned() else {
+            return;
+        };
+        match shiki_core::wikilinks::link_mention(&mention_path, &target.frontmatter.title) {
+            Ok(true) => {
+                if let Some(nb) = self.selected_notebook() {
+                    let name = nb.name.clone();
+                    self.note_changed(&name);
+                }
+                self.refresh_notes_preserve_selection();
+                self.set_status(format!(
+                    "linked [[{}]] in '{mention_title}'",
+                    target.frontmatter.title
+                ));
+                // Rebuild so the mention shows up under Backlinks now —
+                // open_links re-reads everything from disk fresh.
+                self.open_links();
+            }
+            Ok(false) => {
+                self.set_status(format!(
+                    "no linkable mention left in '{mention_title}' \u{2014} note changed on disk?"
+                ));
+            }
+            Err(e) => self.set_status(format!("couldn't link mention: {e}")),
         }
     }
     /// The deep link: an outgoing link jumps to its resolved note (a broken
@@ -1150,7 +1192,8 @@ impl App {
                 self.set_status(format!("'{text}' doesn't match any note"));
                 return;
             }
-            crate::links_panel::LinkRow::Backlink { note } => {
+            crate::links_panel::LinkRow::Backlink { note }
+            | crate::links_panel::LinkRow::Mention { note } => {
                 (note.path.clone(), note.frontmatter.title.clone())
             }
             crate::links_panel::LinkRow::Header(_) => {
@@ -1179,6 +1222,116 @@ impl App {
         self.set_status(format!("opened '{title}'"));
     }
 
+    /// Opens the global tasks view: every checkbox task across every
+    /// notebook (`NotebookStore::all_notes`, the same walk global search
+    /// does on open), pending-only by default. Built fresh every time it
+    /// opens, same as the tags/links modals.
+    fn open_tasks(&mut self) {
+        self.tasks_show_done = false;
+        self.task_selected = 0;
+        self.rebuild_task_rows();
+        if self.task_rows.is_empty() {
+            self.set_status("no pending tasks in any notebook".into());
+            return;
+        }
+        self.show_tasks = true;
+    }
+    fn rebuild_task_rows(&mut self) {
+        let pool = self.store.all_notes().unwrap_or_default();
+        self.task_rows = crate::panel_tasks::build(&pool, self.tasks_show_done);
+    }
+    fn task_selectable_count(&self) -> usize {
+        self.task_rows.len()
+    }
+    fn handle_tasks_key(&mut self, key: KeyEvent) {
+        match key.code {
+            KeyCode::Esc | KeyCode::Char('q') => self.show_tasks = false,
+            KeyCode::Char('j') | KeyCode::Down => {
+                if self.task_selected + 1 < self.task_selectable_count() {
+                    self.task_selected += 1;
+                }
+            }
+            KeyCode::Char('k') | KeyCode::Up => {
+                self.task_selected = self.task_selected.saturating_sub(1);
+            }
+            KeyCode::PageDown => {
+                self.task_selected = (self.task_selected + PAGE_STEP as usize)
+                    .min(self.task_selectable_count().saturating_sub(1));
+            }
+            KeyCode::PageUp => {
+                self.task_selected = self.task_selected.saturating_sub(PAGE_STEP as usize);
+            }
+            KeyCode::Home => self.task_selected = 0,
+            KeyCode::End => self.task_selected = self.task_selectable_count().saturating_sub(1),
+            KeyCode::Enter | KeyCode::Char(' ') => self.toggle_selected_task(),
+            KeyCode::Char('l') | KeyCode::Right | KeyCode::Char('o') => self.jump_to_task_note(),
+            KeyCode::Char('a') => {
+                self.tasks_show_done = !self.tasks_show_done;
+                self.rebuild_task_rows();
+                self.task_selected = self
+                    .task_selected
+                    .min(self.task_selectable_count().saturating_sub(1));
+            }
+            _ => {}
+        }
+    }
+    /// Flips the selected task's checkbox in its source file and updates
+    /// the row in place — deliberately *not* a rebuild, so a task checked
+    /// off while the pending-only filter is active stays visible (checked,
+    /// struck through) and can be immediately un-toggled instead of
+    /// vanishing out from under the cursor.
+    fn toggle_selected_task(&mut self) {
+        let Some(row) = self.task_rows.get(self.task_selected) else {
+            return;
+        };
+        let notebook = row.notebook.clone();
+        let note_path = row.note_path.clone();
+        let task = &row.task;
+        match shiki_core::tasks::toggle(&note_path, &task.raw_line, task.occurrence) {
+            Ok(toggled) => {
+                let done = toggled.done;
+                let task = &mut self.task_rows[self.task_selected].task;
+                task.done = toggled.done;
+                task.raw_line = toggled.raw_line;
+                task.occurrence = toggled.occurrence;
+                // A toggle is a real note edit: refresh the panels/caches
+                // underneath the modal and count it toward auto_sync, the
+                // same as any other save.
+                self.refresh_notes_preserve_selection();
+                self.note_changed(&notebook);
+                self.set_status(format!(
+                    "task {}",
+                    if done { "completed" } else { "reopened" }
+                ));
+            }
+            Err(e) => self.set_status(format!("couldn't toggle task: {e}")),
+        }
+    }
+    /// Cross-notebook jump to the selected task's note — same shape as
+    /// `jump_to_global_hit`, which is the other flow that can land on a
+    /// note in a *different* notebook than the selected one.
+    fn jump_to_task_note(&mut self) {
+        let Some(row) = self.task_rows.get(self.task_selected) else {
+            return;
+        };
+        let notebook = row.notebook.clone();
+        let note_path = row.note_path.clone();
+        if let Some(nb_idx) = self.notebooks.iter().position(|n| n.name == notebook) {
+            self.selected_notebook = nb_idx;
+            let nb_path = self.notebooks[nb_idx].path.clone();
+            self.notes_path = relative_folder(&note_path, &nb_path);
+            self.reload_notes();
+            if let Some(idx) = self.notes.iter().position(|n| n.path == note_path) {
+                self.selected_note = self.folders.len() + idx;
+            }
+            self.focus = Focus::Preview;
+            if let Some(note) = self.selected_note() {
+                let title = note.frontmatter.title.clone();
+                self.set_status(format!("opened '{title}'"));
+            }
+        }
+        self.show_tasks = false;
+    }
     /// The tags modal has two levels: the tag list itself, and (after
     /// drilling into one) the notes that carry it — reset to level 1 every
     /// time it opens, so it never reopens showing a stale drill-down from
@@ -1821,6 +1974,7 @@ impl App {
             && !self.show_logs
             && !self.show_tree
             && !self.show_links
+            && !self.show_tasks
             && !self.show_history
             && !self.show_update
             && !self.show_settings
@@ -2078,11 +2232,20 @@ impl App {
             }
         };
         let today = chrono::Local::now().date_naive();
+        // Today's due/overdue tasks across *every* notebook, injected only
+        // if the daily is actually being created (an existing one opens
+        // untouched — create_or_open ignores the agenda then).
+        let agenda = self
+            .store
+            .all_notes()
+            .ok()
+            .and_then(|pool| shiki_core::tasks::agenda_section(&pool, today));
         match shiki_core::daily::create_or_open(
             &nb,
             today,
             &templates_dir,
             &self.config.general.daily_template,
+            agenda.as_deref(),
         ) {
             Ok(note) => {
                 // Daily notes always live at the notebook root — jump the
@@ -2418,6 +2581,14 @@ impl App {
         }
         if let (Some(editor), Some(mut note)) = (editor, self.selected_note().cloned()) {
             note.body = editor.contents();
+            // Pin relative due specs (`@due(+3d)`, `@due(mon)`) to real
+            // dates now — they're relative to the day they were written,
+            // so save time is the one moment they can be resolved
+            // unambiguously.
+            let today = chrono::Local::now().date_naive();
+            if let Some(normalized) = shiki_core::tasks::normalize_due_tags(&note.body, today) {
+                note.body = normalized;
+            }
             let _ = note.save();
             self.note_changed(&note.frontmatter.notebook);
         }
@@ -2466,6 +2637,7 @@ impl App {
             Action::UndoDelete => self.undo_delete(),
             Action::ToggleSettings => self.toggle_settings(),
             Action::Scratchpad => self.start_scratchpad(),
+            Action::ToggleTasks => self.open_tasks(),
 
             Action::NewNotebook => self.start_input(PendingInput::NewNotebook, String::new()),
             Action::RenameNotebook => self.start_rename_notebook(),
@@ -4164,6 +4336,10 @@ impl App {
         }
         if self.show_links {
             self.handle_links_key(key);
+            return;
+        }
+        if self.show_tasks {
+            self.handle_tasks_key(key);
             return;
         }
         if self.show_history {

--- a/shiki-tui/src/keybindings.rs
+++ b/shiki-tui/src/keybindings.rs
@@ -22,6 +22,9 @@ pub enum Action {
     /// config, with a key to jump straight to editing `config.toml` itself.
     ToggleSettings,
     Scratchpad,
+    /// Opens the global tasks view: every `- [ ]` checkbox across every
+    /// notebook, toggleable in place without opening the note.
+    ToggleTasks,
     // Notebooks-focus
     NewNotebook,
     RenameNotebook,
@@ -129,6 +132,10 @@ impl KeyMaps {
         bind(&mut global, &cfg.global.undo_delete, Action::UndoDelete);
         bind(&mut global, &cfg.global.settings, Action::ToggleSettings);
         bind(&mut global, &cfg.global.scratchpad, Action::Scratchpad);
+        // The same links modal PREVIEW's own binding opens — global so
+        // "what links here?" is answerable without focusing PREVIEW first.
+        bind(&mut global, &cfg.global.links, Action::ShowLinks);
+        bind(&mut global, &cfg.global.tasks_panel, Action::ToggleTasks);
 
         let mut notebooks = HashMap::new();
         bind(&mut notebooks, &cfg.notebooks.new, Action::NewNotebook);
@@ -359,7 +366,8 @@ pub fn action_label(action: Action) -> &'static str {
         Action::EditInline => "edit (insert mode)",
         Action::EditExternal => "edit externally ($EDITOR)",
         Action::ShowHistory => "note history (view/revert)",
-        Action::ShowLinks => "links (wikilinks + backlinks)",
+        Action::ShowLinks => "links (outgoing / backlinks / mentions)",
+        Action::ToggleTasks => "tasks (all notebooks)",
     }
 }
 
@@ -387,7 +395,7 @@ pub fn action_icon(action: Action) -> char {
         Action::SortNotes => crate::icons::COLUMNS,
         Action::ToggleTreeView => crate::icons::TREE,
         Action::ToggleDates | Action::ShowHistory => crate::icons::HISTORY,
-        Action::ToggleVisual => crate::icons::CHECK,
+        Action::ToggleVisual | Action::ToggleTasks => crate::icons::CHECK,
         Action::CopyEntries => crate::icons::CLIPBOARD,
         Action::ShowLinks => crate::icons::LINK,
         Action::UndoDelete => crate::icons::UNDO,

--- a/shiki-tui/src/lib.rs
+++ b/shiki-tui/src/lib.rs
@@ -17,6 +17,7 @@ pub mod panel_notes;
 pub mod panel_preview;
 pub mod panel_settings;
 pub mod panel_tags;
+pub mod panel_tasks;
 pub mod render;
 pub mod slash_menu;
 pub mod status_bar;

--- a/shiki-tui/src/links_panel.rs
+++ b/shiki-tui/src/links_panel.rs
@@ -22,6 +22,12 @@ pub enum LinkRow {
     Backlink {
         note: Note,
     },
+    /// A note that mentions the current note's title in plain text without
+    /// linking to it (`wikilinks::unlinked_mentions`) — always jumpable,
+    /// same as a backlink.
+    Mention {
+        note: Note,
+    },
 }
 
 /// Builds the rows for `current`: its own outgoing links first (in the
@@ -53,6 +59,16 @@ pub fn build(current: &Note, notes: &[Note]) -> Vec<LinkRow> {
     if !backlinks.is_empty() {
         rows.push(LinkRow::Header("Backlinks"));
         rows.extend(backlinks);
+    }
+
+    let mentions: Vec<LinkRow> = wikilinks::unlinked_mentions(current, notes)
+        .into_iter()
+        .cloned()
+        .map(|note| LinkRow::Mention { note })
+        .collect();
+    if !mentions.is_empty() {
+        rows.push(LinkRow::Header("Mentions (unlinked)"));
+        rows.extend(mentions);
     }
 
     rows
@@ -124,6 +140,24 @@ mod tests {
         // Index 1 -> the Backlink row at position 3 (after its own header).
         assert_eq!(selected_row(&rows, 1), Some(3));
         assert_eq!(selected_row(&rows, 2), None);
+    }
+
+    #[test]
+    fn unlinked_mentions_get_their_own_section_after_backlinks() {
+        let current = note("a/hub.md", "Hub", "");
+        let linker = note("a/linker.md", "Linker", "See [[Hub]].");
+        let mentioner = note("a/mentioner.md", "Mentioner", "the hub is central");
+        let notes = vec![current.clone(), linker, mentioner];
+
+        let rows = build(&current, &notes);
+
+        assert!(matches!(rows[0], LinkRow::Header("Backlinks")));
+        assert!(matches!(rows[1], LinkRow::Backlink { .. }));
+        assert!(matches!(rows[2], LinkRow::Header("Mentions (unlinked)")));
+        assert!(
+            matches!(&rows[3], LinkRow::Mention { note } if note.frontmatter.title == "Mentioner")
+        );
+        assert_eq!(selectable_count(&rows), 2);
     }
 
     #[test]

--- a/shiki-tui/src/panel_tasks.rs
+++ b/shiki-tui/src/panel_tasks.rs
@@ -1,0 +1,243 @@
+//! The global tasks modal (leader+`t`): every checkbox task across every
+//! notebook in one flat list, each row carrying its own location — an
+//! earlier version grouped tasks under per-note header rows instead
+//! (`links_panel::LinkRow`-style), but a header scrolls out of view while
+//! its tasks are still on screen, so the location lives *on the row*,
+//! muted, where it can't be lost. `Enter`/`space` toggles the task in its
+//! source file (`shiki_core::tasks::toggle`); `l`/`o` jumps to its note.
+
+use std::path::PathBuf;
+
+use chrono::NaiveDate;
+use ratatui::layout::Rect;
+use ratatui::style::{Modifier, Style};
+use ratatui::text::{Line, Span};
+use ratatui::widgets::{Clear, List, ListItem, ListState};
+use ratatui::Frame;
+
+use shiki_core::tasks::Task;
+use shiki_core::{Note, Notebook};
+
+use crate::app::{centered_rect, App};
+use crate::icons;
+use crate::render::{hex_to_color, panel_block};
+
+/// One task in the flattened list — every row is selectable (no headers).
+#[derive(Debug, Clone)]
+pub struct TaskRow {
+    /// Which notebook the note belongs to — `note_changed` needs the name
+    /// after a toggle, so it's carried here rather than re-derived.
+    pub notebook: String,
+    pub note_path: PathBuf,
+    /// `"{notebook}/{folders…}/{note title}"` — rendered muted next to the
+    /// task text so every row says where it lives without a header.
+    pub location: String,
+    pub task: Task,
+}
+
+/// Builds the rows from the same `(Notebook, Note)` pool global search
+/// walks (`NotebookStore::all_notes`). Sorted by urgency: dated tasks
+/// first in due order (overdue at the very top), undated ones after, in
+/// walk order — the sort is stable, so tasks from the same note keep their
+/// file order within each bucket. `include_done` off (the default) hides
+/// already-checked tasks; a task toggled *while the modal is open* is
+/// updated in place rather than rebuilt, so it stays visible either way.
+pub fn build(pool: &[(Notebook, Note)], include_done: bool) -> Vec<TaskRow> {
+    let mut rows: Vec<TaskRow> = pool
+        .iter()
+        .flat_map(|(nb, note)| {
+            let location = shiki_core::tasks::location_of(nb, note);
+            shiki_core::tasks::extract(&note.body)
+                .into_iter()
+                .filter(|t| include_done || !t.done)
+                .map(move |task| TaskRow {
+                    notebook: nb.name.clone(),
+                    note_path: note.path.clone(),
+                    location: location.clone(),
+                    task,
+                })
+        })
+        .collect();
+    // `Option`'s derived ordering puts `None` first — flip it so undated
+    // tasks sink below dated ones instead of floating above the overdue.
+    rows.sort_by_key(|r| (r.task.due.is_none(), r.task.due));
+    rows
+}
+
+/// How many of the visible tasks are still pending — shown in the title so
+/// the modal doubles as a "what's left" count without scrolling.
+pub fn pending_count(rows: &[TaskRow]) -> usize {
+    rows.iter().filter(|r| !r.task.done).count()
+}
+
+pub fn render(frame: &mut Frame, frame_area: Rect, app: &App) {
+    let height = (frame_area.height * 3 / 4).max(8);
+    let popup_area = centered_rect(frame_area, (frame_area.width * 3 / 4).max(50), height);
+    frame.render_widget(Clear, popup_area);
+
+    let fg = hex_to_color(&app.theme.fg);
+    let muted = hex_to_color(&app.theme.muted);
+    let success = hex_to_color(&app.theme.success);
+    let warning = hex_to_color(&app.theme.warning);
+    let error = hex_to_color(&app.theme.error);
+    let today = chrono::Local::now().date_naive();
+
+    let items: Vec<ListItem> = app
+        .task_rows
+        .iter()
+        .map(|row| {
+            let task = &row.task;
+            let (marker, marker_style) = if task.done {
+                (
+                    format!(" [{}] ", icons::CHECK),
+                    Style::default().fg(success),
+                )
+            } else {
+                (" [ ] ".to_string(), Style::default().fg(fg))
+            };
+            let text_style = if task.done {
+                Style::default()
+                    .fg(muted)
+                    .add_modifier(Modifier::CROSSED_OUT)
+            } else {
+                Style::default().fg(fg)
+            };
+            let mut spans = vec![
+                Span::styled(marker, marker_style),
+                Span::styled(task.text.clone(), text_style),
+            ];
+            if let Some(due) = task.due {
+                spans.push(Span::styled(
+                    format!("  {} {due}", icons::CALENDAR),
+                    Style::default().fg(due_color(due, today, task.done, muted, warning, error)),
+                ));
+            }
+            spans.push(Span::styled(
+                format!("  {} {}", icons::NOTE, row.location),
+                Style::default().fg(muted),
+            ));
+            ListItem::new(Line::from(spans))
+        })
+        .collect();
+
+    let title = format!(
+        " {}  Tasks [{} pending]  \u{2014}  enter/space toggle \u{B7} l jump \u{B7} a show done \u{B7} esc close ",
+        icons::CHECK,
+        pending_count(&app.task_rows),
+    );
+    let highlight_symbol = format!("{} ", icons::ARROW);
+    let list = List::new(items)
+        .block(panel_block(Line::from(title), true, &app.theme))
+        .highlight_style(
+            Style::default()
+                .bg(hex_to_color(&app.theme.selection))
+                .fg(hex_to_color(&app.theme.accent))
+                .add_modifier(Modifier::BOLD),
+        )
+        .highlight_symbol(highlight_symbol.as_str());
+
+    let mut state = ListState::default();
+    state.select(Some(app.task_selected));
+    frame.render_stateful_widget(list, popup_area, &mut state);
+}
+
+/// Overdue reads as an error, due today as a warning, anything else (or an
+/// already-done task's date) stays muted — done tasks' dates aren't
+/// actionable no matter how far past they are.
+fn due_color(
+    due: NaiveDate,
+    today: NaiveDate,
+    done: bool,
+    muted: ratatui::style::Color,
+    warning: ratatui::style::Color,
+    error: ratatui::style::Color,
+) -> ratatui::style::Color {
+    if done {
+        muted
+    } else if due < today {
+        error
+    } else if due == today {
+        warning
+    } else {
+        muted
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use shiki_core::note::Frontmatter;
+
+    fn pool_entry(nb: &str, rel_path: &str, title: &str, body: &str) -> (Notebook, Note) {
+        (
+            Notebook::new(nb, PathBuf::from(format!("/tmp/{nb}"))),
+            Note::new(
+                PathBuf::from(format!("/tmp/{nb}/{rel_path}")),
+                Frontmatter::new(title, nb),
+                body.to_string(),
+            ),
+        )
+    }
+
+    #[test]
+    fn build_flattens_tasks_with_their_location() {
+        let pool = vec![
+            pool_entry(
+                "work",
+                "sprint.md",
+                "Sprint",
+                "- [ ] ship it\n- [x] plan it",
+            ),
+            pool_entry("home", "chores.md", "Chores", "- [ ] mow lawn"),
+            pool_entry("home", "empty.md", "Empty", "no tasks here"),
+        ];
+
+        let rows = build(&pool, false);
+
+        // Done tasks hidden by default; the taskless note contributes nothing.
+        assert_eq!(rows.len(), 2);
+        assert_eq!(rows[0].task.text, "ship it");
+        assert_eq!(rows[0].location, "work/Sprint");
+        assert_eq!(rows[1].location, "home/Chores");
+        assert_eq!(pending_count(&rows), 2);
+    }
+
+    #[test]
+    fn build_includes_done_tasks_when_asked() {
+        let pool = vec![pool_entry(
+            "work",
+            "sprint.md",
+            "Sprint",
+            "- [ ] ship it\n- [x] plan it",
+        )];
+        let rows = build(&pool, true);
+        assert_eq!(rows.len(), 2);
+        assert_eq!(pending_count(&rows), 1);
+    }
+
+    #[test]
+    fn build_sorts_dated_tasks_first_in_due_order() {
+        let pool = vec![pool_entry(
+            "work",
+            "plan.md",
+            "Plan",
+            "- [ ] no date\n- [ ] later @due(2026-12-01)\n- [ ] soon @due(2026-08-05)",
+        )];
+        let rows = build(&pool, false);
+        assert_eq!(rows[0].task.text, "soon @due(2026-08-05)");
+        assert_eq!(rows[1].task.text, "later @due(2026-12-01)");
+        assert_eq!(rows[2].task.text, "no date");
+    }
+
+    #[test]
+    fn location_includes_nested_folders_and_the_human_title() {
+        let pool = vec![pool_entry(
+            "work",
+            "projects/q3/roadmap-v2.md",
+            "Roadmap v2",
+            "- [ ] draft",
+        )];
+        let rows = build(&pool, false);
+        assert_eq!(rows[0].location, "work/projects/q3/Roadmap v2");
+    }
+}


### PR DESCRIPTION
## What's new

### Tasks (GTD light, everywhere)
- **Global tasks view (leader+`t`)**: every `- [ ]` checkbox task across every notebook in one flat list, sorted by urgency (overdue → due today → future → undated). Every row carries its own muted location (`notebook/folders…/note title`) so where a task lives never scrolls out of view. `Enter`/`space` toggles the task **in its source file** (matched by content + occurrence, never by line index, so a file that drifted since the list was built errors clearly instead of flipping the wrong line); `l`/`o` jumps to the note; `a` also shows completed tasks.
- **`shiki tasks` CLI**: the same view, scriptable. `--overdue`/`--today`/`--all`/`--notebook` filters, `--json` (with a precomputed `overdue` bool per task), and `--count` printing just the number — made for status bars: `shiki tasks --overdue --count` is a ready-to-use waybar/polybar/tmux module.
- **`@due(...)` dates**, colored by urgency in the TUI and CLI (overdue = error, today = warning, future = muted). Relative specs — `@due(tomorrow)`, `@due(+3d)`, `@due(+2w)`, `@due(fri)` — are pinned to their resolved ISO date at save time (inline or external editor), since they're relative to the day they were written.
- **Daily agenda**: creating the daily note (TUI `t` or `shiki daily`) appends a `## Due today` section with every pending due/overdue task across all notebooks — plain bullets with `[[wikilinks]]` back to each source note, deliberately *not* checkbox copies (those would double-count in the tasks view). Reopening an existing daily never re-injects it.

### Links (Zettelkasten complete)
- **Unlinked mentions**: the links modal grew a "Mentions (unlinked)" section — notes that mention the current note's title in plain text without linking to it. `c` on a mention row **repairs the missed link**: wraps the mention into a real `[[wikilink]]` in place (preserving casing, skipping text already inside links), and the row visibly migrates to Backlinks.
- **leader+`B`**: the links modal is now reachable globally from any panel, not only via PREVIEW's `L`.
- **`shiki graph`**: the wikilink connection graph drawn right in the terminal — a deterministic force-directed layout (Fruchterman–Reingold on a char canvas, golden-angle seeded, no RNG so the same notebook always draws the same picture). Hubs render as `◉`, edges as `╱╲─│`, orphans (`○`, no links in or out) drift free and are listed below. `--json` emits nodes/edges/orphans for graphviz/d3/gephi; graphs past 60 notes show the most-connected subset.

### Fixes
- `shiki doctor`'s keybinding-collision check now covers the new `links`/`tasks_panel` global keys — a config with `theme_picker = "t"` (colliding with the tasks default) gets flagged instead of one of the two actions silently not working. (The doctor scope list is hand-maintained; both new fields were added.)

## Verification
- 165 tests across the workspace (new coverage: task extraction/toggle-by-content-address, relative due parsing/normalization, agenda section, edges/orphans/link_mention, flat task rows + urgency sort), clippy clean.
- Everything exercised live in a tmux-driven TUI session against isolated XDG dirs: toggle → file flips on disk → un-toggle; cross-notebook jump; mention repair verified on disk (`El proyecto shiki` → `El [[proyecto shiki]]`); `@due(+3d)` → `@due(2026-08-07)` on save; daily created with overdue-first agenda and verified idempotent by file hash; `shiki graph` rendered a real hub-and-spoke cluster with orphans listed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)