### PR TITLE
feat(editor): add writing-comfort improvements to the native note editor

### DIFF
--- a/IDEA.md
+++ b/IDEA.md
@@ -211,7 +211,8 @@ search, tree view) using the same list/selection they already navigate with `j`/
 | `P` | Publish the selected notebook to a themed PDF via `pretty-pdf` (external binary, auto-fetched on first use — see CLI commands), written to `{data_dir}/exports/{notebook}.pdf`, then opened. Same rendering `shiki publish` uses; the theme comes from `export.pdf_theme`, cyclable in Settings → EXPORT |
 | `U` | Check for updates — modal; checks GitHub Releases in the background (never blocks the UI), shows "update available" if there's a newer version, and `Enter` downloads, verifies (against GitHub's own per-asset checksum), installs, and automatically relaunches into it |
 | `u` | Undo the last delete — restores the most recently deleted note/folder (or whole batch, from a Visual-mode delete) from the trash (`~/.config/shiki/trash/`) back to exactly where it came from. A single level of undo, not a full history: only the *most recent* delete is restorable this way; an older one is still on disk in the trash, just no longer reachable from here. With nothing to undo, reports that instead of doing anything |
-| `s` | Settings — near-full-screen, paged by tab (`←`/`→` switches GENERAL/THEME/GIT/EDITOR/EXPORT/NOTEBOOKS/SNIPPETS, `j`/`k` moves within one). Doesn't repeat the keybindings tables — `?` (which-key) already covers those live. Every tab is editable with `Enter`: GENERAL/GIT booleans (`use_favorite_editor`, `auto_commit`/`auto_push`/`sign_commits`/`auto_sync`) toggle in place and save immediately; every other GENERAL/GIT field opens a prompt prefilled with its current value; THEME's `name` opens the theme picker (live preview, same as leader+`c`) and `overrides` stays informational; EDITOR is six plain boolean toggles for the native note editor's UX (see `[editor]` below); EXPORT is one field, `pdf_theme`, cycling through `pretty-pdf`'s 17 built-in themes (the default `shiki publish`/leader+`P` fall back to); NOTEBOOKS lists every notebook's actual git remote (redacted) and drills into one to edit its remote plus its `auto_push`/`auto_sync`/`auto_sync_every` overrides (booleans cycle inherit → true → false → inherit); SNIPPETS supports `a` (new snippet) and `d` (delete, with confirmation), and drilling into one edits its `label` and its full multi-line `body` through the same inline editor a note's own body uses. `i`/`E` still jump straight to editing `config.toml` itself for anything not covered above (inline or externally, same convention as editing a note); on save, the config is re-read, re-applied, and takes effect immediately (no restart) — an invalid edit is reported and neither written nor applied, keeping the previous config running. `h`/`Esc`/`Backspace` backs out of a drilled-into notebook/snippet a level; `Esc`/`q` at the top level closes |
+| `s` | Settings — near-full-screen, paged by tab (`←`/`→` switches GENERAL/THEME/GIT/EDITOR/EXPORT/NOTEBOOKS/SNIPPETS, `j`/`k` moves within one). Doesn't repeat the keybindings tables — `?` (which-key) already covers those live. Every tab is editable with `Enter`: GENERAL/GIT booleans (`use_favorite_editor`, `auto_commit`/`auto_push`/`sign_commits`/`auto_sync`) toggle in place and save immediately; every other GENERAL/GIT field opens a prompt prefilled with its current value; THEME's `name` opens the theme picker (live preview, same as leader+`c`) and `overrides` stays informational; EDITOR is twelve plain boolean toggles for the native note editor's UX (see `[editor]` below); EXPORT is one field, `pdf_theme`, cycling through `pretty-pdf`'s 17 built-in themes (the default `shiki publish`/leader+`P` fall back to); NOTEBOOKS lists every notebook's actual git remote (redacted) and drills into one to edit its remote plus its `auto_push`/`auto_sync`/`auto_sync_every` overrides (booleans cycle inherit → true → false → inherit); SNIPPETS supports `a` (new snippet) and `d` (delete, with confirmation), and drilling into one edits its `label` and its full multi-line `body` through the same inline editor a note's own body uses. `i`/`E` still jump straight to editing `config.toml` itself for anything not covered above (inline or externally, same convention as editing a note); on save, the config is re-read, re-applied, and takes effect immediately (no restart) — an invalid edit is reported and neither written nor applied, keeping the previous config running. `h`/`Esc`/`Backspace` backs out of a drilled-into notebook/snippet a level; `Esc`/`q` at the top level closes |
+| `z` | Zen mode — forces the full-screen single-panel layout (the same one a very small terminal already falls into) regardless of actual terminal size, hiding NOTEBOOKS/NOTES so only the focused panel shows. A true toggle, same `leader z` both enters and exits it; purely a view state, not persisted to `config.toml` |
 
 #### `[keybindings.notebooks]` — active while NOTEBOOKS is focused
 
@@ -262,6 +263,7 @@ sync attempt (manual or automatic) just tries the push again.
 | `E` | Edit externally ($EDITOR) |
 | `H` | Note history — every commit that changed this specific note, newest first, real git history (not a separate versioning system). `j`/`k`/`PageUp`/`PageDown`/`Home`/`End` move, `Enter` views a revision's full content (frontmatter included, since that's what's actually in the commit), `r` reverts to the highlighted (or currently-viewed) revision — behind a confirmation, since it overwrites the current content. The revert itself doesn't commit; it shows up as a normal pending change, picked up by `s`/`u`/`auto_sync` like any other edit. The footer shows the count while reading a note (`{n} changes`) |
 | `L` | Links — the selected note's outgoing `[[wikilinks]]` (resolved against every note in the notebook, any folder depth), every other note that links back to it, and notes that *mention* this note's title in plain text without linking to it ("Outgoing"/"Backlinks"/"Mentions (unlinked)" sections; a section with nothing in it is omitted). `j`/`k`/`PageUp`/`PageDown`/`Home`/`End` move, `Enter` jumps to the selected note (an unresolved outgoing link reports that instead of jumping), `c` on a mention row *repairs* the missed link — it wraps that note's plain-text mention into a real `[[wikilink]]` (preserving its casing) and the row visibly migrates to Backlinks — and `Esc`/`q` closes. Also reachable globally via leader+`B` |
+| `o` | Outline — every `#`..`######` heading in the selected note, indented by level. `j`/`k`/`PageUp`/`PageDown`/`Home`/`End` move, `Enter` scrolls PREVIEW to that heading, `Esc`/`q` closes. Also reachable as `Ctrl+O` from inside `Mode::Edit` itself — there, `Enter` moves the editor's own cursor to the heading instead of scrolling PREVIEW, and the headings come from the live, possibly-unsaved buffer rather than the note's last-saved body |
 
 Mouse: a plain click over a note's rendered body jumps straight into the inline editor with the
 cursor on the clicked line — a mouse-only alternative to `i`/vim motions. Click-and-drag instead
@@ -317,6 +319,25 @@ The rest of the editor's mouse/keyboard UX is opt-in via `[editor]` (Settings' E
   saves and exits, as usual). Secondary cursors render as a solid accent-colored block (bold,
   distinct from the primary's plain reverse-video) — a terminal can only blink one real caret, so
   this is the compensating visual signal rather than an attempt to actually blink more than one.
+- `auto_list_continue` (on by default): `Enter` on a `- item`/`- [ ] task`/`1. item` line carries
+  the same prefix onto the next line (checkboxes always reset to `[ ]`, never copy `[x]`); `Enter`
+  on an already-empty list item exits the list instead of continuing it, and `Backspace` right
+  after an empty prefix removes it in one step instead of one character at a time.
+- `format_shortcuts` (on by default): `Ctrl+B` wraps the current selection in `**bold**`;
+  `Ctrl+Alt+I` does the same for `_italic_` (not `Ctrl+I` — that's indistinguishable from `Tab` at
+  the terminal level in most emulators). With nothing selected, either inserts an empty pair with
+  the cursor left in the middle.
+- `auto_pair_brackets` (on by default): typing `(`, `` ` ``, or `"` wraps the current selection in
+  the matching pair, or inserts an empty pair with the cursor in the middle. Deliberately excludes
+  `[` so it can't interfere with `[[wikilink]]` autocomplete below, which depends on the user
+  typing two real `[` characters in a row.
+- `paste_url_as_link` (on by default): pasting a bare URL over an active selection wraps it as
+  `[selected text](url)` instead of replacing the selection with the raw URL.
+- `snippet_expand_tab` (on by default): `Tab`, when the text immediately before the cursor matches
+  a configured snippet trigger, replaces that trigger text with the snippet's body instead of
+  inserting a literal tab.
+- `typewriter_scroll` (off by default): keeps the cursor's line vertically centered in the editor
+  viewport while typing, instead of only scrolling once the cursor reaches the edge.
 
 `[[wikilink]]` autocomplete is always on too, not gated by `[editor]`: typing `[[` opens an
 Obsidian-style fuzzy note picker (same fuzzy matching as `/` and global search), showing each
@@ -540,6 +561,8 @@ scratchpad = "p"
 links = "B"
 # Global tasks view — every checkbox task in every notebook.
 tasks_panel = "t"
+# Full-screen single-panel layout, hiding NOTEBOOKS/NOTES — a true toggle.
+zen_mode = "z"
 
 [keybindings.notebooks]
 new = "a"
@@ -572,6 +595,7 @@ edit_inline = "i"
 edit_external = "E"
 history = "H"
 links = "L"
+outline = "o"
 
 [theme]
 name = "gruvbox-dark"
@@ -618,6 +642,12 @@ os_clipboard = false     # Ctrl+C/X/V use the real OS clipboard (falls back to O
 select_all_ctrl_a = false  # Ctrl+A selects everything instead of "start of line"
 line_numbers = false     # shows a line-number gutter
 multi_cursor = false     # Alt+Click adds a cursor, Ctrl+D adds the next occurrence
+auto_list_continue = true  # Enter continues a list/checkbox line; empty item exits it
+format_shortcuts = true    # Ctrl+B / Ctrl+Alt+I wrap the selection in bold/italic
+auto_pair_brackets = true  # typing ( ` " wraps the selection or inserts an empty pair
+paste_url_as_link = true   # pasting a URL over a selection wraps it as a markdown link
+snippet_expand_tab = true  # Tab expands a matching snippet trigger
+typewriter_scroll = false  # keeps the cursor's line vertically centered while typing
 
 # PDF export (`shiki publish`, leader+`P`) — pdf_theme picks one of
 # go-pretty-pdf's 17 built-in themes: default, minimal, modern, classic,

--- a/IDEA.md
+++ b/IDEA.md
@@ -320,9 +320,13 @@ The rest of the editor's mouse/keyboard UX is opt-in via `[editor]` (Settings' E
   distinct from the primary's plain reverse-video) — a terminal can only blink one real caret, so
   this is the compensating visual signal rather than an attempt to actually blink more than one.
 - `auto_list_continue` (on by default): `Enter` on a `- item`/`- [ ] task`/`1. item` line carries
-  the same prefix onto the next line (checkboxes always reset to `[ ]`, never copy `[x]`); `Enter`
-  on an already-empty list item exits the list instead of continuing it, and `Backspace` right
-  after an empty prefix removes it in one step instead of one character at a time.
+  the same prefix onto the next line (checkboxes always reset to `[ ]`, never copy `[x]`; an
+  ordered `N.` marker increments — `1.` → `2.` → `3.` … as you keep pressing `Enter`, rather than
+  repeating the same number); `Enter` on an already-empty list item exits the list instead of
+  continuing it, and `Backspace` right after an empty prefix removes it in one step instead of one
+  character at a time. The same setting also gates `Tab`/`Shift+Tab` on a list/checkbox line with
+  nothing selected: they nest it one level deeper or back out (adding/removing 2 leading spaces),
+  keeping the cursor over the same character.
 - `format_shortcuts` (on by default): `Ctrl+B` wraps the current selection in `**bold**`;
   `Ctrl+Alt+I` does the same for `_italic_` (not `Ctrl+I` — that's indistinguishable from `Tab` at
   the terminal level in most emulators). With nothing selected, either inserts an empty pair with
@@ -347,11 +351,15 @@ distinguishable; picking one inserts `[[Title]]`. In PREVIEW, `Ctrl`+click on a 
 everywhere, including on top of a wikilink.
 
 Navigation inside the editor is always on, not gated by `[editor]`: `PageUp`/`PageDown` move the
-cursor a page at a time, `Home`/`End` go to the start/end of the current line, `Ctrl+Home`/
-`Ctrl+End` jump to the very start/end of the note, and the mouse wheel scrolls too. `PageUp`/
-`PageDown`/mouse-wheel scrolling move the cursor itself (there's no independent scroll offset —
-the editor's word-wrap support means it bypasses `tui-textarea`'s own rendering, and with it,
-`tui-textarea`'s own viewport-based `PageUp`/`PageDown`, which otherwise does nothing here).
+cursor a page at a time, plain `Home` is "smart" — the first press goes to the line's first
+non-whitespace character, pressing it again (or pressing it on a line already at column 0) goes to
+column 0 — `End` goes to the end of the current line, `Ctrl+Home`/`Ctrl+End` jump to the very
+start/end of the note, and the mouse wheel scrolls too. `PageUp`/`PageDown`/mouse-wheel scrolling
+move the cursor itself (there's no independent scroll offset — the editor's word-wrap support
+means it bypasses `tui-textarea`'s own rendering, and with it, `tui-textarea`'s own viewport-based
+`PageUp`/`PageDown`, which otherwise does nothing here). `Tab`/`Shift+Tab` with an active selection
+indent/outdent every line the selection spans — a plain block-indent, not list-specific, also
+always on regardless of `auto_list_continue`.
 
 ---
 

--- a/shiki-cli/src/commands/doctor.rs
+++ b/shiki-cli/src/commands/doctor.rs
@@ -327,6 +327,7 @@ fn check_keybinding_health(config: &Config, r: &mut Report) {
                 ("tasks_panel", kb.global.tasks_panel.as_str()),
                 ("publish", kb.global.publish.as_str()),
                 ("export", kb.global.export.as_str()),
+                ("zen_mode", kb.global.zen_mode.as_str()),
             ],
         ),
         (
@@ -368,6 +369,7 @@ fn check_keybinding_health(config: &Config, r: &mut Report) {
                 ("edit_external", kb.preview.edit_external.as_str()),
                 ("history", kb.preview.history.as_str()),
                 ("links", kb.preview.links.as_str()),
+                ("outline", kb.preview.outline.as_str()),
             ],
         ),
     ];

