### PR TITLE
docs: fix version-chip styling, dedicated changelog page, OS-aware quick install

### DIFF
--- a/docs/changelog.html
+++ b/docs/changelog.html
@@ -1,0 +1,103 @@
+<!DOCTYPE html>
+<html lang="en" data-theme="gruvbox-dark">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Changelog — shiki (私記)</title>
+  <meta name="description" content="Full version history for shiki: every release, every feature, every fix, in Keep a Changelog format — fetched live from CHANGELOG.md, never out of sync with the repo." />
+  <meta name="keywords" content="shiki changelog, shiki release notes, shiki version history" />
+  <meta name="author" content="sazardev" />
+  <meta name="robots" content="index, follow" />
+  <link rel="canonical" href="https://sazardev.github.io/shiki/changelog.html" />
+
+  <meta property="og:type" content="website" />
+  <meta property="og:url" content="https://sazardev.github.io/shiki/changelog.html" />
+  <meta property="og:site_name" content="shiki" />
+  <meta property="og:title" content="Changelog — shiki (私記)" />
+  <meta property="og:description" content="Full version history for shiki, in Keep a Changelog format — fetched live so it's never out of sync with the repo." />
+  <meta property="og:image" content="https://sazardev.github.io/shiki/assets/og-image.png" />
+  <meta property="og:image:width" content="1200" />
+  <meta property="og:image:height" content="630" />
+  <meta property="og:image:alt" content="shiki (私記) — a TUI note-taking app, shown running in a terminal window" />
+  <meta property="og:locale" content="en_US" />
+
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:title" content="Changelog — shiki (私記)" />
+  <meta name="twitter:description" content="Full version history for shiki, in Keep a Changelog format — fetched live so it's never out of sync with the repo." />
+  <meta name="twitter:image" content="https://sazardev.github.io/shiki/assets/og-image.png" />
+  <meta name="twitter:image:alt" content="shiki (私記) — a TUI note-taking app, shown running in a terminal window" />
+
+  <link rel="icon" type="image/svg+xml" href="assets/favicon.svg" />
+  <link rel="icon" type="image/png" sizes="32x32" href="assets/favicon-32.png" />
+  <link rel="apple-touch-icon" sizes="180x180" href="assets/apple-touch-icon.png" />
+
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;700;800&display=swap" rel="stylesheet" />
+
+  <link rel="stylesheet" href="css/styles.css" />
+  <link rel="stylesheet" href="css/documentation.css" />
+</head>
+<body class="doc-page">
+
+  <header class="topbar">
+    <div class="brand"><a href="index.html" style="color:inherit;text-decoration:none;">shiki (私記)</a><span class="cursor"></span></div>
+    <button type="button" class="nav-toggle" id="nav-toggle" aria-label="Toggle navigation" aria-expanded="false" aria-controls="site-nav">☰</button>
+    <nav id="site-nav">
+      <a href="index.html#themes">Themes</a>
+      <a href="index.html#features">Features</a>
+      <a href="index.html#install">Install</a>
+      <a href="documentation.html">Docs</a>
+      <a href="changelog.html" class="active">Changelog</a>
+      <a href="https://github.com/sazardev/shiki">GitHub</a>
+      <span class="version-chip-wrap" id="version-chip-wrap">
+        <button type="button" class="pill pill-button" id="version-pill" hidden></button>
+        <div class="version-popover" id="version-popover" role="dialog" aria-label="What's new" hidden>
+          <div class="version-popover-header">
+            <strong>What's new</strong>
+            <a href="changelog.html">Full changelog →</a>
+          </div>
+          <div class="version-popover-body changelog-body" id="version-popover-content">
+            <p class="changelog-loading">Loading changelog…</p>
+          </div>
+        </div>
+      </span>
+    </nav>
+  </header>
+
+  <section class="doc-hero">
+    <div class="container">
+      <span class="eyebrow">What's new</span>
+      <h1>Changelog</h1>
+      <p class="muted" style="max-width: 66ch;">
+        Everything that's shipped — new features, real fixes, the occasional oops. No
+        highlight reel, no spin. Fetched live from
+        <a href="https://github.com/sazardev/shiki/blob/main/CHANGELOG.md">CHANGELOG.md</a>
+        on every load, so this page can never drift out of sync with the repo.
+      </p>
+    </div>
+  </section>
+
+  <section>
+    <div class="container">
+      <div id="changelog-content" class="changelog-body" data-full>
+        <p class="changelog-loading">Loading changelog…</p>
+      </div>
+    </div>
+  </section>
+
+  <footer class="site-footer">
+    <div class="container">
+      <div class="footer-links">
+        <a href="https://github.com/sazardev/shiki">GitHub</a>
+        <a href="https://github.com/sazardev/shiki/issues">Issues</a>
+        <a href="https://github.com/sazardev/shiki/blob/main/LICENSE">MIT License</a>
+        <a class="coffee-link" href="https://buymeacoffee.com/sazarcode">☕ Buy me a coffee</a>
+      </div>
+      <small>shiki (私記) — built by <a href="https://github.com/sazardev">sazardev</a>. Free and open source, forever.</small>
+    </div>
+  </footer>
+
+  <script src="js/main.js"></script>
+</body>
+</html>

