### PR TITLE
fix(tui): box TreeRow::Note to satisfy clippy::large_enum_variant

### DIFF
--- a/shiki-tui/src/tree.rs
+++ b/shiki-tui/src/tree.rs
@@ -11,7 +11,7 @@ use shiki_core::{Note, Notebook};
 #[derive(Debug, Clone)]
 pub enum TreeRow {
     Folder { depth: usize, name: String },
-    Note { depth: usize, note: Note },
+    Note { depth: usize, note: Box<Note> },
 }
 
 /// Depth-first flatten of `nb`'s entire tree, folders (and everything under
@@ -35,6 +35,9 @@ fn build_at(nb: &Notebook, relative: &Path, depth: usize, out: &mut Vec<TreeRow>
         build_at(nb, &relative.join(folder), depth + 1, out);
     }
     for note in notes {
-        out.push(TreeRow::Note { depth, note });
+        out.push(TreeRow::Note {
+            depth,
+            note: Box::new(note),
+        });
     }
 }


### PR DESCRIPTION
## Summary
- CI's `-D warnings` started failing on `main` because clippy flags `TreeRow::Note`'s 256-byte `Note` payload against `Folder`'s 32 bytes (`clippy::large_enum_variant`).
- Boxes the `Note` field per clippy's own suggestion, keeping the enum small. Unrelated to any dependency bump — verified the same failure reproduces on current `main` HEAD independently.

## Test plan
- [x] `cargo build --workspace`
- [x] `cargo clippy --workspace --all-targets -- -D warnings` (clean)
- [x] `cargo fmt --all -- --check`
- [x] `cargo test --workspace` (85 passed)