--- a/shiki-config/src/config.rs
+++ b/shiki-config/src/config.rs
@@ -219,6 +219,12 @@ pub struct GlobalKeybindings {
     /// `toggle_favorite_editor`.
     #[serde(default = "default_export_key")]
     pub export: String,
+    /// Forces the full-screen single-panel layout regardless of terminal
+    /// size, hiding NOTEBOOKS/NOTES for distraction-free writing. Field-
+    /// level default for the same backward-compatibility reason as
+    /// `logs`/`toggle_favorite_editor`.
+    #[serde(default = "default_zen_mode_key")]
+    pub zen_mode: String,
 }
 
 impl Default for GlobalKeybindings {
@@ -238,8 +244,13 @@ impl Default for GlobalKeybindings {
             tasks_panel: default_tasks_panel_key(),
             publish: default_publish_key(),
             export: default_export_key(),
+            zen_mode: default_zen_mode_key(),
         }
     }
+}
+
+fn default_zen_mode_key() -> String {
+    "z".into()
 }
 
 fn default_publish_key() -> String {
@@ -525,6 +536,12 @@ pub struct PreviewKeybindings {
     /// backward-compatibility reasoning as `history`.
     #[serde(default = "default_links_key")]
     pub links: String,
+    /// Opens the outline modal — every heading in the selected note, jump
+    /// straight to one. Also reachable as `Ctrl+O` inside `Mode::Edit`
+    /// itself. Same field-level-default backward-compatibility reasoning
+    /// as `history`.
+    #[serde(default = "default_outline_key")]
+    pub outline: String,
 }
 
 impl Default for PreviewKeybindings {
@@ -534,8 +551,13 @@ impl Default for PreviewKeybindings {
             edit_external: default_preview_edit_external_key(),
             history: default_history_key(),
             links: default_links_key(),
+            outline: default_outline_key(),
         }
     }
+}
+
+fn default_outline_key() -> String {
+    "o".into()
 }
 
 fn default_preview_edit_inline_key() -> String {
@@ -852,6 +874,46 @@ pub struct EditorConfig {
     /// something the library supports natively.
     #[serde(default)]
     pub multi_cursor: bool,
+    /// Enter on a `- item`/`- [ ] task`/`1. item` line continues the same
+    /// prefix on the next line (checkboxes always reset to `[ ]`, never copy
+    /// `[x]`); Enter on an *empty* list item exits the list instead of
+    /// continuing it, and Backspace right after an empty prefix removes it
+    /// in one step. Defaults to `true`: purely additive list-editing
+    /// convenience, doesn't touch any existing binding.
+    #[serde(default = "default_true")]
+    pub auto_list_continue: bool,
+    /// Ctrl+B wraps the selection in `**bold**` (or inserts an empty pair
+    /// with the cursor in the middle if nothing's selected); Ctrl+Alt+I does
+    /// the same for `_italic_` (not Ctrl+I — that collides with Tab at the
+    /// terminal level in most emulators). Defaults to `true`: purely
+    /// additive, doesn't touch any existing binding.
+    #[serde(default = "default_true")]
+    pub format_shortcuts: bool,
+    /// Typing `(`, `` ` ``, or `"` wraps the current selection in the
+    /// matching pair, or inserts an empty pair with the cursor in the
+    /// middle if nothing's selected. Deliberately excludes `[` so it can't
+    /// interfere with `[[wikilink]]` autocomplete, which depends on the
+    /// user typing two real `[` characters in a row. Defaults to `true`.
+    #[serde(default = "default_true")]
+    pub auto_pair_brackets: bool,
+    /// Pasting a bare URL over an active selection wraps it as
+    /// `[selected text](url)` instead of replacing the selection with the
+    /// raw URL. Defaults to `true`: only triggers when the pasted text is
+    /// itself a URL, otherwise paste behaves exactly as before.
+    #[serde(default = "default_true")]
+    pub paste_url_as_link: bool,
+    /// Tab, when the text immediately before the cursor matches a
+    /// configured snippet trigger, replaces that trigger text with the
+    /// snippet's body instead of inserting a literal tab. Falls through to
+    /// normal Tab behavior when there's no match. Defaults to `true`.
+    #[serde(default = "default_true")]
+    pub snippet_expand_tab: bool,
+    /// Keeps the cursor's line vertically centered in the editor viewport
+    /// while typing, instead of only scrolling once the cursor reaches the
+    /// edge. Off by default: it's a visible change to how scrolling feels,
+    /// not a pure addition, so it needs an explicit opt-in.
+    #[serde(default)]
+    pub typewriter_scroll: bool,
 }
 
 impl Default for EditorConfig {
@@ -863,6 +925,12 @@ impl Default for EditorConfig {
             select_all_ctrl_a: false,
             line_numbers: false,
             multi_cursor: false,
+            auto_list_continue: true,
+            format_shortcuts: true,
+            auto_pair_brackets: true,
+            paste_url_as_link: true,
+            snippet_expand_tab: true,
+            typewriter_scroll: false,
         }
     }
 }
@@ -1244,7 +1312,20 @@ fn section_comment(line: &str) -> Option<&'static str> {
 #   start of the line.
 # - line_numbers: shows a line-number gutter.
 # - multi_cursor: Alt+Click adds a cursor, Ctrl+D adds the next occurrence
