### PR TITLE
fix: don't treat the templates directory as a notebook on macOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -116,6 +116,12 @@ semver yet (pre-1.0), but version bumps are still meaningful and tracked here.
 
 ### Fixed
 
+- On macOS, `NotebookStore::list()` could pick up the `templates` directory as if it were a real
+  notebook. `directories::ProjectDirs` resolves `config_dir()` and `data_dir()` to the exact same
+  path on macOS (unlike Linux/Windows), so `default_templates_dir()`'s plain, non-git `templates/`
+  folder ended up sitting directly inside the data dir alongside real notebooks. Auto-discovered
+  subdirectories of the data dir now require a `.git` directory to count as a notebook — a real
+  distinction, not a heuristic, since every notebook is git-initialized immediately on creation.
 - The empty NOTEBOOKS panel's hint said `press \`A\` to create one`, but the actual default
   keybinding for it is lowercase `a` (found by actually using the freshly-built app, not just
   reading the diff).

--- a/shiki-core/src/notebook.rs
+++ b/shiki-core/src/notebook.rs
@@ -444,12 +444,22 @@ impl NotebookStore {
             }
         }
 
-        // 2. Subdirectories under the root data dir
+        // 2. Subdirectories under the root data dir that are actually git repos.
+        //
+        // A notebook is *always* git-managed from creation (`NotebookStore::create`
+        // calls `git::init_repo` immediately), so requiring a `.git` directory here
+        // is a real, load-bearing distinction, not a heuristic: it's what actually
+        // separates a notebook from an incidental sibling directory. This matters in
+        // practice on macOS, where `directories::ProjectDirs` resolves `config_dir()`
+        // and `data_dir()` to the exact same path — `default_templates_dir()` (a
+        // plain, non-git `templates/` folder living in the config dir) then ends up
+        // sitting directly inside the data dir too, and used to get listed as a
+        // notebook purely as a side effect of that OS-specific path collision.
         if self.root.exists() {
             for entry in std::fs::read_dir(&self.root)? {
                 let entry = entry?;
                 let path = entry.path();
-                if !path.is_dir() {
+                if !path.is_dir() || !path.join(".git").is_dir() {
                     continue;
                 }
                 let name = path
@@ -794,5 +804,32 @@ mod tests {
 
         assert_eq!(renamed.path, root.join("work2"));
         assert!(root.join("work2").is_dir());
+    }
+
+    #[test]
+    fn list_only_picks_up_real_notebooks_not_plain_sibling_directories() {
+        // Reproduces the macOS bug from issue #43: `directories::ProjectDirs`
+        // resolves `config_dir()` and `data_dir()` to the same path there, so
+        // the (plain, non-git) templates directory ends up sitting directly
+        // inside the data dir alongside real notebooks.
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path().join("data-dir");
+        let store = NotebookStore::new(root.clone());
+        store.create("personal").unwrap();
+        std::fs::create_dir_all(root.join("templates")).unwrap();
+
+        let names: Vec<String> = store.list().unwrap().into_iter().map(|n| n.name).collect();
+
+        assert_eq!(names, vec!["personal".to_string()]);
+    }
+
+    #[test]
+    fn list_ignores_a_directory_whose_git_repo_was_never_initialized() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path().join("data-dir");
+        std::fs::create_dir_all(root.join("not-a-notebook")).unwrap();
+        let store = NotebookStore::new(root);
+
+        assert!(store.list().unwrap().is_empty());
     }
 }


### PR DESCRIPTION
## Summary
- On macOS, `directories::ProjectDirs` resolves `config_dir()` and `data_dir()` to the exact same path (there's no XDG-style config/data split on macOS the way there is on Linux). `default_templates_dir()`'s plain, non-git `templates/` folder ends up sitting directly inside the data dir as a result, and `NotebookStore::list()` had no exclusion for it — any subdirectory of the data dir was treated as a notebook.
- `NotebookStore::list()` now requires a `.git` directory for an auto-discovered subdirectory to count as a notebook. This isn't a heuristic/allowlist of reserved names — every real notebook is git-initialized immediately on creation (`NotebookStore::create` calls `git::init_repo` right away), so requiring `.git` is an actual, correct distinction between a notebook and an incidental sibling directory.
- Verified end-to-end by pointing `XDG_CONFIG_HOME`/`XDG_DATA_HOME` at the same directory (reproducing the macOS collision), creating a notebook, then manually creating a plain `templates/` folder next to it — before the fix `shiki doctor`/`notebook list` picked it up as a second notebook; after the fix only the real one shows.

Fixes #43.

## Test plan
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets` (clean)
- [x] `cargo test --workspace` (76 passed in shiki-core, including 2 new tests: `list_only_picks_up_real_notebooks_not_plain_sibling_directories`, `list_ignores_a_directory_whose_git_repo_was_never_initialized`)
- [x] Manually reproduced the macOS bug via XDG env var override and confirmed `shiki doctor`/`notebook list` no longer show `templates` as a notebook
- [x] `CHANGELOG.md` updated under `## [Unreleased]` / `### Fixed`

🤖 Generated with [Claude Code](https://claude.com/claude-code)