### PR TITLE
fix(tui): preserve preview scroll position when entering edit mode

### DIFF
--- a/shiki-tui/src/key_handlers.rs
+++ b/shiki-tui/src/key_handlers.rs
@@ -3892,6 +3892,12 @@ impl App {
                             .unwrap_or_else(|| self.config.general.editor.clone());
                         self.want_external_edit = Some((note.path.clone(), editor));
                     }
+                } else if self.focus == Focus::Preview
+                    && self
+                        .note_preview_source_line(self.preview_scroll as usize)
+                        .is_some()
+                {
+                    self.enter_edit_at_preview_row(self.preview_scroll as usize);
                 } else {
                     self.start_edit_inline();
                 }


### PR DESCRIPTION
## Summary
- Pressing `i` in PREVIEW always opened the editor at line 1, discarding the scroll position the user had while reading — the only positional context available in a read-only view.
- Reuses the existing click-to-edit source-line mapping (`App::enter_edit_at_preview_row`, already used by mouse click-to-edit) so the editor's cursor jumps to whichever raw source line was at the top of the preview viewport when `i` was pressed.
- Falls back to the previous behavior (open at line 1) if the preview cache hasn't caught up yet.

Fixes #55

## Test plan
- [x] `cargo check --workspace` / `cargo clippy --workspace --all-targets` / `cargo fmt --all` all clean
- [x] Verified live in tmux: created a 100-line note, scrolled PREVIEW so "Line number 31" was at the top, pressed `i`, confirmed the editor cursor landed on that exact line (typed a marker to prove it) instead of resetting to line 1

🤖 Generated with [Claude Code](https://claude.com/claude-code)