-#   of the current word/selection."
+#   of the current word/selection.
+# - auto_list_continue: Enter on a list/checkbox line continues it on the
+#   next line; Enter on an empty item exits the list; Backspace removes an
+#   empty item's prefix in one step. Defaults to true.
+# - format_shortcuts: Ctrl+B / Ctrl+Alt+I wrap the selection in bold/italic.
+#   Defaults to true.
+# - auto_pair_brackets: typing ( ` \" wraps the selection or inserts an
+#   empty pair. Defaults to true.
+# - paste_url_as_link: pasting a bare URL over a selection wraps it as a
+#   markdown link. Defaults to true.
+# - snippet_expand_tab: Tab expands a matching snippet trigger instead of
+#   inserting a literal tab. Defaults to true.
+# - typewriter_scroll: keeps the cursor's line vertically centered while
+#   typing. Defaults to false."
         }
         "[export]" => {
             "\

--- a/shiki-core/src/headings.rs
+++ b/shiki-core/src/headings.rs
@@ -1,0 +1,97 @@
+//! Markdown ATX headings (`#` through `######`) extracted from a note's
+//! body, for the outline-jump modal (`shiki-tui`'s PREVIEW-scope `o` /
+//! `Mode::Edit`'s Ctrl+O). `extract` is a pure function of a body string,
+//! same shape as `tasks::extract` — unit-testable without touching disk.
+
+use std::sync::OnceLock;
+
+use regex::Regex;
+
+/// One heading line found in a note's body.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Heading {
+    /// 0-based line index within the body, for `CursorMove::Jump`/preview
+    /// scroll positioning.
+    pub line: usize,
+    /// 1-6, the number of leading `#` characters.
+    pub level: u8,
+    /// The heading text with the leading `#`s and surrounding whitespace
+    /// stripped.
+    pub text: String,
+}
+
+fn heading_re() -> &'static Regex {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    RE.get_or_init(|| Regex::new(r"^(#{1,6})\s+(.*)$").unwrap())
+}
+
+/// Every ATX heading in `body`, in document order.
+pub fn extract(body: &str) -> Vec<Heading> {
+    body.lines()
+        .enumerate()
+        .filter_map(|(line, text)| {
+            let caps = heading_re().captures(text)?;
+            Some(Heading {
+                line,
+                level: caps[1].len() as u8,
+                text: caps[2].trim_end().to_string(),
+            })
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn extracts_headings_in_order() {
+        let body = "# Title\n\nSome text\n## Section\ntext\n### Sub\n";
+        let headings = extract(body);
+        assert_eq!(headings.len(), 3);
+        assert_eq!(
+            headings[0],
+            Heading {
+                line: 0,
+                level: 1,
+                text: "Title".into()
+            }
+        );
+        assert_eq!(
+            headings[1],
+            Heading {
+                line: 3,
+                level: 2,
+                text: "Section".into()
+            }
+        );
+        assert_eq!(
+            headings[2],
+            Heading {
+                line: 5,
+                level: 3,
+                text: "Sub".into()
+            }
+        );
+    }
+
+    #[test]
+    fn ignores_non_heading_hashes() {
+        let body = "no heading here\n#nohash\n#### Real heading";
+        let headings = extract(body);
+        assert_eq!(headings.len(), 1);
+        assert_eq!(headings[0].text, "Real heading");
+    }
+
+    #[test]
+    fn trims_trailing_whitespace_from_text() {
+        let body = "## Section   \n";
+        let headings = extract(body);
+        assert_eq!(headings[0].text, "Section");
+    }
+
+    #[test]
+    fn empty_body_has_no_headings() {
+        assert!(extract("").is_empty());
+    }
+}

--- a/shiki-core/src/lib.rs
+++ b/shiki-core/src/lib.rs
@@ -3,6 +3,7 @@ pub mod daily;
 pub mod editor;
 pub mod export;
 pub mod git;
+pub mod headings;
 pub mod note;
 pub mod notebook;
 pub mod process;

--- a/shiki-tui/src/app.rs
+++ b/shiki-tui/src/app.rs
@@ -401,6 +401,12 @@ pub struct App {
     /// Index into the *filtered* notes list, only meaningful while
     /// `tags_viewing.is_some()`.
     pub tags_notes_selected: usize,
+    pub show_outline: bool,
+    /// Snapshotted the instant the outline opens (`open_outline`) — from
+    /// the selected note's saved body normally, or the live editor buffer
+    /// when opened via `Ctrl+O` mid-edit, so unsaved headings show up too.
+    pub outline_headings: Vec<shiki_core::headings::Heading>,
+    pub outline_selected: usize,
     pub status_message: Option<String>,
     /// When `status_message` was last set — the footer only shows it for
     /// `STATUS_MESSAGE_TIMEOUT`, after which `expire_status_message` (called
@@ -423,6 +429,13 @@ pub struct App {
     pub drawer_statuses: Vec<(String, shiki_core::git::GitStatus)>,
     pub show_drawer: bool,
     pub drawer_selected: usize,
+    /// Session-only toggle (`leader z`, `Action::ToggleZenMode`) — forces
+    /// `layout::split` into its `single()` full-screen-focused-panel tier
+    /// regardless of terminal size, hiding NOTEBOOKS/NOTES for
+    /// distraction-free writing. Not persisted to `config.toml`, same as
+    /// `show_drawer`/`show_settings`: it's a per-session view state, not a
+    /// user preference.
+    pub zen_mode: bool,
     pub input: InputBox,
     pub confirm: Option<confirm::ConfirmDialog>,
     pub editor: Option<InlineEditor<'static>>,
@@ -905,6 +918,9 @@ impl App {
             tags_selected: 0,
             tags_viewing: None,
             tags_notes_selected: 0,
+            show_outline: false,
+            outline_headings: Vec::new(),
+            outline_selected: 0,
             status_message: None,
             status_message_set_at: None,
             git_status,
@@ -912,6 +928,7 @@ impl App {
             drawer_statuses: Vec::new(),
             show_drawer: false,
             drawer_selected: 0,
+            zen_mode: false,
             input: InputBox::default(),
             confirm: None,
             editor: None,
@@ -1475,7 +1492,7 @@ impl App {
                     .selected_note()
                     .map(|n| n.body.lines().count() as u16)
                     .unwrap_or(0);
-                let content_height = layout::split(self.last_frame_area, self.focus)
+                let content_height = layout::split(self.last_frame_area, self.focus, self.zen_mode)
                     .preview
                     .height
                     .saturating_sub(2);
@@ -1712,7 +1729,7 @@ impl App {
             hex_to_color(&self.theme.link),
             hex_to_color(&self.theme.bg),
         ];
-        let width = layout::split(self.last_frame_area, self.focus)
+        let width = layout::split(self.last_frame_area, self.focus, self.zen_mode)
             .preview
             .width
             .saturating_sub(2);

--- a/shiki-tui/src/draw.rs
+++ b/shiki-tui/src/draw.rs
@@ -5,8 +5,8 @@ use crate::app::{
 use crate::icons;
 use crate::render::{hex_to_color, panel_block};
 use crate::{
-    layout, panel_drawer, panel_notebooks, panel_notes, panel_preview, panel_settings, panel_tags,
-    panel_tasks, status_bar, which,
+    layout, panel_drawer, panel_notebooks, panel_notes, panel_outline, panel_preview,
+    panel_settings, panel_tags, panel_tasks, status_bar, which,
 };
 use ratatui::layout::{Constraint, Layout, Rect};
 use ratatui::style::{Modifier, Style};
@@ -20,7 +20,7 @@ pub fn draw(frame: &mut Frame, app: &App) {
         .style(ratatui::style::Style::default().bg(hex_to_color(&app.theme.bg)));
     frame.render_widget(background, frame.area());
 
-    let areas = layout::split(frame.area(), app.focus);
+    let areas = layout::split(frame.area(), app.focus, app.zen_mode);
     panel_notebooks::render(frame, areas.notebooks, app);
     panel_notes::render(frame, areas.notes, app);
     if app.mode == Mode::Edit {
@@ -33,10 +33,13 @@ pub fn draw(frame: &mut Frame, app: &App) {
             editor.render(
                 frame,
                 areas.preview,
-                app.config.editor.line_numbers,
-                gutter_style,
-                secondary_cursor_style,
-                &app.editor_secondary_cursors,
+                crate::editor::RenderOptions {
+                    line_numbers: app.config.editor.line_numbers,
+                    gutter_style,
+                    secondary_cursor_style,
+                    secondary_cursors: &app.editor_secondary_cursors,
+                    typewriter_scroll: app.config.editor.typewriter_scroll,
+                },
             );
             if app.show_slash_menu {
                 render_slash_menu(frame, areas.preview, editor, app);
@@ -146,6 +149,13 @@ pub fn draw(frame: &mut Frame, app: &App) {
         let popup_area = centered_rect(frame.area(), 40, (rows as u16 + 2).max(3));
         frame.render_widget(Clear, popup_area);
         panel_tags::render(frame, popup_area, app);
+    }
+
+    if app.show_outline {
+        let rows = app.outline_headings.len().max(1);
+        let popup_area = centered_rect(frame.area(), 50, (rows as u16 + 2).max(3));
+        frame.render_widget(Clear, popup_area);
+        panel_outline::render(frame, popup_area, app);
     }
 
     if app.show_drawer {

--- a/shiki-tui/src/editor.rs
+++ b/shiki-tui/src/editor.rs
@@ -66,6 +66,18 @@ pub struct InlineEditor<'a> {
     cursor_screen_row: Cell<u16>,
 }
 
+/// Bundles `InlineEditor::render`'s style/state parameters (everything
+/// besides `&self`/`frame`/`area`) into one value — keeps the function's
+/// own parameter count under clippy's `too_many_arguments` threshold, which
+/// `typewriter_scroll` pushed past once it was added as a plain 8th param.
+pub(crate) struct RenderOptions<'a> {
+    pub line_numbers: bool,
+    pub gutter_style: Style,
+    pub secondary_cursor_style: Style,
+    pub secondary_cursors: &'a [crate::multicursor::CursorState],
+    pub typewriter_scroll: bool,
+}
+
 impl<'a> InlineEditor<'a> {
     pub fn from_contents(contents: &str) -> Self {
         let lines: Vec<String> = if contents.is_empty() {
@@ -181,15 +193,7 @@ impl<'a> InlineEditor<'a> {
     /// Renders the buffer word-wrapped to `area`'s width, instead of
     /// `ratatui-textarea`'s own unwrapped-with-horizontal-scroll rendering —
     /// see the struct doc comment for why this exists at all.
-    pub(crate) fn render(
-        &self,
-        frame: &mut Frame,
-        area: Rect,
-        line_numbers: bool,
-        gutter_style: Style,
-        secondary_cursor_style: Style,
-        secondary_cursors: &[crate::multicursor::CursorState],
-    ) {
+    pub(crate) fn render(&self, frame: &mut Frame, area: Rect, opts: RenderOptions) {
         if let Some(block) = self.textarea.block() {
             frame.render_widget(block.clone(), area);
         }
@@ -197,7 +201,7 @@ impl<'a> InlineEditor<'a> {
         if inner.width == 0 || inner.height == 0 {
             return;
         }
-        let gutter = self.gutter_width(line_numbers);
+        let gutter = self.gutter_width(opts.line_numbers);
         let width = (inner.width as usize)
             .saturating_sub(gutter as usize)
             .max(1);
@@ -237,11 +241,19 @@ impl<'a> InlineEditor<'a> {
         let cursor_visual_row = visual_offset_of + cursor_local_row;
         let total_visual_rows: usize = wraps.iter().map(Vec::len).sum();
 
-        let mut scroll_top = next_scroll_top(
-            self.scroll_top.get(),
-            cursor_visual_row as u16,
-            height as u16,
-        );
+        // `typewriter_scroll` (`config.editor.typewriter_scroll`): keep the
+        // cursor's row vertically centered instead of only scrolling once
+        // it reaches the viewport's edge — a real re-centering every
+        // keystroke, not a threshold like `next_scroll_top`'s default.
+        let mut scroll_top = if opts.typewriter_scroll {
+            (cursor_visual_row as u16).saturating_sub(height as u16 / 2)
+        } else {
+            next_scroll_top(
+                self.scroll_top.get(),
+                cursor_visual_row as u16,
+                height as u16,
+            )
+        };
         let max_scroll = total_visual_rows.saturating_sub(height) as u16;
         scroll_top = scroll_top.min(max_scroll);
         self.scroll_top.set(scroll_top);
@@ -258,7 +270,7 @@ impl<'a> InlineEditor<'a> {
             // shiki never calls `set_selection_style`, so this is the same
             // value `TextArea::default()` already uses internally.
             select: Style::default().bg(Color::LightBlue),
-            secondary_cursor: secondary_cursor_style,
+            secondary_cursor: opts.secondary_cursor_style,
         };
         let selection = self.textarea.selection_range();
 
@@ -276,7 +288,7 @@ impl<'a> InlineEditor<'a> {
                         cursor_col,
                         is_cursor_segment: row == cursor_row && local_idx == cursor_local_row,
                         selection,
-                        secondary: secondary_cursors,
+                        secondary: opts.secondary_cursors,
                     };
                     let mut line = build_segment_line(chars, seg, &ctx, &styles);
                     if gutter > 0 {
@@ -285,7 +297,8 @@ impl<'a> InlineEditor<'a> {
                         } else {
                             " ".repeat(gutter as usize)
                         };
-                        line.spans.insert(0, Span::styled(prefix, gutter_style));
+                        line.spans
+                            .insert(0, Span::styled(prefix, opts.gutter_style));
                     }
                     rendered.push(line);
                 }
@@ -762,7 +775,17 @@ mod tests {
             .expect("test backend");
         terminal
             .draw(|frame| {
-                editor.render(frame, area, false, Style::default(), Style::default(), &[])
+                editor.render(
+                    frame,
+                    area,
+                    RenderOptions {
+                        line_numbers: false,
+                        gutter_style: Style::default(),
+                        secondary_cursor_style: Style::default(),
+                        secondary_cursors: &[],
+                        typewriter_scroll: false,
+                    },
+                )
             })
             .unwrap();
 
@@ -786,7 +809,19 @@ mod tests {
         let mut terminal = ratatui::Terminal::new(ratatui::backend::TestBackend::new(20, 5))
             .expect("test backend");
         terminal
-            .draw(|frame| editor.render(frame, area, true, Style::default(), Style::default(), &[]))
+            .draw(|frame| {
+                editor.render(
+                    frame,
+                    area,
+                    RenderOptions {
+                        line_numbers: true,
+                        gutter_style: Style::default(),
+                        secondary_cursor_style: Style::default(),
+                        secondary_cursors: &[],
+                        typewriter_scroll: false,
+                    },
+                )
+            })
             .unwrap();
         // Gutter for a 1-line file is "1 " (2 columns) — a click landing
         // in the gutter itself clamps to column 0 of the actual text.

--- a/shiki-tui/src/icons.rs
+++ b/shiki-tui/src/icons.rs
@@ -28,3 +28,4 @@ pub const UNDO: char = '\u{f0e2}'; // undo, restore-from-trash
 pub const GEAR: char = '\u{f013}'; // gear/cog, settings screen
 pub const IMAGE: char = '\u{f03e}'; // picture-o, markdown image placeholder in the preview
 pub const PDF: char = '\u{f1c1}'; // file-pdf-o, publish-to-PDF action
+pub const EXPAND: char = '\u{f065}'; // arrows-alt (expand), zen mode

--- a/shiki-tui/src/key_handlers.rs
+++ b/shiki-tui/src/key_handlers.rs
@@ -18,6 +18,12 @@ use crate::{
     status_bar,
 };
 
+/// Spaces added/removed per level by the editor's list indent/outdent
+/// (`try_indent_list_line`/`indent_selected_lines`) — 2 lines up under a
+/// `- `/`* `/`+ ` marker's own width, the same convention CommonMark's
+/// nested-list rules already expect.
+const LIST_INDENT_STEP: usize = 2;
+
 impl App {
     fn open_theme_picker(&mut self) {
         self.theme_picker_index = self.theme_index;
@@ -3750,11 +3756,37 @@ impl App {
             {
                 self.editor_duplicate_line();
             }
-            // Tab expands a matching snippet trigger — see
-            // `try_expand_snippet_on_tab`'s own doc comment. Falls through
-            // to plain Tab (a literal tab character) when nothing matches.
-            KeyCode::Tab if self.config.editor.snippet_expand_tab => {
-                if !self.try_expand_snippet_on_tab() {
+            // Tab: with an active selection, indents every line it spans
+            // (a plain block-indent, not list-specific — same as any code
+            // editor's Tab-on-a-selection); otherwise expands a matching
+            // snippet trigger; otherwise, on a list/checkbox line, nests it
+            // one level deeper. Falls through to plain Tab when none of
+            // those apply. Shift+Tab (`KeyCode::BackTab`) mirrors this in
+            // reverse (outdent), with no snippet step — there's nothing to
+            // "un-expand".
+            KeyCode::Tab => {
+                let has_selection = self
+                    .editor
+                    .as_ref()
+                    .is_some_and(|e| e.textarea.selection_range().is_some());
+                if has_selection {
+                    self.indent_selected_lines(1);
+                } else if self.config.editor.snippet_expand_tab && self.try_expand_snippet_on_tab()
+                {
+                    // handled
+                } else if !(self.config.editor.auto_list_continue && self.try_indent_list_line(1)) {
+                    self.editor_forward_key_default(key);
+                }
+            }
+            KeyCode::BackTab => {
+                let has_selection = self
+                    .editor
+                    .as_ref()
+                    .is_some_and(|e| e.textarea.selection_range().is_some());
+                if has_selection {
+                    self.indent_selected_lines(-1);
+                } else if !(self.config.editor.auto_list_continue && self.try_indent_list_line(-1))
+                {
                     self.editor_forward_key_default(key);
                 }
             }
@@ -3763,11 +3795,20 @@ impl App {
             // them to `ratatui-textarea` does nothing in this editor.
             KeyCode::PageDown => self.editor_scroll_cursor(PAGE_STEP),
             KeyCode::PageUp => self.editor_scroll_cursor(-PAGE_STEP),
-            // Plain Home/End already work via the generic forward
-            // (`ratatui-textarea`'s own `CursorMove::Head`/`End` — start/end of
-            // the *current* line, no viewport dependency). Ctrl+Home/
-            // Ctrl+End add the jump-to-document-start/end that plain
-            // Home/End don't cover, the common convention this was missing.
+            // Smart Home (no modifiers): toggles between the first
+            // non-whitespace character and column 0, instead of always
+            // column 0 — the common modern-editor convention (VS Code,
+            // JetBrains, Emacs' `back-to-indentation`). Shift+Home is left
+            // to the generic forward below, since this doesn't extend a
+            // selection — only plain, unmodified Home gets the toggle.
+            KeyCode::Home if key.modifiers.is_empty() => {
+                self.smart_home();
+            }
+            // Plain End already works via the generic forward
+            // (`ratatui-textarea`'s own `CursorMove::End` — end of the
+            // *current* line, no viewport dependency). Ctrl+Home/Ctrl+End
+            // add the jump-to-document-start/end that plain Home/End
+            // don't cover, the common convention this was missing.
             KeyCode::Home if key.modifiers.contains(KeyModifiers::CONTROL) => {
                 if let Some(editor) = &mut self.editor {
                     editor.textarea.cancel_selection();
@@ -3902,11 +3943,31 @@ impl App {
         };
         Some(&line[..indent_len + marker_len + checkbox_len])
     }
-    /// The prefix to carry onto the *next* line when continuing a list —
-    /// identical to the source prefix except a checkbox always resets to
-    /// unchecked, since copying `[x]` would silently mark the new item
-    /// done before it's even been written.
+    /// The prefix to carry onto the *next* line when continuing a list.
+    /// A checkbox always resets to unchecked, since copying `[x]` would
+    /// silently mark the new item done before it's even been written. An
+    /// ordered marker (`N.`) increments — pressing Enter repeatedly after
+    /// `1. ` walks `2. `, `3. `, … the same way Word/Notion do, rather than
+    /// repeating the same number on every line; a bullet marker (`-`/`*`/
+    /// `+`) is otherwise carried over unchanged.
     fn continuation_prefix(prefix: &str) -> String {
+        let indent_len = prefix.len() - prefix.trim_start_matches(' ').len();
+        let indent = &prefix[..indent_len];
+        let rest = &prefix[indent_len..];
+        let digits = rest.chars().take_while(|c| c.is_ascii_digit()).count();
+        if digits > 0 && rest.get(digits..digits + 2) == Some(". ") {
+            let number: u64 = rest[..digits].parse().unwrap_or(1);
+            let after = &rest[digits + 2..];
+            let checkbox = if after.starts_with("[ ] ")
+                || after.starts_with("[x] ")
+                || after.starts_with("[X] ")
+            {
+                "[ ] "
+            } else {
+                ""
+            };
+            return format!("{indent}{}. {checkbox}", number + 1);
+        }
         match prefix.find("[x] ").or_else(|| prefix.find("[X] ")) {
             Some(idx) => format!("{}[ ] ", &prefix[..idx]),
             None => prefix.to_string(),
@@ -3995,6 +4056,137 @@ impl App {
             self.editor_redo_groups.clear();
         }
         true
+    }
+    /// Tab/Shift+Tab (`config.editor.auto_list_continue`), no selection:
+    /// nests the cursor's list/checkbox line one level deeper (positive
+    /// `direction`) or back out (negative `direction`) by adding/removing
+    /// `LIST_INDENT_STEP` leading spaces — a no-op (but still "handled",
+    /// so it doesn't fall through to snippet-expand/plain-Tab) on a line
+    /// that isn't a list item, or when outdenting past column 0. The
+    /// cursor stays over the same character, shifting with the indent.
+    fn try_indent_list_line(&mut self, direction: i8) -> bool {
+        if !self.editor_secondary_cursors.is_empty() {
+            return false;
+        }
+        let Some(editor) = &self.editor else {
+            return false;
+        };
+        let (row, col) = crate::editor::cursor_tuple(&editor.textarea);
+        let Some(line) = editor.textarea.lines().get(row).cloned() else {
+            return false;
+        };
+        if Self::list_prefix(&line).is_none() {
+            return false;
+        }
+        let (new_line, shift) = Self::indent_line(&line, direction);
+        if new_line == line {
+            return true;
+        }
+        let Some(editor) = &mut self.editor else {
+            return false;
+        };
+        let edits = Self::replace_whole_line(editor, row, &line, &new_line);
+        let new_col = (col as isize + shift).max(0) as u16;
+        editor.textarea.cancel_selection();
+        editor
+            .textarea
+            .move_cursor(ratatui_textarea::CursorMove::Jump(row as u16, new_col));
+        if edits > 0 {
+            self.editor_undo_groups.push(edits);
+            self.editor_redo_groups.clear();
+        }
+        true
+    }
+    /// Tab/Shift+Tab with an active selection: indents/outdents every line
+    /// the selection spans, list or not — the general "block indent"
+    /// behavior any code editor gives a multi-line selection, not gated by
+    /// `auto_list_continue` since it isn't list-specific. A selection
+    /// whose end sits at column 0 doesn't visually include that row (the
+    /// common result of a `Shift+Down`-built selection), so that row is
+    /// excluded — otherwise a 3-line visual selection would indent a 4th,
+    /// untouched-looking row.
+    fn indent_selected_lines(&mut self, direction: i8) {
+        let Some(editor) = &mut self.editor else {
+            return;
+        };
+        let Some((start, end)) = editor.textarea.selection_range() else {
+            return;
+        };
+        let (start_row, _) = start;
+        let (end_row, end_col) = end;
+        let last_row = editor.textarea.lines().len().saturating_sub(1);
+        let end_row = if end_col == 0 && end_row > start_row {
+            end_row - 1
+        } else {
+            end_row
+        }
+        .min(last_row);
+        let lines: Vec<String> = editor.textarea.lines().to_vec();
+        editor.textarea.cancel_selection();
+        let mut edits = 0usize;
+        for row in start_row..=end_row {
+            let Some(line) = lines.get(row) else {
+                continue;
+            };
+            let (new_line, _shift) = Self::indent_line(line, direction);
+            if new_line == *line {
+                continue;
+            }
+            edits += Self::replace_whole_line(editor, row, line, &new_line);
+        }
+        if edits > 0 {
+            self.editor_undo_groups.push(edits);
+            self.editor_redo_groups.clear();
+        }
+    }
+    /// Adds (`direction > 0`) or removes (`direction < 0`) one
+    /// `LIST_INDENT_STEP`-wide chunk of leading spaces from `line`,
+    /// returning the new text plus the column shift that keeps whatever
+    /// was under the cursor lined up. Outdenting never removes more than
+    /// the line's own existing indent.
+    fn indent_line(line: &str, direction: i8) -> (String, isize) {
+        if direction > 0 {
+            (
+                format!("{}{line}", " ".repeat(LIST_INDENT_STEP)),
+                LIST_INDENT_STEP as isize,
+            )
+        } else {
+            let current_indent = line.len() - line.trim_start_matches(' ').len();
+            let remove = LIST_INDENT_STEP.min(current_indent);
+            (line[remove..].to_string(), -(remove as isize))
+        }
+    }
+    /// Replaces `row`'s entire content with `new_line` — select the whole
+    /// line (by its *old* text's char length) and cut, then insert the
+    /// replacement, the same two-step primitive `editor_move_line`/
+    /// `editor_duplicate_line` already use for whole-line edits. Returns
+    /// how many of the two steps actually changed anything, for the
+    /// caller's own undo-group bookkeeping.
+    fn replace_whole_line(
+        editor: &mut InlineEditor,
+        row: usize,
+        old_line: &str,
+        new_line: &str,
+    ) -> usize {
+        editor.textarea.cancel_selection();
+        editor
+            .textarea
+            .move_cursor(ratatui_textarea::CursorMove::Jump(row as u16, 0));
+        editor.textarea.start_selection();
+        editor
+            .textarea
+            .move_cursor(ratatui_textarea::CursorMove::Jump(
+                row as u16,
+                old_line.chars().count() as u16,
+            ));
+        let mut edits = 0usize;
+        if editor.textarea.cut() {
+            edits += 1;
+        }
+        if editor.textarea.insert_str(new_line) {
+            edits += 1;
+        }
+        edits
     }
     /// Snapshots the current notebook's notes (excluding the one being
     /// edited — linking to yourself isn't useful) once, the moment `[[`
@@ -4260,6 +4452,28 @@ impl App {
             self.editor_undo_groups.push(edits);
             self.editor_redo_groups.clear();
         }
+    }
+    /// Plain Home (no modifiers): the first press moves to the line's
+    /// first non-whitespace character; pressing it again from there (or
+    /// pressing it on a line that's already at column 0, e.g. blank or
+    /// unindented) moves to column 0 — the standard "smart home" toggle.
+    fn smart_home(&mut self) {
+        let Some(editor) = &mut self.editor else {
+            return;
+        };
+        let (row, col) = crate::editor::cursor_tuple(&editor.textarea);
+        let Some(line) = editor.textarea.lines().get(row) else {
+            return;
+        };
+        let first_non_ws = line.chars().take_while(|c| *c == ' ' || *c == '\t').count();
+        let target = if col == first_non_ws { 0 } else { first_non_ws };
+        editor.textarea.cancel_selection();
+        editor
+            .textarea
+            .move_cursor(ratatui_textarea::CursorMove::Jump(
+                row as u16,
+                target as u16,
+            ));
     }
     /// Alt+Up/Alt+Down: swaps the cursor's line with the neighbor `delta`
     /// rows away (`delta` is always `-1` or `1` — a single step, repeated

--- a/shiki-tui/src/key_handlers.rs
+++ b/shiki-tui/src/key_handlers.rs
@@ -95,6 +95,17 @@ impl App {
             self.refresh_drawer_statuses();
         }
     }
+    /// A true toggle like `toggle_drawer` above, not one-directional — the
+    /// same `leader z` both enters and exits zen mode. Purely a layout
+    /// flag (`layout::split` reads it); nothing about focus, selection, or
+    /// which notes are loaded changes when it flips.
+    fn toggle_zen_mode(&mut self) {
+        self.zen_mode = !self.zen_mode;
+        self.set_status(format!(
+            "zen mode: {}",
+            if self.zen_mode { "on" } else { "off" }
+        ));
+    }
     fn handle_drawer_key(&mut self, key: KeyEvent) {
         match key.code {
             KeyCode::Esc => self.show_drawer = false,
@@ -440,6 +451,30 @@ impl App {
             EditorField::MultiCursor => {
                 self.config.editor.multi_cursor = !self.config.editor.multi_cursor;
                 ("multi_cursor", self.config.editor.multi_cursor)
+            }
+            EditorField::AutoListContinue => {
+                self.config.editor.auto_list_continue = !self.config.editor.auto_list_continue;
+                ("auto_list_continue", self.config.editor.auto_list_continue)
+            }
+            EditorField::FormatShortcuts => {
+                self.config.editor.format_shortcuts = !self.config.editor.format_shortcuts;
+                ("format_shortcuts", self.config.editor.format_shortcuts)
+            }
+            EditorField::AutoPairBrackets => {
+                self.config.editor.auto_pair_brackets = !self.config.editor.auto_pair_brackets;
+                ("auto_pair_brackets", self.config.editor.auto_pair_brackets)
+            }
+            EditorField::PasteUrlAsLink => {
+                self.config.editor.paste_url_as_link = !self.config.editor.paste_url_as_link;
+                ("paste_url_as_link", self.config.editor.paste_url_as_link)
+            }
+            EditorField::SnippetExpandTab => {
+                self.config.editor.snippet_expand_tab = !self.config.editor.snippet_expand_tab;
+                ("snippet_expand_tab", self.config.editor.snippet_expand_tab)
+            }
+            EditorField::TypewriterScroll => {
+                self.config.editor.typewriter_scroll = !self.config.editor.typewriter_scroll;
+                ("typewriter_scroll", self.config.editor.typewriter_scroll)
             }
         };
         self.save_config();
@@ -921,6 +956,82 @@ impl App {
             KeyCode::Char(c) => {
                 self.which_key_input.push(c);
                 self.which_key_selected = 0;
+            }
+            _ => {}
+        }
+    }
+    /// Loads the selected note's headings and opens the outline modal.
+    /// While actively editing (`Mode::Edit`, reached via `Ctrl+O`), reads
+    /// the *live* editor buffer instead of the last-saved body, so a
+    /// heading typed but not yet saved still shows up.
+    fn open_outline(&mut self) {
+        let body = if self.mode == Mode::Edit {
+            match &self.editor {
+                Some(editor) => editor.textarea.lines().join("\n"),
+                None => {
+                    self.set_status("no note selected".into());
+                    return;
+                }
+            }
+        } else {
+            match self.selected_note() {
+                Some(note) => note.body.clone(),
+                None => {
+                    self.set_status("no note selected".into());
+                    return;
+                }
+            }
+        };
+        self.outline_headings = shiki_core::headings::extract(&body);
+        self.outline_selected = 0;
+        self.show_outline = true;
+        if self.outline_headings.is_empty() {
+            self.set_status("no headings in this note".into());
+        }
+    }
+    /// `Enter` jumps to the selected heading: inside `Mode::Edit`, moves
+    /// the editor's cursor there directly; otherwise (opened from
+    /// PREVIEW), scrolls the preview panel to that source line. Either way
+    /// the modal closes.
+    fn handle_outline_key(&mut self, key: KeyEvent) {
+        match key.code {
+            KeyCode::Esc | KeyCode::Char('q') => self.show_outline = false,
+            KeyCode::Enter => {
+                if let Some(heading) = self.outline_headings.get(self.outline_selected).cloned() {
+                    if self.mode == Mode::Edit {
+                        if let Some(editor) = &mut self.editor {
+                            editor.textarea.cancel_selection();
+                            editor
+                                .textarea
+                                .move_cursor(ratatui_textarea::CursorMove::Jump(
+                                    heading.line as u16,
+                                    0,
+                                ));
+                        }
+                    } else {
+                        self.preview_scroll = heading.line as u16;
+                    }
+                }
+                self.show_outline = false;
+            }
+            KeyCode::Char('j') | KeyCode::Down => {
+                if self.outline_selected + 1 < self.outline_headings.len() {
+                    self.outline_selected += 1;
+                }
+            }
+            KeyCode::Char('k') | KeyCode::Up => {
+                self.outline_selected = self.outline_selected.saturating_sub(1);
+            }
+            KeyCode::PageDown => {
+                self.outline_selected = (self.outline_selected + PAGE_STEP as usize)
+                    .min(self.outline_headings.len().saturating_sub(1));
+            }
+            KeyCode::PageUp => {
+                self.outline_selected = self.outline_selected.saturating_sub(PAGE_STEP as usize);
+            }
+            KeyCode::Home => self.outline_selected = 0,
+            KeyCode::End => {
+                self.outline_selected = self.outline_headings.len().saturating_sub(1);
             }
             _ => {}
         }
@@ -1613,9 +1724,9 @@ impl App {
             && !self.show_slash_menu
             && !self.show_wikilink_menu
         {
-            if let Some(editor) = &mut self.editor {
-                editor.textarea.insert_str(&text);
-                self.editor_undo_groups.push(1);
+            let edits = self.insert_pasted_text(&text);
+            if edits > 0 {
+                self.editor_undo_groups.push(edits);
                 self.editor_redo_groups.clear();
             }
             return;
@@ -1643,7 +1754,7 @@ impl App {
         if !self.can_start_preview_selection() {
             return false;
         }
-        let preview = layout::split(self.last_frame_area, self.focus).preview;
+        let preview = layout::split(self.last_frame_area, self.focus, self.zen_mode).preview;
         let content_left = preview.x + 1;
         if column < content_left {
             return false;
@@ -1715,7 +1826,7 @@ impl App {
         // click reaching the layout underneath an open popup can't be
         // misread as a panel click.
         if self.mode == Mode::Normal && self.no_modal_open() {
-            let areas = layout::split(self.last_frame_area, self.focus);
+            let areas = layout::split(self.last_frame_area, self.focus, self.zen_mode);
             if let Some(index) = panel_notebooks::notebooks_hit_at(
                 self.notebooks.len(),
                 areas.notebooks,
@@ -1740,7 +1851,7 @@ impl App {
         }
 
         if self.can_start_preview_selection() {
-            let preview = layout::split(self.last_frame_area, self.focus).preview;
+            let preview = layout::split(self.last_frame_area, self.focus, self.zen_mode).preview;
             let row_count = self.note_preview_lines().map(|l| l.len()).unwrap_or(0);
             if let Some(hit) =
                 panel_preview::preview_row_at(preview, self.preview_scroll, row_count, column, row)
@@ -1754,7 +1865,7 @@ impl App {
             }
         }
 
-        let footer = layout::split(self.last_frame_area, self.focus).status_bar;
+        let footer = layout::split(self.last_frame_area, self.focus, self.zen_mode).status_bar;
         if status_bar::coffee_hit_at(footer, column, row) {
             self.open_coffee_link();
         }
@@ -1775,7 +1886,7 @@ impl App {
         // `PreviewSelection::dragged`'s own doc comment for why that
         // distinction is what `on_mouse_up` branches on.
         self.preview_selection.as_mut().unwrap().dragged = true;
-        let preview = layout::split(self.last_frame_area, self.focus).preview;
+        let preview = layout::split(self.last_frame_area, self.focus, self.zen_mode).preview;
         let row_count = self.note_preview_lines().map(|l| l.len()).unwrap_or(0);
         let scroll = self.preview_scroll;
         // Dragging outside the panel clamps to its nearest edge instead of
@@ -1867,7 +1978,7 @@ impl App {
     /// an already-present cursor's exact cell is a harmless no-op rather
     /// than a duplicate.
     fn on_editor_alt_click(&mut self, column: u16, row: u16) {
-        let preview = layout::split(self.last_frame_area, self.focus).preview;
+        let preview = layout::split(self.last_frame_area, self.focus, self.zen_mode).preview;
         let line_numbers = self.config.editor.line_numbers;
         let Some(editor) = &self.editor else {
             return;
@@ -1890,7 +2001,7 @@ impl App {
     /// word/line just selected); `false` for a plain single click, which
     /// hasn't anchored anything yet.
     fn on_editor_mouse_down(&mut self, column: u16, row: u16) {
-        let preview = layout::split(self.last_frame_area, self.focus).preview;
+        let preview = layout::split(self.last_frame_area, self.focus, self.zen_mode).preview;
         let line_numbers = self.config.editor.line_numbers;
         let Some(editor) = &mut self.editor else {
             return;
@@ -1962,7 +2073,7 @@ impl App {
     /// skips re-anchoring since one already exists (see `editor_drag_active`'s
     /// own doc comment).
     fn on_editor_mouse_drag(&mut self, column: u16, row: u16) {
-        let preview = layout::split(self.last_frame_area, self.focus).preview;
+        let preview = layout::split(self.last_frame_area, self.focus, self.zen_mode).preview;
         let line_numbers = self.config.editor.line_numbers;
         let Some(editor) = &mut self.editor else {
             return;
@@ -2714,6 +2825,7 @@ impl App {
             Action::ToggleTasks => self.open_tasks(),
             Action::PublishNotebook => self.publish_notebook(),
             Action::ExportNotebook => self.start_export_notebook(),
+            Action::ToggleZenMode => self.toggle_zen_mode(),
 
             Action::NewNotebook => self.start_input(PendingInput::NewNotebook, String::new()),
             Action::RenameNotebook => self.start_rename_notebook(),
@@ -2745,6 +2857,7 @@ impl App {
             }
             Action::ShowHistory => self.open_history(),
             Action::ShowLinks => self.open_links(),
+            Action::ShowOutline => self.open_outline(),
             Action::ToggleFavoriteEditor => self.toggle_favorite_editor(),
             Action::ToggleVisual => self.toggle_visual(),
             Action::CopyEntries => {
@@ -3551,8 +3664,51 @@ impl App {
             KeyCode::Char('u') if key.modifiers.contains(KeyModifiers::CONTROL) => {
                 self.editor_undo();
             }
+            // Opens the same outline modal PREVIEW's `o` binding does,
+            // without leaving Mode::Edit — jumping to a heading from here
+            // moves the editor's own cursor instead of scrolling PREVIEW.
+            KeyCode::Char('o') if key.modifiers.contains(KeyModifiers::CONTROL) => {
+                self.open_outline();
+            }
             KeyCode::Char('r') if key.modifiers.contains(KeyModifiers::CONTROL) => {
                 self.editor_redo();
+            }
+            // Ctrl+B wraps the selection in `**bold**` (or inserts an empty
+            // pair with the cursor in the middle if nothing's selected).
+            KeyCode::Char('b')
+                if key.modifiers.contains(KeyModifiers::CONTROL)
+                    && !key.modifiers.contains(KeyModifiers::ALT)
+                    && self.config.editor.format_shortcuts =>
+            {
+                self.wrap_or_insert_pair("**", "**");
+            }
+            // Ctrl+Alt+I, not plain Ctrl+I — most terminal emulators send
+            // Ctrl+I identically to Tab, so it isn't a reliable binding.
+            KeyCode::Char('i')
+                if key.modifiers.contains(KeyModifiers::CONTROL)
+                    && key.modifiers.contains(KeyModifiers::ALT)
+                    && self.config.editor.format_shortcuts =>
+            {
+                self.wrap_or_insert_pair("_", "_");
+            }
+            // Auto-pair: typing an opening bracket/quote wraps the current
+            // selection in the matching pair, or inserts an empty pair with
+            // the cursor left in the middle. `[` is deliberately excluded —
+            // pairing it would break `[[wikilink]]` autocomplete just below,
+            // which depends on the user typing two real `[` in a row. Skips
+            // while a multi-cursor edit is in flight, same as the
+            // list-continuation features above.
+            KeyCode::Char(c @ ('(' | '`' | '"'))
+                if self.config.editor.auto_pair_brackets
+                    && self.editor_secondary_cursors.is_empty() =>
+            {
+                let (open, close) = match c {
+                    '(' => ("(", ")"),
+                    '`' => ("`", "`"),
+                    '"' => ("\"", "\""),
+                    _ => unreachable!(),
+                };
+                self.wrap_or_insert_pair(open, close);
             }
             // VS Code's own "Add Cursor Above/Below" binding — a keyboard
             // alternative to Alt+Click that doesn't need the mouse at all,
@@ -3570,6 +3726,37 @@ impl App {
                     && self.config.editor.multi_cursor =>
             {
                 self.editor_add_cursor_vertical(1);
+            }
+            // Alt+Up/Alt+Down move the current line past its neighbor;
+            // Alt+D duplicates it. Always on, like Ctrl+Home/Ctrl+End below
+            // — none of these three combos are used for anything else in
+            // the editor. Excludes Ctrl so it can't shadow the
+            // Ctrl+Alt+Up/Down multi-cursor bindings above.
+            KeyCode::Up
+                if key.modifiers.contains(KeyModifiers::ALT)
+                    && !key.modifiers.contains(KeyModifiers::CONTROL) =>
+            {
+                self.editor_move_line(-1);
+            }
+            KeyCode::Down
+                if key.modifiers.contains(KeyModifiers::ALT)
+                    && !key.modifiers.contains(KeyModifiers::CONTROL) =>
+            {
+                self.editor_move_line(1);
+            }
+            KeyCode::Char('d')
+                if key.modifiers.contains(KeyModifiers::ALT)
+                    && !key.modifiers.contains(KeyModifiers::CONTROL) =>
+            {
+                self.editor_duplicate_line();
+            }
+            // Tab expands a matching snippet trigger — see
+            // `try_expand_snippet_on_tab`'s own doc comment. Falls through
+            // to plain Tab (a literal tab character) when nothing matches.
+            KeyCode::Tab if self.config.editor.snippet_expand_tab => {
+                if !self.try_expand_snippet_on_tab() {
+                    self.editor_forward_key_default(key);
+                }
             }
             // Always replaces the generic forward for these two — see
             // `editor_scroll_cursor`'s own doc comment for why forwarding
@@ -3602,64 +3789,212 @@ impl App {
                         ));
                 }
             }
-            _ => {
-                if let Some(editor) = &mut self.editor {
-                    let edits = if self.editor_secondary_cursors.is_empty() {
-                        // A plain `input()` call can itself push *two*
-                        // history entries (typing over an active selection
-                        // is "delete selection, then insert" — see
-                        // `multicursor::undo_history_depth`'s own doc
-                        // comment for why this is measured, not assumed).
-                        let snapshot = editor.textarea.lines().to_vec();
-                        if editor.textarea.input(key) {
-                            crate::multicursor::undo_history_depth(&mut editor.textarea, &snapshot)
-                        } else {
-                            0
-                        }
-                    } else {
-                        crate::multicursor::replay_keystroke(
-                            &mut editor.textarea,
-                            key,
-                            &mut self.editor_secondary_cursors,
-                        )
-                    };
-                    if edits > 0 {
-                        self.editor_undo_groups.push(edits);
-                        self.editor_redo_groups.clear();
-                    }
-                }
-                // `/` only opens the menu when it lands as the very first
-                // character of the line (cursor was at column 0, so it's
-                // at column 1 right after) — typing it anywhere else (a
-                // fraction, a URL, mid-sentence) is just a literal slash.
-                if key.code == KeyCode::Char('/') {
-                    let at_line_start = self
-                        .editor
-                        .as_ref()
-                        .is_some_and(|e| e.textarea.cursor().1 == 1);
-                    if at_line_start {
-                        self.slash_menu_selected = 0;
-                        self.show_slash_menu = true;
-                    }
-                }
-                // `[[` opens the wikilink menu the instant the second `[`
-                // completes the pair, anywhere in the line — unlike `/`,
-                // a wikilink is meaningful mid-sentence ("see [[Some
-                // Note]] for details"), not just at line start.
-                if key.code == KeyCode::Char('[') {
-                    let opens_wikilink = self.editor.as_ref().is_some_and(|e| {
-                        let (row, col) = crate::editor::cursor_tuple(&e.textarea);
-                        e.textarea
-                            .lines()
-                            .get(row)
-                            .is_some_and(|line| col >= 2 && line.chars().nth(col - 2) == Some('['))
-                    });
-                    if opens_wikilink {
-                        self.open_wikilink_menu();
-                    }
+            // Enter continues a list/checkbox line onto the next line, or
+            // clears an already-empty item's prefix — see
+            // `try_auto_continue_list`'s own doc comment. Falls through to
+            // plain newline insertion when it doesn't apply.
+            KeyCode::Enter if self.config.editor.auto_list_continue => {
+                if !self.try_auto_continue_list() {
+                    self.editor_forward_key_default(key);
                 }
             }
+            // Backspace right after an empty list/checkbox prefix removes
+            // the whole prefix in one step — see
+            // `try_backspace_exit_list`'s own doc comment.
+            KeyCode::Backspace if self.config.editor.auto_list_continue => {
+                if !self.try_backspace_exit_list() {
+                    self.editor_forward_key_default(key);
+                }
+            }
+            _ => self.editor_forward_key_default(key),
         }
+    }
+    /// The default "just type it" path for any key `handle_edit_key` didn't
+    /// intercept above — plain character input, Enter/Backspace when
+    /// `auto_list_continue` doesn't apply or is off, etc. Factored out of
+    /// the old catch-all `_` arm so `try_auto_continue_list`/
+    /// `try_backspace_exit_list` can fall back to exactly this same path
+    /// instead of duplicating it.
+    fn editor_forward_key_default(&mut self, key: KeyEvent) {
+        if let Some(editor) = &mut self.editor {
+            let edits = if self.editor_secondary_cursors.is_empty() {
+                // A plain `input()` call can itself push *two*
+                // history entries (typing over an active selection
+                // is "delete selection, then insert" — see
+                // `multicursor::undo_history_depth`'s own doc
+                // comment for why this is measured, not assumed).
+                let snapshot = editor.textarea.lines().to_vec();
+                if editor.textarea.input(key) {
+                    crate::multicursor::undo_history_depth(&mut editor.textarea, &snapshot)
+                } else {
+                    0
+                }
+            } else {
+                crate::multicursor::replay_keystroke(
+                    &mut editor.textarea,
+                    key,
+                    &mut self.editor_secondary_cursors,
+                )
+            };
+            if edits > 0 {
+                self.editor_undo_groups.push(edits);
+                self.editor_redo_groups.clear();
+            }
+        }
+        // `/` only opens the menu when it lands as the very first
+        // character of the line (cursor was at column 0, so it's
+        // at column 1 right after) — typing it anywhere else (a
+        // fraction, a URL, mid-sentence) is just a literal slash.
+        if key.code == KeyCode::Char('/') {
+            let at_line_start = self
+                .editor
+                .as_ref()
+                .is_some_and(|e| e.textarea.cursor().1 == 1);
+            if at_line_start {
+                self.slash_menu_selected = 0;
+                self.show_slash_menu = true;
+            }
+        }
+        // `[[` opens the wikilink menu the instant the second `[`
+        // completes the pair, anywhere in the line — unlike `/`,
+        // a wikilink is meaningful mid-sentence ("see [[Some
+        // Note]] for details"), not just at line start.
+        if key.code == KeyCode::Char('[') {
+            let opens_wikilink = self.editor.as_ref().is_some_and(|e| {
+                let (row, col) = crate::editor::cursor_tuple(&e.textarea);
+                e.textarea
+                    .lines()
+                    .get(row)
+                    .is_some_and(|line| col >= 2 && line.chars().nth(col - 2) == Some('['))
+            });
+            if opens_wikilink {
+                self.open_wikilink_menu();
+            }
+        }
+    }
+    /// Parses `line`'s leading list/checkbox marker, if any: optional
+    /// leading spaces, then `-`/`*`/`+` or `N.`, then a single space,
+    /// optionally followed by `[ ]`/`[x]`/`[X]` and another space. Returns
+    /// the exact prefix substring (byte-for-byte, so `line[prefix.len()..]`
+    /// is always a valid slice) or `None` if the line isn't a list item.
+    fn list_prefix(line: &str) -> Option<&str> {
+        let indent_len = line.len() - line.trim_start_matches(' ').len();
+        let rest = &line[indent_len..];
+        let marker_len =
+            if rest.starts_with("- ") || rest.starts_with("* ") || rest.starts_with("+ ") {
+                2
+            } else {
+                let digits = rest.chars().take_while(|c| c.is_ascii_digit()).count();
+                if digits > 0 && rest[digits..].starts_with(". ") {
+                    digits + 2
+                } else {
+                    return None;
+                }
+            };
+        let after_marker = &rest[marker_len..];
+        let checkbox_len = if after_marker.starts_with("[ ] ")
+            || after_marker.starts_with("[x] ")
+            || after_marker.starts_with("[X] ")
+        {
+            4
+        } else {
+            0
+        };
+        Some(&line[..indent_len + marker_len + checkbox_len])
+    }
+    /// The prefix to carry onto the *next* line when continuing a list —
+    /// identical to the source prefix except a checkbox always resets to
+    /// unchecked, since copying `[x]` would silently mark the new item
+    /// done before it's even been written.
+    fn continuation_prefix(prefix: &str) -> String {
+        match prefix.find("[x] ").or_else(|| prefix.find("[X] ")) {
+            Some(idx) => format!("{}[ ] ", &prefix[..idx]),
+            None => prefix.to_string(),
+        }
+    }
+    /// Enter (`config.editor.auto_list_continue`): continues a
+    /// `- item`/`- [ ] task`/`1. item` line onto the next line with the
+    /// same prefix (checkboxes always reset to unchecked); Enter on an
+    /// already-empty list item clears the prefix in place instead of
+    /// starting a new empty item, matching Word/Notion's "empty item exits
+    /// the list" convention. Only fires when the cursor sits at the end of
+    /// the line and no multi-cursor edit is in flight — everywhere else,
+    /// Enter is just a plain newline via `editor_forward_key_default`.
+    fn try_auto_continue_list(&mut self) -> bool {
+        if !self.editor_secondary_cursors.is_empty() {
+            return false;
+        }
+        let Some(editor) = &mut self.editor else {
+            return false;
+        };
+        let (row, col) = crate::editor::cursor_tuple(&editor.textarea);
+        let Some(line) = editor.textarea.lines().get(row).cloned() else {
+            return false;
+        };
+        if col != line.chars().count() {
+            return false;
+        }
+        let Some(prefix) = Self::list_prefix(&line) else {
+            return false;
+        };
+        let prefix_len = prefix.len();
+        let is_empty_item = line[prefix_len..].trim().is_empty();
+        let continuation = Self::continuation_prefix(prefix);
+        let mut edits = 0usize;
+        if is_empty_item {
+            editor.textarea.cancel_selection();
+            editor
+                .textarea
+                .move_cursor(ratatui_textarea::CursorMove::Jump(row as u16, 0));
+            editor.textarea.start_selection();
+            editor
+                .textarea
+                .move_cursor(ratatui_textarea::CursorMove::Jump(row as u16, col as u16));
+            if editor.textarea.cut() {
+                edits += 1;
+            }
+        } else if editor.textarea.insert_str(format!("\n{continuation}")) {
+            edits += 1;
+        }
+        if edits > 0 {
+            self.editor_undo_groups.push(edits);
+            self.editor_redo_groups.clear();
+        }
+        true
+    }
+    /// Backspace (`config.editor.auto_list_continue`): if the cursor sits
+    /// right after a list/checkbox prefix with nothing else on the line,
+    /// removes the whole prefix in one step instead of one character.
+    fn try_backspace_exit_list(&mut self) -> bool {
+        if !self.editor_secondary_cursors.is_empty() {
+            return false;
+        }
+        let Some(editor) = &mut self.editor else {
+            return false;
+        };
+        let (row, col) = crate::editor::cursor_tuple(&editor.textarea);
+        let Some(line) = editor.textarea.lines().get(row).cloned() else {
+            return false;
+        };
+        let Some(prefix) = Self::list_prefix(&line) else {
+            return false;
+        };
+        if col != prefix.chars().count() || !line[prefix.len()..].trim().is_empty() {
+            return false;
+        }
+        editor.textarea.cancel_selection();
+        editor
+            .textarea
+            .move_cursor(ratatui_textarea::CursorMove::Jump(row as u16, 0));
+        editor.textarea.start_selection();
+        editor
+            .textarea
+            .move_cursor(ratatui_textarea::CursorMove::Jump(row as u16, col as u16));
+        if editor.textarea.cut() {
+            self.editor_undo_groups.push(1);
+            self.editor_redo_groups.clear();
+        }
+        true
     }
     /// Snapshots the current notebook's notes (excluding the one being
     /// edited — linking to yourself isn't useful) once, the moment `[[`
@@ -3835,15 +4170,181 @@ impl App {
     /// internal yank register (`paste()`), exactly what Ctrl+V already did
     /// before `os_clipboard` existed, so nothing regresses in that case.
     fn editor_paste_os(&mut self) {
+        match crate::clipboard::paste_os() {
+            Some(text) => {
+                let edits = self.insert_pasted_text(&text);
+                if edits > 0 {
+                    self.editor_undo_groups.push(edits);
+                    self.editor_redo_groups.clear();
+                }
+            }
+            None => {
+                let Some(editor) = &mut self.editor else {
+                    return;
+                };
+                if editor.textarea.paste() {
+                    self.editor_undo_groups.push(1);
+                    self.editor_redo_groups.clear();
+                }
+            }
+        }
+    }
+    /// Shared by `editor_paste_os` (Ctrl+V) and `on_paste` (bracketed
+    /// paste): inserts `text` as-is, unless `paste_url_as_link` is on,
+    /// there's an active selection, and `text` (trimmed) is a bare
+    /// `http(s)://` URL with no whitespace — in that case the selected
+    /// text is wrapped as `[selected](url)` instead of being replaced by
+    /// the raw URL. Returns how many textarea-level edits happened, for
+    /// the caller's own undo-group bookkeeping.
+    fn insert_pasted_text(&mut self, text: &str) -> usize {
+        let Some(editor) = &mut self.editor else {
+            return 0;
+        };
+        let trimmed = text.trim();
+        let is_bare_url = (trimmed.starts_with("http://") || trimmed.starts_with("https://"))
+            && !trimmed.contains(char::is_whitespace);
+        if self.config.editor.paste_url_as_link && is_bare_url {
+            if let Some((start, end)) = editor.textarea.selection_range() {
+                let selected = crate::editor::selection_text(editor.textarea.lines(), start, end);
+                if !selected.is_empty() {
+                    let mut edits = 0usize;
+                    if editor.textarea.cut() {
+                        edits += 1;
+                    }
+                    if editor
+                        .textarea
+                        .insert_str(format!("[{selected}]({trimmed})"))
+                    {
+                        edits += 1;
+                    }
+                    return edits;
+                }
+            }
+        }
+        usize::from(editor.textarea.insert_str(text))
+    }
+    /// Shared by the bold/italic shortcuts (`format_shortcuts`) and
+    /// bracket/quote auto-pairing (`auto_pair_brackets`): wraps the active
+    /// selection in `open`/`close`, or — with nothing selected — inserts
+    /// the empty pair and leaves the cursor between the two, ready to type
+    /// inside it.
+    fn wrap_or_insert_pair(&mut self, open: &str, close: &str) {
         let Some(editor) = &mut self.editor else {
             return;
         };
-        let pasted = match crate::clipboard::paste_os() {
-            Some(text) => editor.textarea.insert_str(&text),
-            None => editor.textarea.paste(),
+        let mut edits = 0usize;
+        if let Some((start, end)) = editor.textarea.selection_range() {
+            let text = crate::editor::selection_text(editor.textarea.lines(), start, end);
+            if editor.textarea.cut() {
+                edits += 1;
+            }
+            if editor.textarea.insert_str(format!("{open}{text}{close}")) {
+                edits += 1;
+            }
+        } else {
+            if editor.textarea.insert_str(format!("{open}{close}")) {
+                edits += 1;
+            }
+            let (row, col) = crate::editor::cursor_tuple(&editor.textarea);
+            let close_len = close.chars().count();
+            if col >= close_len {
+                editor
+                    .textarea
+                    .move_cursor(ratatui_textarea::CursorMove::Jump(
+                        row as u16,
+                        (col - close_len) as u16,
+                    ));
+            }
+        }
+        if edits > 0 {
+            self.editor_undo_groups.push(edits);
+            self.editor_redo_groups.clear();
+        }
+    }
+    /// Alt+Up/Alt+Down: swaps the cursor's line with the neighbor `delta`
+    /// rows away (`delta` is always `-1` or `1` — a single step, repeated
+    /// presses walk it further). No-op at either edge of the buffer. Cursor
+    /// column is preserved (clamped to the destination line's length) so
+    /// the same character stays under the cursor after the move.
+    fn editor_move_line(&mut self, delta: isize) {
+        let Some(editor) = &mut self.editor else {
+            return;
         };
-        if pasted {
-            self.editor_undo_groups.push(1);
+        let (row, col) = crate::editor::cursor_tuple(&editor.textarea);
+        let line_count = editor.textarea.lines().len();
+        let target = row as isize + delta;
+        if target < 0 || target as usize >= line_count {
+            return;
+        }
+        let target = target as usize;
+        let a = row.min(target);
+        let b = row.max(target);
+        let line_a = editor.textarea.lines()[a].clone();
+        let line_b = editor.textarea.lines()[b].clone();
+        let b_len = line_b.chars().count();
+        editor.textarea.cancel_selection();
+        editor
+            .textarea
+            .move_cursor(ratatui_textarea::CursorMove::Jump(a as u16, 0));
+        editor.textarea.start_selection();
+        editor
+            .textarea
+            .move_cursor(ratatui_textarea::CursorMove::Jump(b as u16, b_len as u16));
+        let mut edits = 0usize;
+        if editor.textarea.cut() {
+            edits += 1;
+        }
+        if editor.textarea.insert_str(format!("{line_b}\n{line_a}")) {
+            edits += 1;
+        }
+        let new_col = col.min(if target == a {
+            line_b.chars().count()
+        } else {
+            line_a.chars().count()
+        });
+        editor.textarea.cancel_selection();
+        editor
+            .textarea
+            .move_cursor(ratatui_textarea::CursorMove::Jump(
+                target as u16,
+                new_col as u16,
+            ));
+        if edits > 0 {
+            self.editor_undo_groups.push(edits);
+            self.editor_redo_groups.clear();
+        }
+    }
+    /// Alt+D: duplicates the cursor's current line directly below it,
+    /// keeping the cursor at the same column on the new copy.
+    fn editor_duplicate_line(&mut self) {
+        let Some(editor) = &mut self.editor else {
+            return;
+        };
+        let (row, col) = crate::editor::cursor_tuple(&editor.textarea);
+        let Some(line) = editor.textarea.lines().get(row).cloned() else {
+            return;
+        };
+        let line_len = line.chars().count();
+        editor.textarea.cancel_selection();
+        editor
+            .textarea
+            .move_cursor(ratatui_textarea::CursorMove::Jump(
+                row as u16,
+                line_len as u16,
+            ));
+        let mut edits = 0usize;
+        if editor.textarea.insert_str(format!("\n{line}")) {
+            edits += 1;
+        }
+        editor.textarea.cancel_selection();
+        editor
+            .textarea
+            .move_cursor(ratatui_textarea::CursorMove::Jump(
+                (row + 1) as u16,
+                col.min(line_len) as u16,
+            ));
+        if edits > 0 {
+            self.editor_undo_groups.push(edits);
             self.editor_redo_groups.clear();
         }
     }
@@ -4285,6 +4786,107 @@ impl App {
             _ => {}
         }
     }
+    /// Substitutes `{{title}}`/`{{date}}` in a snippet body the same way
+    /// note templates are rendered (`shiki_core::Template::render`), then
+    /// splits off a literal `{{cursor}}` marker if present — shared by
+    /// `apply_slash_command` (the `/`-menu) and `try_expand_snippet_on_tab`
+    /// (Tab-expansion), the two places a snippet's body actually gets
+    /// turned into text.
+    fn render_snippet_template(&self, body: &str) -> (String, Option<String>) {
+        let title = self
+            .selected_note()
+            .map(|n| n.frontmatter.title.clone())
+            .unwrap_or_default();
+        let mut vars = std::collections::HashMap::new();
+        vars.insert("title", title);
+        vars.insert("date", chrono::Local::now().format("%Y-%m-%d").to_string());
+        let rendered = shiki_core::Template {
+            name: String::new(),
+            contents: body.to_string(),
+        }
+        .render(&vars);
+        match rendered.split_once("{{cursor}}") {
+            Some((before, after)) => (before.to_string(), Some(after.to_string())),
+            None => (rendered, None),
+        }
+    }
+    /// Tab (`config.editor.snippet_expand_tab`): if the run of
+    /// non-whitespace characters immediately before the cursor matches a
+    /// snippet trigger — built-in or `[snippets.<trigger>]`, the exact same
+    /// set the `/`-menu draws from (`slash_menu::all_commands`) — replaces
+    /// just that trigger text with the snippet's rendered body. Falls
+    /// through to plain Tab otherwise, or while a multi-cursor edit is in
+    /// flight (same scope limit as the other new editor behaviors above).
+    fn try_expand_snippet_on_tab(&mut self) -> bool {
+        if !self.editor_secondary_cursors.is_empty() {
+            return false;
+        }
+        let Some(editor) = &self.editor else {
+            return false;
+        };
+        let (row, col) = crate::editor::cursor_tuple(&editor.textarea);
+        let Some(line) = editor.textarea.lines().get(row) else {
+            return false;
+        };
+        let chars: Vec<char> = line.chars().collect();
+        let upto = &chars[..col.min(chars.len())];
+        let trigger_start = upto
+            .iter()
+            .rposition(|c| c.is_whitespace())
+            .map(|i| i + 1)
+            .unwrap_or(0);
+        let trigger: String = upto[trigger_start..].iter().collect();
+        if trigger.is_empty() {
+            return false;
+        }
+        let Some(cmd) = slash_menu::all_commands(&self.config)
+            .into_iter()
+            .find(|c| c.trigger.eq_ignore_ascii_case(&trigger))
+        else {
+            return false;
+        };
+        let (before, cursor_marker) = self.render_snippet_template(&cmd.body);
+        let Some(editor) = &mut self.editor else {
+            return false;
+        };
+        editor.textarea.cancel_selection();
+        editor
+            .textarea
+            .move_cursor(ratatui_textarea::CursorMove::Jump(
+                row as u16,
+                trigger_start as u16,
+            ));
+        editor.textarea.start_selection();
+        editor
+            .textarea
+            .move_cursor(ratatui_textarea::CursorMove::Jump(row as u16, col as u16));
+        let mut edits = 0usize;
+        if editor.textarea.cut() {
+            edits += 1;
+        }
+        let inserted = match &cursor_marker {
+            Some(after) => editor.textarea.insert_str(format!("{before}{after}")),
+            None => editor.textarea.insert_str(&before),
+        };
+        if inserted {
+            edits += 1;
+        }
+        if cursor_marker.is_some() {
+            let target_row = row + before.matches('\n').count();
+            let target_col = before.rsplit('\n').next().unwrap_or("").chars().count();
+            editor
+                .textarea
+                .move_cursor(ratatui_textarea::CursorMove::Jump(
+                    target_row as u16,
+                    target_col as u16,
+                ));
+        }
+        if edits > 0 {
+            self.editor_undo_groups.push(edits);
+            self.editor_redo_groups.clear();
+        }
+        true
+    }
     /// Runs the chosen `/`-menu entry: deletes the typed `/query` (the
     /// same range `slash_query` reads, from the start of the line up to
     /// the cursor — `delete_line_by_head` is exactly that operation) and
@@ -4300,23 +4902,7 @@ impl App {
         // shifted, on top of each one still holding its own unconsumed
         // literal "/command" text.
         self.editor_secondary_cursors.clear();
-        let title = self
-            .selected_note()
-            .map(|n| n.frontmatter.title.clone())
-            .unwrap_or_default();
-        let mut vars = std::collections::HashMap::new();
-        vars.insert("title", title);
-        vars.insert("date", chrono::Local::now().format("%Y-%m-%d").to_string());
-        let rendered = shiki_core::Template {
-            name: String::new(),
-            contents: cmd.body.clone(),
-        }
-        .render(&vars);
-
-        let (before, cursor_marker) = match rendered.split_once("{{cursor}}") {
-            Some((before, after)) => (before.to_string(), Some(after.to_string())),
-            None => (rendered, None),
-        };
+        let (before, cursor_marker) = self.render_snippet_template(&cmd.body);
 
         let Some(editor) = &mut self.editor else {
             return;
@@ -4456,6 +5042,10 @@ impl App {
         }
         if self.show_history {
             self.handle_history_key(key);
+            return;
+        }
+        if self.show_outline {
+            self.handle_outline_key(key);
             return;
         }
         if self.show_drawer {

--- a/shiki-tui/src/keybindings.rs
+++ b/shiki-tui/src/keybindings.rs
@@ -31,6 +31,9 @@ pub enum Action {
     /// Exports the selected notebook to a single HTML or Markdown bundle —
     /// the same rendering `shiki export` (CLI) uses.
     ExportNotebook,
+    /// Forces the full-screen single-panel layout regardless of terminal
+    /// size, hiding NOTEBOOKS/NOTES for distraction-free writing.
+    ToggleZenMode,
     // Notebooks-focus
     NewNotebook,
     RenameNotebook,
@@ -67,6 +70,11 @@ pub enum Action {
     /// Opens the links modal — the selected note's outgoing `[[wikilinks]]`
     /// plus every other note that links back to it.
     ShowLinks,
+    /// Opens the outline modal — every `#`..`######` heading in the
+    /// selected note, jump straight to one. Also reachable as `Ctrl+O`
+    /// inside `Mode::Edit` itself (bound directly in `handle_edit_key`,
+    /// not through this scoped map).
+    ShowOutline,
 }
 
 /// Translates a config string (e.g. `"enter"`, `"tab"`, `"a"`, `"space"`) into a `KeyCode`.
@@ -144,6 +152,7 @@ impl KeyMaps {
         bind(&mut global, &cfg.global.tasks_panel, Action::ToggleTasks);
         bind(&mut global, &cfg.global.publish, Action::PublishNotebook);
         bind(&mut global, &cfg.global.export, Action::ExportNotebook);
+        bind(&mut global, &cfg.global.zen_mode, Action::ToggleZenMode);
 
         let mut notebooks = HashMap::new();
         bind(&mut notebooks, &cfg.notebooks.new, Action::NewNotebook);
@@ -192,6 +201,7 @@ impl KeyMaps {
         );
         bind(&mut preview, &cfg.preview.history, Action::ShowHistory);
         bind(&mut preview, &cfg.preview.links, Action::ShowLinks);
+        bind(&mut preview, &cfg.preview.outline, Action::ShowOutline);
 
         Self {
             leader,
@@ -378,6 +388,8 @@ pub fn action_label(action: Action) -> &'static str {
         Action::ToggleTasks => "tasks (all notebooks)",
         Action::PublishNotebook => "publish notebook to PDF",
         Action::ExportNotebook => "export notebook to HTML/Markdown",
+        Action::ToggleZenMode => "zen mode (full-screen, hide side panels)",
+        Action::ShowOutline => "outline (jump to a heading)",
     }
 }
 
@@ -413,5 +425,7 @@ pub fn action_icon(action: Action) -> char {
         Action::Scratchpad => crate::icons::PENCIL,
         Action::PublishNotebook => crate::icons::PDF,
         Action::ExportNotebook => crate::icons::NOTE,
+        Action::ToggleZenMode => crate::icons::EXPAND,
+        Action::ShowOutline => crate::icons::TREE,
     }
 }

--- a/shiki-tui/src/layout.rs
+++ b/shiki-tui/src/layout.rs
@@ -35,7 +35,12 @@ const STACK_WIDTH: u16 = 70;
 const SINGLE_WIDTH: u16 = 46;
 const SINGLE_HEIGHT: u16 = 14;
 
-pub fn split(area: Rect, focus: Focus) -> Areas {
+/// `zen_mode` forces the same full-screen-focused-panel `single()` tier
+/// `columned`/`stacked` only fall into on a genuinely small terminal —
+/// `App::zen_mode` (`leader z`) opts into it regardless of actual terminal
+/// size, to hide NOTEBOOKS/NOTES for distraction-free writing. No new
+/// layout math: it's the exact same tier a small terminal already gets.
+pub fn split(area: Rect, focus: Focus, zen_mode: bool) -> Areas {
     // No outer margin and no gap between constraints: panels go edge-to-edge
     // with the terminal and with each other, so the only "padding" visible
     // anywhere is each panel's own border.
@@ -48,7 +53,7 @@ pub fn split(area: Rect, focus: Focus) -> Areas {
     let main = rows[0];
     let status_bar = rows[1];
 
-    if main.width < SINGLE_WIDTH || main.height < SINGLE_HEIGHT {
+    if zen_mode || main.width < SINGLE_WIDTH || main.height < SINGLE_HEIGHT {
         return single(main, status_bar, focus);
     }
     if main.width < STACK_WIDTH {

--- a/shiki-tui/src/lib.rs
+++ b/shiki-tui/src/lib.rs
@@ -14,6 +14,7 @@ pub(crate) mod multicursor;
 pub mod panel_drawer;
 pub mod panel_notebooks;
 pub mod panel_notes;
+pub mod panel_outline;
 pub mod panel_preview;
 pub mod panel_settings;
 pub mod panel_tags;

--- a/shiki-tui/src/panel_outline.rs
+++ b/shiki-tui/src/panel_outline.rs
@@ -1,0 +1,55 @@
+use ratatui::layout::Rect;
+use ratatui::style::{Modifier, Style};
+use ratatui::text::Line;
+use ratatui::widgets::{List, ListItem, ListState};
+use ratatui::Frame;
+
+use crate::app::App;
+use crate::icons;
+use crate::render::{hex_to_color, panel_block};
+
+/// Outline/heading-jump popup (PREVIEW-scope `o`, or `Ctrl+O` inside
+/// `Mode::Edit`) — a flat list of the selected note's `#`..`######`
+/// headings (`shiki_core::headings::extract`), indented by level. Read-only
+/// rendering; `App::handle_outline_key` drives selection/close/jump.
+pub fn render(frame: &mut Frame, area: Rect, app: &App) {
+    let fg = hex_to_color(&app.theme.fg);
+    let muted = hex_to_color(&app.theme.muted);
+
+    let items: Vec<ListItem> = if app.outline_headings.is_empty() {
+        vec![ListItem::new("  no headings in this note").style(Style::default().fg(muted))]
+    } else {
+        app.outline_headings
+            .iter()
+            .map(|h| {
+                let indent = "  ".repeat((h.level.saturating_sub(1)) as usize);
+                ListItem::new(format!(
+                    "{indent}{} {}",
+                    "#".repeat(h.level as usize),
+                    h.text
+                ))
+                .style(Style::default().fg(fg))
+            })
+            .collect()
+    };
+
+    let title = format!(
+        " {}  Outline [{}] ",
+        icons::TREE,
+        app.outline_headings.len()
+    );
+    let highlight_symbol = format!("{} ", icons::ARROW);
+    let list = List::new(items)
+        .block(panel_block(Line::from(title), true, &app.theme))
+        .highlight_style(
+            Style::default()
+                .bg(hex_to_color(&app.theme.selection))
+                .fg(hex_to_color(&app.theme.accent))
+                .add_modifier(Modifier::BOLD),
+        )
+        .highlight_symbol(highlight_symbol.as_str());
+
+    let mut state = ListState::default();
+    state.select(Some(app.outline_selected));
+    frame.render_stateful_widget(list, area, &mut state);
+}

--- a/shiki-tui/src/panel_settings.rs
+++ b/shiki-tui/src/panel_settings.rs
@@ -139,16 +139,28 @@ pub enum EditorField {
     SelectAllCtrlA,
     LineNumbers,
     MultiCursor,
+    AutoListContinue,
+    FormatShortcuts,
+    AutoPairBrackets,
+    PasteUrlAsLink,
+    SnippetExpandTab,
+    TypewriterScroll,
 }
 
 impl EditorField {
-    pub const ALL: [EditorField; 6] = [
+    pub const ALL: [EditorField; 12] = [
         EditorField::MouseSelection,
         EditorField::FindReplace,
         EditorField::OsClipboard,
         EditorField::SelectAllCtrlA,
         EditorField::LineNumbers,
         EditorField::MultiCursor,
+        EditorField::AutoListContinue,
+        EditorField::FormatShortcuts,
+        EditorField::AutoPairBrackets,
+        EditorField::PasteUrlAsLink,
+        EditorField::SnippetExpandTab,
+        EditorField::TypewriterScroll,
     ];
 }
 
@@ -338,6 +350,36 @@ fn editor_rows(app: &App) -> Vec<Line<'static>> {
         ),
         row_line(app, "line_numbers", cfg.editor.line_numbers.to_string()),
         row_line(app, "multi_cursor", cfg.editor.multi_cursor.to_string()),
+        row_line(
+            app,
+            "auto_list_continue",
+            cfg.editor.auto_list_continue.to_string(),
+        ),
+        row_line(
+            app,
+            "format_shortcuts",
+            cfg.editor.format_shortcuts.to_string(),
+        ),
+        row_line(
+            app,
+            "auto_pair_brackets",
+            cfg.editor.auto_pair_brackets.to_string(),
+        ),
+        row_line(
+            app,
+            "paste_url_as_link",
+            cfg.editor.paste_url_as_link.to_string(),
+        ),
+        row_line(
+            app,
+            "snippet_expand_tab",
+            cfg.editor.snippet_expand_tab.to_string(),
+        ),
+        row_line(
+            app,
+            "typewriter_scroll",
+            cfg.editor.typewriter_scroll.to_string(),
+        ),
     ]
 }
 


### PR DESCRIPTION
## Summary
- Adds nine editor UX improvements, all reachable from the native inline editor (no `$EDITOR` required):
  - List/checkbox auto-continuation on Enter, with empty-item exit and Backspace cleanup
  - Bold/italic wrap shortcuts (Ctrl+B / Ctrl+Alt+I) and bracket/quote auto-pairing (`(`, `` ` ``, `"` — `[` deliberately excluded to not break `[[wikilink]]` autocomplete)
  - Pasting a bare URL over a selection wraps it as a markdown link
  - Move line up/down (Alt+↑/↓) and duplicate line (Alt+D)
  - Snippet expansion via trigger + Tab, reusing the existing `/`-menu snippet catalog
  - Zen mode (`leader z`): forces the full-screen single-panel layout for distraction-free writing
  - Outline modal (PREVIEW `o`, or `Ctrl+O` while editing): jump to any heading in the note
  - Typewriter scrolling (opt-in): keeps the cursor's line vertically centered while typing
- All new `[editor]` toggles default to `true` (purely additive) except `typewriter_scroll` (opt-in, changes scroll feel)
- New `shiki-core::headings` module with unit tests for heading extraction
- Updated `IDEA.md` (config schema, keybindings tables), `shiki doctor`'s keybinding-collision list, and the Settings EDITOR tab (now 12 toggles)

## Test plan
- [x] `cargo build --workspace` / `cargo check --workspace`
- [x] `cargo clippy --workspace --all-targets` clean
- [x] `cargo fmt --all`
- [x] `cargo test --workspace` (including new `shiki-core::headings` unit tests)
- [x] `shiki doctor` — no keybinding collisions
- [x] Manually exercised every feature live in a real `tmux` session against isolated `XDG_CONFIG_HOME`/`XDG_DATA_HOME` test dirs: list auto-continue/exit, bold wrap, auto-pair, move/duplicate line, Tab snippet expansion, outline modal (both PREVIEW and Ctrl+O-in-edit), zen mode toggle on/off

🤖 Generated with [Claude Code](https://claude.com/claude-code)