--- a/docs/css/styles.css
+++ b/docs/css/styles.css
@@ -334,6 +334,7 @@ code, .code {
 
 .topbar nav {
   display: flex;
+  align-items: center;
   gap: 24px;
   font-size: 0.9rem;
 }
@@ -465,6 +466,22 @@ code, .code {
 .hero .install-hint {
   font-size: 0.85rem;
   color: var(--muted);
+  max-width: 420px;
+}
+
+.install-hint-label {
+  font-size: 0.78rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  margin-bottom: 8px;
+}
+
+.quick-install {
+  margin-bottom: 10px;
+}
+
+.install-alt {
+  margin-bottom: 6px;
 }
 
 /* Fake terminal window chrome wrapping the real screenshots */
@@ -677,7 +694,8 @@ code, .code {
   color: var(--fg);
 }
 
-.install-card pre {
+.install-card pre,
+.quick-install pre {
   margin: 0;
   overflow-x: auto;
   font-size: 0.85rem;
@@ -925,6 +943,17 @@ code, .code {
 }
 
 .pill-button {
+  /* Reset the browser's own <button> chrome (UA-default background/box
+     shadow, line-height) that .pill's rules don't touch — without this the
+     chip rendered as a plain white system button, with its text sitting
+     off-center relative to the pill shape, on top of whatever `color`
+     .pill actually set. */
+  appearance: none;
+  -webkit-appearance: none;
+  background: transparent;
+  display: inline-flex;
+  align-items: center;
+  line-height: 1;
   font: inherit;
   cursor: pointer;
   transition: border-color 0.15s, color 0.15s;

--- a/docs/documentation.html
+++ b/docs/documentation.html
@@ -48,14 +48,14 @@
       <a href="index.html#features">Features</a>
       <a href="index.html#install">Install</a>
       <a href="documentation.html" class="active">Docs</a>
-      <a href="index.html#changelog">Changelog</a>
+      <a href="changelog.html">Changelog</a>
       <a href="https://github.com/sazardev/shiki">GitHub</a>
       <span class="version-chip-wrap" id="version-chip-wrap">
         <button type="button" class="pill pill-button" id="version-pill" hidden></button>
         <div class="version-popover" id="version-popover" role="dialog" aria-label="What's new" hidden>
           <div class="version-popover-header">
             <strong>What's new</strong>
-            <a href="https://github.com/sazardev/shiki/blob/main/CHANGELOG.md" target="_blank" rel="noopener">Full changelog →</a>
+            <a href="changelog.html">Full changelog →</a>
           </div>
           <div class="version-popover-body changelog-body" id="version-popover-content">
             <p class="changelog-loading">Loading changelog…</p>

--- a/docs/index.html
+++ b/docs/index.html
@@ -78,14 +78,14 @@
       <a href="#features">Features</a>
       <a href="#install">Install</a>
       <a href="documentation.html">Docs</a>
-      <a href="#changelog">Changelog</a>
+      <a href="changelog.html">Changelog</a>
       <a href="https://github.com/sazardev/shiki">GitHub</a>
       <span class="version-chip-wrap" id="version-chip-wrap">
         <button type="button" class="pill pill-button" id="version-pill" hidden></button>
         <div class="version-popover" id="version-popover" role="dialog" aria-label="What's new" hidden>
           <div class="version-popover-header">
             <strong>What's new</strong>
-            <a href="https://github.com/sazardev/shiki/blob/main/CHANGELOG.md" target="_blank" rel="noopener">Full changelog →</a>
+            <a href="changelog.html">Full changelog →</a>
           </div>
           <div class="version-popover-body changelog-body" id="version-popover-content">
             <p class="changelog-loading">Loading changelog…</p>
@@ -110,9 +110,16 @@
           <a class="btn btn-ghost" href="https://github.com/sazardev/shiki">View on GitHub ★</a>
         </div>
         <div class="install-hint">
-          or <code>cargo install shiki-cli</code>
-          <button class="copy-btn copy-btn-inline" type="button" aria-label="Copy command">Copy</button>
-          — see <a href="#install">all install options</a>
+          <p class="install-hint-label" id="quick-install-label">Quick install (Cargo):</p>
+          <div class="quick-install code-block">
+            <pre id="quick-install-cmd">cargo install shiki-cli</pre>
+            <button class="copy-btn" type="button" aria-label="Copy command">Copy</button>
+          </div>
+          <p class="install-alt" id="install-alt-line" hidden>
+            or, the universal fallback: <code>cargo install shiki-cli</code>
+            <button class="copy-btn copy-btn-inline" type="button" aria-label="Copy command">Copy</button>
+          </p>
+          <p class="install-more">See <a href="#install">all install options</a>.</p>
         </div>
       </div>
       <div>
@@ -371,22 +378,6 @@ scoop install shiki</pre>
       <div id="contributors-grid" class="contributors-grid">
         <p class="contributors-loading">Loading contributors…</p>
       </div>
-    </div>
-  </section>
-
-  <section id="changelog">
-    <div class="container">
-      <span class="eyebrow">What's new</span>
-      <h2>Changelog</h2>
-      <p class="muted">Everything that's shipped — new features, real fixes, the occasional
-      oops. No highlight reel, no spin.</p>
-
-      <div id="changelog-content" class="changelog-body">
-        <p class="changelog-loading">Loading changelog…</p>
-      </div>
-      <p class="changelog-more">
-        <a href="https://github.com/sazardev/shiki/blob/main/CHANGELOG.md">Full changelog on GitHub →</a>
-      </p>
     </div>
   </section>
 

--- a/docs/js/main.js
+++ b/docs/js/main.js
@@ -274,9 +274,12 @@ function renderChangelog(markdown, maxVersions = CHANGELOG_MAX_VERSIONS) {
 async function loadChangelog() {
   const container = document.getElementById("changelog-content");
   if (!container) return; // this script is shared across pages — not every page has a changelog
+  // changelog.html sets data-full to render every version instead of the
+  // CHANGELOG_MAX_VERSIONS-capped teaser other pages don't show anymore.
+  const maxVersions = container.hasAttribute("data-full") ? Infinity : CHANGELOG_MAX_VERSIONS;
   try {
     const text = await fetchChangelogMarkdown();
-    container.innerHTML = renderChangelog(text);
+    container.innerHTML = renderChangelog(text, maxVersions);
   } catch (err) {
     container.innerHTML = `<p class="changelog-error">Couldn't load the live changelog right now. See it directly on <a href="https://github.com/sazardev/shiki/blob/main/CHANGELOG.md">GitHub</a>.</p>`;
   }
@@ -383,6 +386,46 @@ function detectPlatformKey() {
   if (/Mac/i.test(ua) || /Mac|iPhone|iPad/i.test(platform)) return "macArm";
   if (/Linux|X11/i.test(ua) || /Linux/i.test(platform)) return "linux";
   return null;
+}
+
+// ---------------------------------------------------------------------------
+// Hero "quick install" command — same OS detection as the download button
+// above, but for the copy-paste package-manager command instead of the
+// binary download link. Only macOS and Windows have a real package manager
+// shiki actually ships to (Homebrew, Scoop); Linux has no single universal
+// one (Arch's `yay -S shiki-bin` already gets its own card further down the
+// page), so `cargo install shiki-cli` — already the one truly
+// platform-agnostic install path — stays the quick-install command there
+// and detection failing entirely (unknown UA) falls back to it too.
+// ---------------------------------------------------------------------------
+
+const QUICK_INSTALL = {
+  windows: {
+    label: "Scoop",
+    command: "scoop bucket add sazardev https://github.com/sazardev/shiki\nscoop install shiki",
+  },
+  macArm: {
+    label: "Homebrew",
+    command: "brew install sazardev/shiki/shiki",
+  },
+};
+
+function initQuickInstall() {
+  const label = document.getElementById("quick-install-label");
+  const cmd = document.getElementById("quick-install-cmd");
+  const altLine = document.getElementById("install-alt-line");
+  if (!cmd) return; // this script is shared across pages — not every page has the hero install block
+
+  const preset = QUICK_INSTALL[detectPlatformKey()];
+  if (preset) {
+    cmd.textContent = preset.command;
+    if (label) label.textContent = `Quick install (${preset.label}):`;
+    // Cargo is the fallback shown as an "optional" secondary line only once
+    // the primary command above has actually become something else — with
+    // no override (Linux/unknown), it's already the primary, so a second
+    // "or cargo install" line right under it would just repeat itself.
+    if (altLine) altLine.hidden = false;
+  }
 }
 
 // A hung (not failed) request otherwise never resolves or rejects — the
@@ -665,6 +708,7 @@ document.addEventListener("DOMContentLoaded", () => {
   initTheme();
   loadChangelog();
   loadLatestRelease();
+  initQuickInstall();
   loadContributors();
   initCopyButtons();
   const versionPopover = initVersionPopover();

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -32,7 +32,7 @@ Key facts for citation or summarization:
 
 - [Full reference documentation](https://sazardev.github.io/shiki/documentation.html): every keybinding, every CLI command, the complete `config.toml` schema, note file format, and included themes.
 - [README](https://github.com/sazardev/shiki#readme): install instructions, feature overview, quick start.
-- [Changelog](https://github.com/sazardev/shiki/blob/main/CHANGELOG.md): version history, Keep a Changelog format.
+- [Changelog](https://sazardev.github.io/shiki/changelog.html): version history, Keep a Changelog format.
 
 ## Project
 

--- a/docs/sitemap.xml
+++ b/docs/sitemap.xml
@@ -12,4 +12,10 @@
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
+  <url>
+    <loc>https://sazardev.github.io/shiki/changelog.html</loc>
+    <lastmod>2026-08-05</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.6</priority>
+  </url>
 </urlset>


### PR DESCRIPTION
## Summary
- Fixed the nav's version-pill `<button>`: it was rendering with the browser's default white button chrome and off-center text instead of the themed, borderless pill every other `.pill` uses.
- Centered the topbar nav links with the version chip (`align-items: center`) — link text sat visibly higher than the chip's text before.
- Moved the changelog off the homepage into its own page (`docs/changelog.html`, full uncapped history, still fetched live from `CHANGELOG.md`). Nav links and the version-pill popover's "Full changelog →" link across every page now point there instead of `#changelog`/the GitHub blob URL.
- The hero now shows an OS-detected "quick install" command — Homebrew on macOS, Scoop on Windows — with `cargo install shiki-cli` demoted to an optional fallback line shown underneath. Linux/undetected OS keeps cargo as the primary command, since there's no single universal Linux package manager for shiki yet.

## Test plan
- [x] Verified locally via `python3 -m http.server` in `docs/`: pill renders themed/centered on `index.html`/`documentation.html`, popover opens and its "Full changelog →" link lands on `changelog.html`.
- [x] Confirmed `changelog.html` renders every version (not just the old 5-version cap) and the nav "Changelog" link highlights active.
- [x] Simulated Windows/macOS/Linux detection paths in-browser — correct command + fallback-line visibility in each case; copy buttons copy the right text.
- [ ] CI (fmt/clippy/build) — no Rust code touched, docs-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)