### PR TITLE
docs: fix documentation↔code coherence drift

### DIFF
--- a/.opencode/agent/docs-auditor.md
+++ b/.opencode/agent/docs-auditor.md
@@ -1,0 +1,23 @@
+---
+description: Audits shiki's documentation (IDEA.md, CLAUDE.md, CHANGELOG.md, README.md, /docs site, docs/js/main.js, docs/css, scripts/screenshots.sh) against the code and returns a numbered drift report with file:line references. Read-only — never edits. Use for "documentation drift", "docs coherentes", "docs vs code".
+mode: subagent
+permission:
+  edit: deny
+  bash: allow
+---
+
+You are the documentation-coherence auditor for the shiki codebase.
+
+1. Load the `docs-coherence` skill with the skill tool and follow its checklist exactly.
+2. Audit every class in the checklist: version coherence, CLI commands, keybindings, config schema,
+   themes, CHANGELOG [Unreleased] → code, and CLAUDE.md operational claims.
+3. Use `rg`/`read` to cross-reference. For config defaults, read the `#[serde(default = "...")]` fn
+   body. For keybinding defaults, compare `shiki-config/src/config.rs` default fns against the
+   documented key in IDEA.md / docs/documentation.html tables.
+4. Return a single report:
+   - For each checklist class: one line — "OK" or a numbered list of findings.
+   - Each finding: severity (HIGH/MED/LOW), `file:line`, what the code does vs what the doc says,
+     and the minimal fix.
+   - End with a one-line summary: how many total drifts found, and which class is worst.
+   Do NOT edit or fix anything — you only report.
+5. If a class is genuinely clean, say so. Do not pad the report.

--- a/.opencode/agent/tui-tester.md
+++ b/.opencode/agent/tui-tester.md
@@ -1,0 +1,24 @@
+---
+description: Live-tests the shiki TUI in a real terminal by driving it through tmux — builds the binary, seeds an isolated XDG env, launches a detached pane, sends real keypresses, and asserts on the captured screen. Use for "prueba en la TUI", "revisa en tui", verifying a keybinding/feature live, or reproducing a UI bug. Read-only — never edits.
+mode: subagent
+permission:
+  edit: deny
+  bash: allow
+---
+
+You are the live-TUI tester for the shiki codebase.
+
+1. Load the `tui-tmux-test` skill with the skill tool and follow its workflow exactly.
+2. The task tells you which feature/binding to verify (e.g. "zen mode via leader z", "outline modal
+   via o and Ctrl+O", or a bug to reproduce). If the task names a keybinding, first confirm the
+   default key in `shiki-config/src/config.rs` (e.g. `zen_mode = "z"`) and the action in
+   `shiki-tui/src/keybindings.rs` so you know the exact keys to send — then verify live.
+3. Isolate ALWAYS: throwaway root under /tmp, XDG_CONFIG_HOME/XDG_DATA_HOME overridden, seed data
+   via the CLI (`shiki notebook create personal`, `shiki new ... -n personal --body ...`).
+4. Drive the TUI with `tmux send-keys` and assert on `tmux capture-pane`:
+   - Report the footer status message, layout shape, and any modal contents verbatim.
+   - A verdict: "verified live" (with the observed screen evidence) or "mismatch" (doc says X,
+     screen shows Y — quote both).
+5. Clean up: kill the tmux session and remove the temp root. Never leave a session or stray dirs.
+6. If the binary doesn't build or the TUI errors, report that as the result with the error output —
+   do not improvise around it.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,56 @@
+# AGENTS.md
+
+## Read this first
+
+- **`CLAUDE.md` is the exhaustive source of truth** (layout, keybindings, config schema, git sync, release automation, per-file design rationale). Read the relevant section before any architectural change. `IDEA.md` is the design spec. `AGENTS.md` only covers what you'd otherwise guess wrong.
+- This is a Rust Cargo workspace (`shiki-core` → `shiki-config` → `shiki-tui` → `shiki-cli`, strict one-way deps). Binary name is **`shiki`** (in `shiki-cli/src/main.rs`), launched with no args = TUI, `-- <args>` = CLI subcommands.
+
+## Commands
+
+```sh
+cargo check --workspace                          # fast iteration
+cargo test --workspace                           # the whole suite
+cargo clippy --workspace --all-targets -- -D warnings   # CI gate — the -D warnings matters
+cargo fmt --all                                  # then re-clippy
+cargo audit                                      # CI runs this; ignore list lives in .cargo/audit.toml
+cargo run -p shiki-cli -- --help                 # CLI; no args launches the TUI
+```
+
+- CI (`ci.yml`) runs `fmt --check` (ubuntu only), `clippy -D warnings` and `cargo test` on all 3 OSes. Clippy is matrixed because `shiki-core/src/editor.rs` has `#[cfg(target_os = ...)]` blocks.
+- Never commit a clippy failure; `-- -D warnings` is enforced in CI.
+
+## Testing
+
+- There are **~220 `#[test]`s** (118 in `shiki-core`, 13 `shiki-config`, 85 `shiki-tui`, 3 `shiki-cli`) — CLAUDE.md's "almost no tests yet" paragraph is stale. They are all inline `#[cfg(test)]` modules inside source files (no `tests/` dirs, no `#[ignore]`, no fixture setup). `cargo test --workspace` is green.
+- To exercise the CLI/TUI without touching real user data, override XDG dirs (used via `directories::ProjectDirs::from("", "", "shiki")`):
+
+```sh
+XDG_CONFIG_HOME=/tmp/shiki-test-config XDG_DATA_HOME=/tmp/shiki-test-data cargo run -p shiki-cli -- notebook create personal
+```
+
+- For `shiki-tui` logic, prefer pure functions over constructing a full `App` in a test — the pattern is `panel_drawer::drawer_hit_at(notebook_count, area, column, row)` (takes plain numbers, not `&App`).
+
+## Invariants that are easy to break
+
+- **`KeyMaps` matches `KeyCode` only, never the full `KeyEvent`/modifiers.** Shift bindings (`A`, `E`, `T`, `P`, `R`) are plain uppercase chars in `config.toml`; making matching modifier-aware silently breaks them.
+- **`shiki-config` must stay ratatui-free.** Theme colors are hex strings (`#rrggbb`/ANSI names/`"reset"`); conversion lives only in `shiki-tui/src/render.rs::hex_to_color`.
+- **`git2` needs `ssh`, `https`, `vendored-libgit2`, `vendored-openssl`** (root `Cargo.toml`). Dropping the vendored features breaks Windows/aarch64 cross-builds; dropping `ssh`/`https` post-git2-0.21 silently kills remote support and the credential-helper fallback.
+- **`tokio` is a workspace dependency but is not used anywhere** — everything is synchronous + `std::thread`/`mpsc`. Don't introduce async for new features.
+- **`shiki doctor` is dispatched *before* `Context::load()`** in `main.rs` (it must work when `config.toml` is broken). A new subcommand that shouldn't require a working config follows the same pattern.
+- **`Cargo.lock` is committed deliberately** (binary crate, reproducible builds). Don't gitignore it.
+
+## Versioning & release
+
+- Single version in `[workspace.package]` (root `Cargo.toml`); all crates inherit via `version.workspace = true`. Bump there + add a `CHANGELOG.md` entry (Keep a Changelog) + update `docs/index.html`'s hardcoded JSON-LD `softwareVersion`.
+- **Never `git tag`/push tags by hand.** Include `[PUBLISH]` in the commit message that lands on `main`; `.github/workflows/auto-tag.yml` reads the version from `Cargo.toml`, tags, and triggers `release.yml` (builds → GitHub Release → crates.io → AUR/Scoop manifests). `release.yml` pushes need `secrets.RELEASE_TAG_PAT` (admin PAT) — don't revert those jobs to `GITHUB_TOKEN`; branch protection requires admin.
+
+## `/docs` (marketing site) sync
+
+- Theme colors in `docs/css/styles.css` and the `THEMES` array in `docs/js/main.js` are copied from `shiki-config/src/themes/*.rs` — update all three together if a palette changes or a theme is added.
+- `/screenshots` (repo root) is gitignored; `docs/assets/screenshots/` is not (and is what README.md's `<img>` tags and the site reference).
+- `docs/documentation.html` is copied verbatim from `IDEA.md` — don't let them drift.
+- `nix/` derivations are drafts validated only by the manual-trigger `nix-package-check.yml` — not a real packaging path.
+
+## Packaging
+
+- `bucket/shiki.json` and `packaging/scoop/shiki.json` are **byte-identical copies** (Scoop bucket install vs. direct-URL install); `release.yml` writes both from one loop. `packaging/aur/` = `shiki-bin` (prebuilt), `packaging/aur-src/` = `shiki` (source build) — both are real AUR packages, don't merge them.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,22 @@ semver yet (pre-1.0), but version bumps are still meaningful and tracked here.
   un-completing) inserts its next occurrence right below it, unchecked, with `@due` advanced by
   that interval from the task's existing due date (or from today if it had none) — a repeat icon
   plus the raw spec shows next to the task text in the tasks view.
+- Dataview-style queries over note frontmatter: `shiki query 'where status = pending sort due
+  asc'` filters/sorts notes across every notebook from the CLI, and leader+`q` opens the same
+  live-editable query modal in the TUI (type the DSL at the top, matching notes render as a
+  table below). Both share one parser/evaluator (`shiki_core::query`), so a query means the
+  same thing in either place. `--count`/`--json`/`--notebook` are there for status bars and
+  scripting, and DSL strings can be saved by name under `[queries]` and run with `shiki query
+  --saved <name>`.
+- Per-notebook encryption at rest (`age::scrypt`, passphrase-based): `shiki notebook encrypt
+  <name>` re-encrypts every note as an age-armored blob (still plain ASCII text, so `git diff`
+  doesn't flip to "binary files differ") and writes an encrypted `.shiki-encryption` canary used
+  to verify a passphrase attempt without risking a real note; `shiki notebook decrypt <name>`
+  reverses it. The TUI unlocks a locked notebook by sniffing the age armor header and prompting
+  for the passphrase, regardless of what any machine's config says. The passphrase itself is
+  never stored anywhere — not in `config.toml`, not in the repo. Write paths (`shiki new`/`shiki
+  daily`) prompt for it; non-interactive read commands (`list`/`tasks`/`graph`/`show`/`search`)
+  fail with a clear error against a locked notebook instead of printing garbage.
 
 ### Fixed
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,13 +21,15 @@ cargo fmt --all                      # format (run after editing, before checkin
 cargo run -p shiki-cli -- <args>     # run the binary, e.g. `-- new "titulo"`, `-- daily`, no args launches the TUI
 ```
 
-Almost no automated tests yet — `panel_drawer::tests` (`shiki-tui/src/panel_drawer.rs`) are the
-first, covering `drawer_hit_at`'s mouse coordinate math (a plain function of numbers, not `&App`,
-specifically so it's unit-testable without constructing a full app). When adding tests for
-`shiki-core`/`shiki-config` logic, put them as `#[cfg(test)]` modules in the relevant file — those
-two crates have no TUI/terminal dependency, so they're the easiest to unit test. For `shiki-tui`,
-prefer designing the function to not need `&App` in the first place (as `drawer_hit_at` does) over
-constructing a full `App` in a test.
+There are ~220 `#[test]`s: 118 in `shiki-core`, 13 in `shiki-config`, 85 in `shiki-tui`, 3 in
+`shiki-cli` — `cargo test --workspace` is green. They're all inline `#[cfg(test)]` modules inside
+the source files (no `tests/` dirs, no `#[ignore]`, no fixture setup), so the pattern set by
+`panel_drawer::tests` (`shiki-tui/src/panel_drawer.rs`) — covering `drawer_hit_at`'s mouse
+coordinate math as a plain function of numbers, not `&App` — is the norm. When adding tests,
+put them as `#[cfg(test)]` modules in the relevant file; `shiki-core`/`shiki-config` have no
+TUI/terminal dependency, so they're the easiest to unit test. For `shiki-tui`, prefer designing
+the function to not need `&App` in the first place (as `drawer_hit_at` does) over constructing a
+full `App` in a test.
 
 To exercise the CLI without touching the real user config/data, override XDG dirs (used via
 `directories::ProjectDirs::from("", "", "shiki")` in `shiki-config`):

--- a/IDEA.md
+++ b/IDEA.md
@@ -33,7 +33,6 @@ A single binary that covers all of this, from the start, no phases.
 | Category | Crate |
 |---|---|
 | **TUI framework** | `ratatui` 0.30 + `crossterm` |
-| **Async runtime** | `tokio` |
 | **Git bindings** | `git2` |
 | **Markdown parsing** | `comrak` |
 | **Syntax highlighting** | `syntect` (note preview) |
@@ -851,6 +850,6 @@ body = "# [{{title}}] {{cursor}}"
 2. **Plain text** — notes are `.md` with frontmatter. Nothing proprietary.
 3. **Git native** — each notebook is its own repo. Commit, push, pull from the app.
 4. **No phases** — everything here is implemented in full. There's no "Phase 2".
-5. **Fast** — Rust + async + ratatui. Sub-millisecond renders.
+5. **Fast** — Rust + ratatui. Sub-millisecond renders.
 6. **Configurable** — keybindings, themes, editor, all in TOML.
-7. **Yazi-inspired** — three panels, modal, which-key, async event loop.
+7. **Yazi-inspired** — three panels, modal, which-key, single-threaded event loop.

--- a/IDEA.md
+++ b/IDEA.md
@@ -207,10 +207,12 @@ search, tree view) using the same list/selection they already navigate with `j`/
 | `p` | Scratchpad — open an in-memory editor; `Ctrl+S` saves its contents through the new-note title/template flow, while `Esc` discards it |
 | `B` | Links — the same modal as PREVIEW's `L` (outgoing wikilinks / backlinks / unlinked mentions for the selected note), reachable from any panel without focusing PREVIEW first |
 | `t` | Tasks — every `- [ ]` checkbox task across every notebook in one flat list, pending-only by default (persisted default: `general.tasks_show_done_default`), sorted by urgency (overdue → due today → future → undated); every row carries its own muted location (`notebook/folders…/note title`) so where a task lives is always visible, even mid-scroll. `Enter`/`space` toggles the task directly in its source file (a normal note edit — flows through auto-sync like any other change) and updates the row in place so it can be immediately un-toggled; `l`/`o` jumps to the note; `a` also shows completed tasks. An optional `@due(YYYY-MM-DD)` tag anywhere in the task text renders the date next to it: overdue in the theme's error color, due today in warning, future in muted. Relative specs — `@due(tomorrow)`, `@due(+3d)`, `@due(+2w)`, `@due(fri)` — are pinned to the real date the moment the note is saved (inline or external editor), since they're relative to the day they were written. An optional `@every(<spec>)` tag (`day`/`daily`, `week`/`weekly`, `month`/`monthly`, `year`/`yearly`, or `Nd`/`Nw`/`Nm`) marks a task as recurring — completing it (not un-completing) inserts its next occurrence right below it, unchecked, with `@due` advanced by that interval from the existing due date (or from today if it had none); a repeat icon plus the raw spec shows next to the task text. Also scriptable as `shiki tasks` (see CLI commands) |
+| `q` | Query — Dataview-style filter/sort over frontmatter across every notebook, live-editable: type the DSL at the top (e.g. `where status = pending sort due asc`), matching notes render as a table below; `↑`/`↓`/`PageUp`/`PageDown`/`Home`/`End` move the selection (deliberately no `j`/`k` — those stay typeable into the query), `Enter` jumps to the note, `Esc` closes. Same engine as `shiki query`; DSL strings can also be saved by name under `[queries]` and run with `shiki query --saved <name>` (see CLI commands) |
 | `P` | Publish the selected notebook to a themed PDF via `pretty-pdf` (external binary, auto-fetched on first use — see CLI commands), written to `{data_dir}/exports/{notebook}.pdf`, then opened. Same rendering `shiki publish` uses; the theme comes from `export.pdf_theme`, cyclable in Settings → EXPORT |
+| `x` | Export the selected notebook to HTML/Markdown — prompts for the output path (prefilled with `{data_dir}/exports/{notebook}.html`); same bundling `shiki export` does (see CLI commands) |
 | `U` | Check for updates — modal; checks GitHub Releases in the background (never blocks the UI), shows "update available" if there's a newer version, and `Enter` downloads, verifies (against GitHub's own per-asset checksum), installs, and automatically relaunches into it |
 | `u` | Undo the last delete — restores the most recently deleted note/folder (or whole batch, from a Visual-mode delete) from the trash (`~/.config/shiki/trash/`) back to exactly where it came from. A single level of undo, not a full history: only the *most recent* delete is restorable this way; an older one is still on disk in the trash, just no longer reachable from here. With nothing to undo, reports that instead of doing anything |
-| `s` | Settings — near-full-screen, paged by tab (`←`/`→` switches GENERAL/THEME/GIT/EDITOR/EXPORT/NOTEBOOKS/SNIPPETS, `j`/`k` moves within one). Doesn't repeat the keybindings tables — `?` (which-key) already covers those live. Every tab is editable with `Enter`: GENERAL/GIT booleans (`use_favorite_editor`, `auto_commit`/`auto_push`/`sign_commits`/`auto_sync`) toggle in place and save immediately; every other GENERAL/GIT field opens a prompt prefilled with its current value; THEME's `name` opens the theme picker (live preview, same as leader+`c`) and `overrides` stays informational; EDITOR is twelve plain boolean toggles for the native note editor's UX (see `[editor]` below); EXPORT is one field, `pdf_theme`, cycling through `pretty-pdf`'s 17 built-in themes (the default `shiki publish`/leader+`P` fall back to); NOTEBOOKS lists every notebook's actual git remote (redacted) and drills into one to edit its remote plus its `auto_push`/`auto_sync`/`auto_sync_every` overrides (booleans cycle inherit → true → false → inherit); SNIPPETS supports `a` (new snippet) and `d` (delete, with confirmation), and drilling into one edits its `label` and its full multi-line `body` through the same inline editor a note's own body uses. `i`/`E` still jump straight to editing `config.toml` itself for anything not covered above (inline or externally, same convention as editing a note); on save, the config is re-read, re-applied, and takes effect immediately (no restart) — an invalid edit is reported and neither written nor applied, keeping the previous config running. `h`/`Esc`/`Backspace` backs out of a drilled-into notebook/snippet a level; `Esc`/`q` at the top level closes |
+| `s` | Settings — near-full-screen, paged by tab (`←`/`→` switches GENERAL/THEME/GIT/EDITOR/EXPORT/NOTEBOOKS/SNIPPETS, `j`/`k` moves within one). Doesn't repeat the keybindings tables — `?` (which-key) already covers those live. Every tab is editable with `Enter`: GENERAL/GIT booleans (`use_favorite_editor`, `auto_commit`/`auto_push`/`sign_commits`/`auto_sync`) toggle in place and save immediately; every other GENERAL/GIT field opens a prompt prefilled with its current value; THEME's `name` opens the theme picker (live preview, same as leader+`c`) and `overrides` stays informational; EDITOR is fifteen plain boolean toggles for the native note editor's UX (see `[editor]` below); EXPORT is `pdf_theme` (cycling through `pretty-pdf`'s 17 built-in themes — the default `shiki publish`/leader+`P` fall back to), `export_dir` (a text prompt showing where PDFs land, resolved against the app's data dir when empty), and `ask_export_path` (a plain in-place toggle); NOTEBOOKS lists every notebook's actual git remote (redacted) and drills into one to edit its remote plus its `auto_push`/`auto_sync`/`auto_sync_every` overrides (booleans cycle inherit → true → false → inherit); SNIPPETS supports `a` (new snippet) and `d` (delete, with confirmation), and drilling into one edits its `label` and its full multi-line `body` through the same inline editor a note's own body uses. `i`/`E` still jump straight to editing `config.toml` itself for anything not covered above (inline or externally, same convention as editing a note); on save, the config is re-read, re-applied, and takes effect immediately (no restart) — an invalid edit is reported and neither written nor applied, keeping the previous config running. `h`/`Esc`/`Backspace` backs out of a drilled-into notebook/snippet a level; `Esc`/`q` at the top level closes |
 | `z` | Zen mode — forces the full-screen single-panel layout (the same one a very small terminal already falls into) regardless of actual terminal size, hiding NOTEBOOKS/NOTES so only the focused panel shows. A true toggle, same `leader z` both enters and exits it; purely a view state, not persisted to `config.toml` |
 
 #### `[keybindings.notebooks]` — active while NOTEBOOKS is focused
@@ -386,6 +388,7 @@ shiki tasks --overdue --count  # just the number — made for waybar/polybar/tmu
 shiki tasks --today --json     # machine-readable, with due/overdue/location per task
 shiki graph               # [[wikilink]] connection graph, force-directed, drawn in the terminal
 shiki graph -n work --json     # nodes/edges/orphans as JSON, for graphviz/d3/gephi
+shiki graph --width 120        # custom canvas width in columns (default: the terminal's own width)
 shiki export -n work --out bundle.html            # every note in "work" as one self-contained HTML file
 shiki export -n work --out bundle.md --format md  # or a plain concatenated Markdown bundle
 shiki publish -n work                     # render "work" to a themed PDF via pretty-pdf (auto-fetched, see below)
@@ -401,6 +404,7 @@ shiki notebook encrypt <name>       # enable encryption at rest (prompts for a p
 shiki notebook decrypt <name>       # reverse it — decrypts every note back to plain text
 shiki query 'where status = pending sort due asc'   # Dataview-style filter/sort over frontmatter
 shiki query 'where due < today' --count             # for status bars, like `shiki tasks --count`
+shiki query --saved due-soon                        # run a query saved under [queries] in config.toml
 shiki theme list          # list built-in themes, marking the active one
 shiki theme set <name>    # switch theme (persisted to config.toml)
 shiki theme create [--from <name>]  # scaffold all 19 color overrides from a real palette
@@ -682,6 +686,11 @@ scratchpad = "p"
 links = "B"
 # Global tasks view — every checkbox task in every notebook.
 tasks_panel = "t"
+# Dataview-style query modal over frontmatter — same engine as `shiki query`.
+query_panel = "q"
+publish = "P"
+# Same HTML/Markdown bundling as `shiki export`.
+export = "x"
 # Full-screen single-panel layout, hiding NOTEBOOKS/NOTES — a true toggle.
 zen_mode = "z"
 
@@ -778,9 +787,13 @@ block_indent_select = true  # Tab/Shift+Tab with a selection indent/outdent ever
 # go-pretty-pdf's 17 built-in themes: default, minimal, modern, classic,
 # corporate, dark, academic, editorial, sepia, terminal, blueprint, ivy,
 # government, resume, legal, latex, gruvbox. Cyclable from the EXPORT tab
-# in Settings.
+# in Settings. export_dir relocates where PDFs land (empty = the app's own
+# data dir); ask_export_path prompts for the exact save path on every
+# publish instead of silently writing there.
 [export]
 pdf_theme = "default"
+# export_dir = ""       # save PDFs elsewhere instead of the app's data dir
+# ask_export_path = true  # prompt for the save path on every publish
 
 # Optional per-notebook overrides of [git] — anything left unset here falls
 # back to the global values above.
@@ -803,6 +816,9 @@ auto_push = true
 # inherit from; this is opt-in per notebook, managed via `shiki notebook
 # encrypt/decrypt <name>` or Settings → NOTEBOOKS, not by hand-editing this.
 # encrypt = true
+# `hidden` is set automatically when "delete notebook" is answered with "just
+# remove the reference": the directory on disk is left untouched, the notebook
+# just stops being listed. No in-app "un-hide" yet — clear it here by hand.
 
 # Custom entries for the inline editor's `/`-menu, keyed by trigger. Empty by
 # default — the built-in commands (h1/h2/h3/code/math/table/check/quote/
@@ -820,6 +836,11 @@ body = "> **Info:** {{cursor}}"
 # adding a duplicate — every command in the menu is customizable this way.
 [snippets.h1]
 body = "# [{{title}}] {{cursor}}"
+
+# Named, saved `shiki query` DSL strings — run one with `shiki query --saved <name>`.
+# Same Dataview-style language as the leader+`q` modal and the literal CLI arg.
+[queries]
+# due-soon = "where due < today sort due asc"
 ```
 
 ---

--- a/IDEA.md
+++ b/IDEA.md
@@ -36,12 +36,11 @@ A single binary that covers all of this, from the start, no phases.
 | **Git bindings** | `git2` |
 | **Markdown parsing** | `comrak` |
 | **Syntax highlighting** | `syntect` (note preview) |
-| **Inline editor** | `tui-textarea` |
-| **Fuzzy search** | `nucleo` (same as Helix) |
+| **Inline editor** | `ratatui-textarea` 0.9 |
+| **Fuzzy search** | `nucleo-matcher` (same as Helix) |
 | **Config / themes** | `serde` + `toml` |
 | **CLI parsing** | `clap` v4 |
 | **Dates** | `chrono` |
-| **File watcher** | `notify` (detect external changes) |
 | **Frontmatter** | `serde_yaml` |
 | **Logging** | `tracing` + `tracing-subscriber` |
 | **Wikilinks** | regex + `pulldown-cmark` |
@@ -63,7 +62,7 @@ shiki/
 │       ├── lib.rs
 │       ├── notebook.rs            # Notebook struct, notebook CRUD
 │       ├── note.rs                # Note struct, frontmatter, body
-│       ├── search.rs              # fuzzy search engine (nucleo)
+│       ├── search.rs              # fuzzy search engine (nucleo-matcher)
 │       ├── git.rs                 # git2: init, commit, push, pull, status
 │       ├── templates.rs           # template system
 │       ├── daily.rs               # daily notes: create by date
@@ -94,7 +93,7 @@ shiki/
 │       ├── panel_notes.rs         # center panel
 │       ├── panel_preview.rs       # right panel (rendered markdown)
 │       ├── panel_tags.rs          # tag filter
-│       ├── editor.rs              # inline editor (tui-textarea)
+│       ├── editor.rs              # inline editor (ratatui-textarea)
 │       ├── status_bar.rs          # bottom status bar
 │       ├── which.rs               # keybindings popup + command palette (like Yazi)
 │       ├── confirm.rs             # confirmation dialog
@@ -164,7 +163,7 @@ This layout is responsive to the terminal's actual size, not just one fixed arra
 |---|---|
 | `NORMAL` | Navigation, single-key shortcuts |
 | `INSERT` | Typing in search / input |
-| `EDIT` | Inline editor active (tui-textarea) |
+| `EDIT` | Inline editor active (ratatui-textarea) |
 | `VISUAL` | Multi-note selection |
 
 ### Keybindings: segmented by focus
@@ -363,8 +362,8 @@ non-whitespace character, pressing it again (or pressing it on a line already at
 column 0 — `End` goes to the end of the current line, `Ctrl+Home`/`Ctrl+End` jump to the very
 start/end of the note, and the mouse wheel scrolls too. `PageUp`/`PageDown`/mouse-wheel scrolling
 move the cursor itself (there's no independent scroll offset — the editor's word-wrap support
-means it bypasses `tui-textarea`'s own rendering, and with it, `tui-textarea`'s own viewport-based
-`PageUp`/`PageDown`, which otherwise does nothing here).
+means it bypasses `ratatui-textarea`'s own rendering, and with it, `ratatui-textarea`'s own
+viewport-based `PageUp`/`PageDown`, which otherwise does nothing here).
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -15,8 +15,7 @@
 [![GitHub repo size](https://img.shields.io/github/repo-size/sazardev/shiki)](https://github.com/sazardev/shiki)
 
 ![Rust](https://img.shields.io/badge/Rust-2021-CE422B?logo=rust&logoColor=white)
-![ratatui](https://img.shields.io/badge/ratatui-0.29-blue?logo=rust&logoColor=white)
-![tokio](https://img.shields.io/badge/tokio-1.x-blue?logo=rust&logoColor=white)
+![ratatui](https://img.shields.io/badge/ratatui-0.30-blue?logo=rust&logoColor=white)
 ![git2](https://img.shields.io/badge/git2-0.21-orange?logo=git&logoColor=white)
 ![clap](https://img.shields.io/badge/clap-4.x-blue?logo=rust&logoColor=white)
 
@@ -60,7 +59,7 @@ always recorded against that release's own binary — not a workflow from severa
 
 These update automatically after every release (`update-screenshots` job in
 [`release.yml`](.github/workflows/release.yml)), so they always reflect the current version — not
-a screenshot from three releases ago. All 15 built-in themes have a live, interactive preview on
+a screenshot from three releases ago. All 16 built-in themes have a live, interactive preview on
 the [website](https://sazardev.github.io/shiki/#themes).
 
 ## Features
@@ -81,7 +80,7 @@ the [website](https://sazardev.github.io/shiki/#themes).
   automatically every N changes), per-notebook policy overrides, robust HTTPS/SSH auth that
   reuses your system's own git credential store, and automatic fallback to the remote's actual
   default branch.
-- **15 built-in themes** (Catppuccin ×4, Tokyo Night ×3, Gruvbox ×2, Solarized ×2, Nord, Dracula,
+- **16 built-in themes** (Catppuccin ×4, Tokyo Night ×3, Gruvbox ×2, Solarized ×2, Nord, Dracula,
   One Dark, Monokai, and a
   terminal-native default that inherits your terminal's own palette) with a live-preview picker.
 - **Config-driven keybindings**, scoped by focus, fully remappable in `config.toml` — nothing
@@ -102,9 +101,11 @@ the [website](https://sazardev.github.io/shiki/#themes).
   `postmortem`/`standup`/`retro`/`1on1`/`weekly`/`brainstorm`) — pick one from the template picker
   when creating a note, or type `@` in the title prompt for a fast dropdown (`today`/`yesterday`/
   `tomorrow` or any template, fuzzy-filtered) that skips straight to editing.
-- **Settings screen** (leader+`s`) — a read-only summary of the whole config (general/theme/git/
-  per-notebook overrides/snippets), with `i`/`E` jumping straight to editing `config.toml` itself;
-  saved changes apply immediately, no restart needed.
+- **Settings screen** (leader+`s`) — every config option editable in place, paged by tab
+  (GENERAL/THEME/GIT/EDITOR/EXPORT/NOTEBOOKS/SNIPPETS): true/false fields toggle and save
+  immediately, anything else opens a prompt prefilled with its current value; `i`/`E` still jump
+  straight to editing `config.toml` itself for anything not covered. Saved changes apply
+  immediately, no restart needed.
 - **Logs modal** recording every status message (so errors don't get lost), with one-key clipboard
   copy (OSC 52) for pasting elsewhere.
 - **In-TUI self-update** (leader+`U`) — checks GitHub Releases for a newer version, and on
@@ -113,7 +114,8 @@ the [website](https://sazardev.github.io/shiki/#themes).
   flags duplicate/colliding keybindings, `/`-menu snippet triggers, unrecognized `config.toml` keys,
   and colliding notebook paths before they cause confusion.
 - **CLI commands** alongside the TUI (`new`, `list`, `edit`, `show`, `search`, `daily`, `sync`,
-  `notebook`, `theme`, `config`, `doctor`) for quick one-off operations without opening the UI.
+  `export`, `publish`, `tasks`, `graph`, `query`, `notebook`, `theme`, `config`, `doctor`) for
+  quick one-off operations without opening the UI.
 
 ## Install
 

--- a/docs/css/styles.css
+++ b/docs/css/styles.css
@@ -536,12 +536,13 @@ code, .code {
   display: none;
 }
 
-/* CSS-only fallback mockup, shown instead of a real screenshot for the 7
-   palettes that don't have one captured yet (screenshots/scripts/screenshot.sh
-   only ran for gruvbox-dark, catppuccin-mocha, tokyo-night-storm, nord, and
-   solarized-dark) — showing a *real* screenshot baked with the wrong
-   theme's pixel colors would be more misleading than a simple live mockup
-   that genuinely recolors with the CSS variables above. */
+/* CSS-only fallback mockup, shown instead of a real screenshot for the 4
+   palettes that don't have one captured yet (dracula, one-dark, monokai,
+   default — scripts/screenshots.sh's THEMES array covers all 16, so these
+   just haven't had a screenshots run capture them) — showing a *real*
+   screenshot baked with the wrong theme's pixel colors would be more
+   misleading than a simple live mockup that genuinely recolors with the CSS
+   variables above. */
 .term-fallback {
   display: grid;
   grid-template-columns: 1fr 1.4fr 1.8fr;

--- a/docs/documentation.html
+++ b/docs/documentation.html
@@ -300,10 +300,13 @@
           <tr><td><code>U</code></td><td>Check for updates — modal; checks GitHub Releases in the background (never blocks the UI), shows "update available" if there's a newer version, and Enter downloads, verifies (against GitHub's own per-asset checksum), installs, and automatically relaunches into it</td></tr>
           <tr><td><code>u</code></td><td>Undo the last delete — restores the most recently deleted note/folder (or whole batch, from a Visual-mode delete) from the trash (<code>~/.config/shiki/trash/</code>) back to exactly where it came from. A single level of undo, not a full history: only the <em>most recent</em> delete is restorable this way; an older one is still on disk in the trash, just no longer reachable from here. With nothing to undo, reports that instead of doing anything</td></tr>
           <tr><td><code>s</code></td><td>Settings — near-full-screen, paged by tab. See <a href="#settings-deep-dive">the Settings deep dive</a> below</td></tr>
+          <tr><td><code>z</code></td><td>Zen mode — forces the full-screen single-panel layout (the same one a very small terminal already falls into) regardless of actual terminal size, hiding NOTEBOOKS/NOTES so only the focused panel shows. A true toggle, the same <code>leader z</code> both enters and exits it; purely a view state, not persisted to <code>config.toml</code></td></tr>
           <tr><td><code>p</code></td><td>Scratchpad — open an in-memory editor; <code>Ctrl+S</code> saves its contents through the new-note title/template flow, while <code>Esc</code> discards it</td></tr>
           <tr><td><code>B</code></td><td>Links — the same modal as PREVIEW's <code>L</code> (outgoing wikilinks / backlinks / unlinked mentions for the selected note), reachable from any panel without focusing PREVIEW first</td></tr>
           <tr><td><code>t</code></td><td>Tasks — every <code>- [ ]</code> checkbox task across every notebook in one flat list, pending-only by default, sorted by urgency (overdue → due today → future → undated); every row carries its own muted location (<code>notebook/folders…/note title</code>) so where a task lives is always visible, even mid-scroll. <code>Enter</code>/<code>space</code> toggles the task directly in its source file and updates the row in place; <code>l</code>/<code>o</code> jumps to the note; <code>a</code> also shows completed tasks. An optional <code>@due(YYYY-MM-DD)</code> tag renders the date next to the task: overdue in the theme's error color, due today in warning, future in muted. Relative specs — <code>@due(tomorrow)</code>, <code>@due(+3d)</code>, <code>@due(+2w)</code>, <code>@due(fri)</code> — are pinned to the real date the moment the note is saved. An optional <code>@every(&lt;spec&gt;)</code> tag (<code>day</code>/<code>daily</code>, <code>week</code>/<code>weekly</code>, <code>month</code>/<code>monthly</code>, <code>year</code>/<code>yearly</code>, or <code>Nd</code>/<code>Nw</code>/<code>Nm</code>) marks a task as recurring — completing it inserts its next occurrence right below it, unchecked, with <code>@due</code> advanced by that interval. Also scriptable as <code>shiki tasks</code> (see CLI commands)</td></tr>
+          <tr><td><code>q</code></td><td>Query — Dataview-style filter/sort over frontmatter across every notebook, live-editable: type the DSL at the top (e.g. <code>where status = pending sort due asc</code>), matching notes render as a table below; <code>↑</code>/<code>↓</code>/<code>PageUp</code>/<code>PageDown</code>/<code>Home</code>/<code>End</code> move the selection, <code>Enter</code> jumps to the note, <code>Esc</code> closes. Same engine as <code>shiki query</code>; DSL strings can also be saved by name under <code>[queries]</code> and run with <code>shiki query --saved &lt;name&gt;</code> (see CLI commands)</td></tr>
           <tr><td><code>P</code></td><td>Publish the selected notebook to a themed PDF via <code>pretty-pdf</code> (external binary, auto-fetched on first use — see CLI commands), written to <code>{data_dir}/exports/{notebook}.pdf</code>, then opened. Theme comes from <code>export.pdf_theme</code>, cyclable in Settings → EXPORT</td></tr>
+          <tr><td><code>x</code></td><td>Export the selected notebook to HTML/Markdown — prompts for the output path (prefilled with <code>{data_dir}/exports/{notebook}.html</code>); same bundling <code>shiki export</code> does (see CLI commands)</td></tr>
         </tbody>
       </table>
       <div class="doc-shot-grid">
@@ -415,6 +418,7 @@
           <tr><td><code>E</code></td><td>Edit externally ($EDITOR)</td></tr>
           <tr><td><code>H</code></td><td>Note history — every commit that changed this specific note, newest first, real git history (not a separate versioning system). <code>j</code>/<code>k</code>/<code>PageUp</code>/<code>PageDown</code>/<code>Home</code>/<code>End</code> move, <code>Enter</code> views a revision's full content (frontmatter included, since that's what's actually in the commit), <code>d</code> views a real unified diff of that revision against its parent instead (colored <code>-</code>/<code>+</code> lines; also works from inside the full-content view to switch straight to the diff), <code>r</code> reverts to the highlighted (or currently-viewed) revision — behind a confirmation, since it overwrites the current content. The revert itself doesn't commit; it shows up as a normal pending change, picked up by <code>s</code>/<code>u</code>/<code>auto_sync</code> like any other edit. The footer shows the count while reading a note (<code>{n} changes</code>)</td></tr>
           <tr><td><code>L</code></td><td>Links — the selected note's outgoing <code>[[wikilinks]]</code> (resolved against every note in the notebook, any folder depth), every other note that links back to it, and notes that <em>mention</em> this note's title in plain text without linking to it ("Outgoing"/"Backlinks"/"Mentions (unlinked)" sections; a section with nothing in it is omitted). <code>j</code>/<code>k</code>/<code>PageUp</code>/<code>PageDown</code>/<code>Home</code>/<code>End</code> move, <code>Enter</code> jumps to the selected note (an unresolved outgoing link reports that instead of jumping), <code>c</code> on a mention row <em>repairs</em> the missed link — it wraps that note's plain-text mention into a real <code>[[wikilink]]</code> (preserving its casing) and the row visibly migrates to Backlinks — and <code>Esc</code>/<code>q</code> closes. Also reachable globally via leader+<code>B</code></td></tr>
+          <tr><td><code>o</code></td><td>Outline — every <code>#</code>..<code>######</code> heading in the selected note, indented by level. <code>j</code>/<code>k</code>/<code>PageUp</code>/<code>PageDown</code>/<code>Home</code>/<code>End</code> move, <code>Enter</code> scrolls PREVIEW to that heading, <code>Esc</code>/<code>q</code> closes. Also reachable as <code>Ctrl+O</code> from inside <code>Mode::Edit</code> itself — there, <code>Enter</code> moves the editor's own cursor to the heading instead of scrolling PREVIEW, and the headings come from the live, possibly-unsaved buffer rather than the note's last-saved body</td></tr>
           <tr><td><code>Ctrl</code>+click</td><td>Click a rendered <code>[[wikilink]]</code> to jump straight to the note it resolves to — a plain click still enters edit mode everywhere, including on top of a wikilink</td></tr>
         </tbody>
       </table>
@@ -498,6 +502,7 @@ shiki tasks --overdue --count  # just the number — made for waybar/polybar/tmu
 shiki tasks --today --json     # machine-readable, with due/overdue/location per task
 shiki graph               # [[wikilink]] connection graph, force-directed, drawn in the terminal
 shiki graph -n work --json     # nodes/edges/orphans as JSON, for graphviz/d3/gephi
+shiki graph --width 120        # custom canvas width in columns (default: the terminal's own width)
 shiki export -n work --out bundle.html            # every note in "work" as one self-contained HTML file
 shiki export -n work --out bundle.md --format md  # or a plain concatenated Markdown bundle
 shiki publish -n work                     # render "work" to a themed PDF via pretty-pdf (auto-fetched, see below)
@@ -513,6 +518,7 @@ shiki notebook encrypt &lt;name&gt;       # enable encryption at rest (prompts f
 shiki notebook decrypt &lt;name&gt;       # reverse it — decrypts every note back to plain text
 shiki query 'where status = pending sort due asc'   # Dataview-style filter/sort over frontmatter
 shiki query 'where due &lt; today' --count             # for status bars, like `shiki tasks --count`
+shiki query --saved due-soon                        # run a query saved under [queries] in config.toml
 shiki theme list          # list built-in themes, marking the active one
 shiki theme set &lt;name&gt;    # switch theme (persisted to config.toml)
 shiki theme create [--from &lt;name&gt;]  # scaffold all 19 color overrides from a real palette
@@ -963,10 +969,14 @@ block_indent_select = true</pre>
         <thead><tr><th>Key</th><th>Default</th><th>What it does</th></tr></thead>
         <tbody>
           <tr><td><code>pdf_theme</code></td><td><code>"default"</code></td><td>One of go-pretty-pdf's 17 built-in themes: <code>default</code>, <code>minimal</code>, <code>modern</code>, <code>classic</code>, <code>corporate</code>, <code>dark</code>, <code>academic</code>, <code>editorial</code>, <code>sepia</code>, <code>terminal</code>, <code>blueprint</code>, <code>ivy</code>, <code>government</code>, <code>resume</code>, <code>legal</code>, <code>latex</code>, <code>gruvbox</code>. Cyclable from the EXPORT tab in Settings, or overridden per-invocation with <code>--theme</code></td></tr>
+          <tr><td><code>export_dir</code></td><td><code>""</code></td><td>Directory PDFs are saved into (default: the app's own data dir, i.e. <code>{data_dir}/exports/{notebook}.pdf</code>). Empty means "use the app's own data dir"; set it to point exports somewhere else instead — a synced folder, Desktop, etc</td></tr>
+          <tr><td><code>ask_export_path</code></td><td><code>false</code></td><td>When true, publishing always opens a prompt asking exactly where to save the PDF (prefilled with the resolved default path) instead of silently writing to <code>export_dir</code>/the default location every time</td></tr>
         </tbody>
       </table>
       <pre class="code">[export]
-pdf_theme = "default"</pre>
+pdf_theme = "default"
+# export_dir = ""       # save PDFs elsewhere instead of the app's data dir
+# ask_export_path = true  # prompt for the save path on every publish</pre>
 
       <h3 id="config-notebooks"><code>[notebooks.&lt;name&gt;]</code> — per-notebook overrides</h3>
       <p style="max-width:70ch;">
@@ -982,6 +992,7 @@ pdf_theme = "default"</pre>
           <tr><td><code>auto_sync</code></td><td>inherits <code>[git]</code></td><td>Override just for this notebook</td></tr>
           <tr><td><code>auto_sync_every</code></td><td>inherits <code>[git]</code></td><td>Override just for this notebook</td></tr>
           <tr><td><code>path</code></td><td>unset (lives under the data directory)</td><td>An absolute path to an existing directory on disk — this notebook lives there instead of under <code>data_dir</code>/the default data directory. Must be absolute; a relative value is ignored (<code>shiki doctor</code> warns if one is found) rather than silently resolved against whatever directory the process happened to be launched from</td></tr>
+          <tr><td><code>hidden</code></td><td>unset (<code>false</code>)</td><td>Set when "delete notebook" was answered with "just remove the reference" instead of "delete the files" — the directory on disk is left untouched, this only stops the notebook from being listed/tracked. No in-app "un-hide" yet; reversing it means clearing the flag by hand in <code>config.toml</code> and relaunching</td></tr>
           <tr><td><code>encrypt</code></td><td><code>false</code></td><td>Encrypts every note in this notebook at rest with a passphrase — no global default to inherit, opt-in per notebook. Managed via <code>shiki notebook encrypt/decrypt &lt;name&gt;</code> or Settings → NOTEBOOKS, not by hand-editing this value (the passphrase itself is never stored here or anywhere else — see <a href="#encryption">Encryption</a> above)</td></tr>
         </tbody>
       </table>
@@ -990,6 +1001,7 @@ auto_sync = true
 auto_sync_every = 3
 auto_push = true
 # encrypt = true
+# hidden = true  # set by "just remove the reference" on delete; no in-app un-hide yet
 
 [notebooks.alcateia]
 path = "/Users/me/obsidian-vaults/alcateia"
@@ -1028,6 +1040,24 @@ body = "# [{{title}}] {{cursor}}"</pre>
         delete these without ever opening the raw file — see below.
       </p>
 
+      <h3 id="config-queries"><code>[queries]</code> — saved query DSL strings</h3>
+      <p style="max-width:70ch;">
+        Named, saved <code>shiki query</code> DSL strings (the same Dataview-style language the
+        leader+<code>q</code> modal accepts), keyed by name. Run one with
+        <code>shiki query --saved &lt;name&gt;</code> — handy for status bars, since
+        <code>--count</code>/<code>--json</code> work the same as with a literal query. Empty by
+        default.
+      </p>
+      <table class="ref-table config-ref-table">
+        <thead><tr><th>Key</th><th>Default</th><th>What it does</th></tr></thead>
+        <tbody>
+          <tr><td><code>&lt;name&gt;</code></td><td><em>(none — no saved queries)</em></td><td>A query DSL string (e.g. <code>where due &lt; today sort due asc</code>), looked up by name with <code>shiki query --saved &lt;name&gt;</code></td></tr>
+        </tbody>
+      </table>
+      <pre class="code">[queries]
+due-soon = "where due &lt; today sort due asc"
+# ...run it with: shiki query --saved due-soon</pre>
+
       <h3 id="settings-deep-dive">The Settings screen — editing all of the above without touching the file</h3>
       <figure class="doc-shot-card">
         <img data-shot="wide-14-settings" width="1260" height="760" loading="lazy" src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw==" alt="The Settings screen, GENERAL tab, showing editable config fields" />
@@ -1035,10 +1065,11 @@ body = "# [{{title}}] {{cursor}}"</pre>
       </figure>
       <p style="max-width:70ch;">
         <code>←</code>/<code>→</code> switches between seven tabs — GENERAL, THEME, GIT, EDITOR,
-        EXPORT, NOTEBOOKS, SNIPPETS — mirroring the sections above one for one. EXPORT is a
-        single field, <code>pdf_theme</code>, cycling through <code>pretty-pdf</code>'s 17
-        built-in themes (the default <code>shiki publish</code>/leader+<code>P</code> fall back
-        to). <code>j</code>/<code>k</code> moves
+        EXPORT, NOTEBOOKS, SNIPPETS — mirroring the sections above one for one. EXPORT holds
+        <code>pdf_theme</code> (cycling through <code>pretty-pdf</code>'s 17 built-in themes — the
+        default <code>shiki publish</code>/leader+<code>P</code> fall back to),
+        <code>export_dir</code> (a text prompt showing where PDFs land, resolved against the app's
+        data dir when empty), and <code>ask_export_path</code> (a plain in-place toggle). <code>j</code>/<code>k</code> moves
         within a tab, <code>Enter</code> edits or toggles the highlighted row (a true/false field
         flips immediately and saves; anything else opens a one-line prompt prefilled with its
         current value), and <code>Esc</code>/<code>q</code> closes. NOTEBOOKS and SNIPPETS are two
@@ -1136,6 +1167,13 @@ scratchpad = "p"
 links = "B"
 # Global tasks view — every checkbox task in every notebook.
 tasks_panel = "t"
+# Dataview-style query modal over frontmatter — same engine as `shiki query`.
+query_panel = "q"
+publish = "P"
+# Same HTML/Markdown bundling as `shiki export`.
+export = "x"
+# Full-screen single-panel layout, hiding NOTEBOOKS/NOTES — a true toggle.
+zen_mode = "z"
 
 [keybindings.notebooks]
 new = "a"
@@ -1168,6 +1206,7 @@ edit_inline = "i"
 edit_external = "E"
 history = "H"
 links = "L"
+outline = "o"
 
 [theme]
 name = "gruvbox-dark"
@@ -1231,6 +1270,8 @@ block_indent_select = true
 # in Settings.
 [export]
 pdf_theme = "default"
+# export_dir = ""       # save PDFs elsewhere instead of the app's data dir
+# ask_export_path = true  # prompt for the save path on every publish
 
 # Optional per-notebook overrides of [git] — anything left unset here falls
 # back to the global values above.
@@ -1248,6 +1289,8 @@ auto_sync = true
 auto_sync = true
 auto_sync_every = 3
 auto_push = true
+# encrypt = true
+# hidden = true  # set by "just remove the reference" on delete; no in-app un-hide yet
 
 # Custom entries for the inline editor's `/`-menu, keyed by trigger. Empty by
 # default — the built-in commands (h1/h2/h3/code/math/table/check/quote/
@@ -1264,7 +1307,11 @@ body = "> **Info:** {{cursor}}"
 # Same trigger as a built-in (case-insensitive) replaces it instead of
 # adding a duplicate — every command in the menu is customizable this way.
 [snippets.h1]
-body = "# [{{title}}] {{cursor}}"</pre>
+body = "# [{{title}}] {{cursor}}"
+
+# Named, saved `shiki query` DSL strings — run one with `shiki query --saved <name>`.
+[queries]
+# due-soon = "where due &lt; today sort due asc"</pre>
       <p class="muted" style="font-size:0.9rem;">
         Every default shown above matches the current release — if this page and a fresh
         <code>shiki</code> install ever disagree, trust the install.

--- a/docs/index.html
+++ b/docs/index.html
@@ -16,7 +16,7 @@
   <meta property="og:url" content="https://sazardev.github.io/shiki/" />
   <meta property="og:site_name" content="shiki" />
   <meta property="og:title" content="shiki (私記) — a TUI note-taking app for people who live in the terminal" />
-  <meta property="og:description" content="Three-pane, Yazi-inspired TUI note-taking app in Rust. Notebooks are independent git repos, every note has real version history, 15 built-in themes, fully keyboard-driven." />
+  <meta property="og:description" content="Three-pane, Yazi-inspired TUI note-taking app in Rust. Notebooks are independent git repos, every note has real version history, 16 built-in themes, fully keyboard-driven." />
   <meta property="og:image" content="https://sazardev.github.io/shiki/assets/og-image.png" />
   <meta property="og:image:width" content="1200" />
   <meta property="og:image:height" content="630" />
@@ -25,7 +25,7 @@
 
   <meta name="twitter:card" content="summary_large_image" />
   <meta name="twitter:title" content="shiki (私記) — a TUI note-taking app for people who live in the terminal" />
-  <meta name="twitter:description" content="Three-pane, Yazi-inspired TUI note-taking app in Rust. Notebooks are independent git repos, every note has real version history, 15 built-in themes, fully keyboard-driven." />
+  <meta name="twitter:description" content="Three-pane, Yazi-inspired TUI note-taking app in Rust. Notebooks are independent git repos, every note has real version history, 16 built-in themes, fully keyboard-driven." />
   <meta name="twitter:image" content="https://sazardev.github.io/shiki/assets/og-image.png" />
   <meta name="twitter:image:alt" content="shiki (私記) — a TUI note-taking app, shown running in a terminal window" />
 
@@ -148,7 +148,7 @@
   <section id="themes">
     <div class="container">
       <span class="eyebrow">Make it yours</span>
-      <h2>15 built-in themes. Pick one below — this whole page changes with it.</h2>
+      <h2>16 built-in themes. Pick one below — this whole page changes with it.</h2>
       <p class="muted" style="max-width: 62ch;">
         Go on, click around. Whatever you land on is exactly what's waiting for you in your
         terminal — no surprises.

--- a/docs/js/main.js
+++ b/docs/js/main.js
@@ -2,7 +2,7 @@
 // order, same names) — "dot" colors are each theme's own `accent` value
 // (docs/css/styles.css has the full palette per theme; this file only
 // needs enough to build/label the swatches and know which ones have a real
-// screenshot). All 12 now have a captured PNG in docs/assets/screenshots/
+// screenshot). 12 of the 16 have a captured PNG in docs/assets/screenshots/
 // (scripts/screenshots.sh's THEMES array covers every one) — `screenshot`
 // stays a per-theme flag rather than being assumed true for everyone so a
 // future theme added to shiki-config without a matching screenshot yet
@@ -21,12 +21,13 @@ const THEMES = [
   { id: "nord", label: "Nord", dot: "#88c0d0", screenshot: true },
   { id: "solarized-dark", label: "Solarized Dark", dot: "#268bd2", screenshot: true },
   { id: "solarized-light", label: "Solarized Light", dot: "#268bd2", screenshot: true },
-  // No captured screenshot yet — `#term-fallback`'s CSS-only mockup shows
-  // instead until `scripts/screenshots.sh`'s own THEMES array is updated
-  // and a release actually captures these three.
+  // No captured PNG yet for these four — `#term-fallback`'s CSS-only
+  // mockup shows instead until a screenshots release run actually captures
+  // them (scripts/screenshots.sh's THEMES array already covers every one).
   { id: "dracula", label: "Dracula", dot: "#bd93f9", screenshot: false },
   { id: "one-dark", label: "One Dark", dot: "#61afef", screenshot: false },
   { id: "monokai", label: "Monokai", dot: "#f92672", screenshot: false },
+  { id: "default", label: "Default", dot: "#8b949e", screenshot: false },
 ];
 
 const STORAGE_KEY = "shiki-site-theme";

--- a/shiki-cli/src/main.rs
+++ b/shiki-cli/src/main.rs
@@ -156,7 +156,7 @@ enum Commands {
     Query {
         /// The query DSL string (quote it). Omit if using `--saved`.
         dsl: Option<String>,
-        /// Runs a query saved under `[queries.<name>]` in config.toml
+        /// Runs a query saved under `[queries]` in config.toml
         /// instead of a literal DSL string.
         #[arg(long, conflicts_with = "dsl")]
         saved: Option<String>,

--- a/shiki-config/src/config.rs
+++ b/shiki-config/src/config.rs
@@ -1602,6 +1602,13 @@ fn section_comment(line: &str) -> Option<&'static str> {
 # divider/date/tags/frontmatter/bullet/numbered/link/image/note/warning/
 # details) replaces it instead of adding a duplicate."
         }
+        "[queries]" => {
+            "\
+# Named, saved `shiki query` DSL strings, keyed by name, e.g.:
+# due-soon = \"where due < today sort due asc\"
+# Run one with `shiki query --saved <name>`; same Dataview-style language
+# as the leader+`q` modal and the literal CLI arg."
+        }
         _ => return None,
     })
 }

--- a/shiki-config/src/config.rs
+++ b/shiki-config/src/config.rs
@@ -310,11 +310,13 @@ pub struct GlobalKeybindings {
     /// `logs`/`toggle_favorite_editor`.
     #[serde(default = "default_undo_delete_key")]
     pub undo_delete: String,
-    /// Opens the Settings screen: a read-only summary of the current
-    /// config (general/theme/git/per-notebook overrides/snippets),
-    /// grouped by section, with `i`/`E` jumping straight to editing
-    /// `config.toml` itself (inline or externally — same convention as
-    /// editing a note) instead of a hand-built form widget per field.
+    /// Opens the Settings screen: every config option editable in place,
+    /// grouped by section and paged by tab (GENERAL/THEME/GIT/EDITOR/
+    /// EXPORT/NOTEBOOKS/SNIPPETS) — true/false fields toggle and save
+    /// immediately, anything else opens a prompt prefilled with its current
+    /// value, and NOTEBOOKS/SNIPPETS drill down a level. `i`/`E` still jump
+    /// straight to editing `config.toml` itself (inline or externally — same
+    /// convention as editing a note) for anything not covered by the tabs.
     /// Field-level default for the same backward-compatibility reason as
     /// `logs`/`toggle_favorite_editor`.
     #[serde(default = "default_settings_key")]
@@ -794,10 +796,10 @@ impl ThemeOverrides {
         }
     }
 
-    /// How many of the 19 slots are actually overridden — used by the
-    /// Settings screen's read-only summary, which shows this count rather
-    /// than dumping all 19 (`shiki theme create`'s job, and already fully
-    /// visible by just opening `config.toml`) so the summary stays short.
+    /// How many of the 19 slots are actually overridden — shown by the
+    /// Settings screen's THEME tab (informational), which displays this count
+    /// rather than dumping all 19 (`shiki theme create`'s job, and already
+    /// fully visible by just opening `config.toml`) so the tab stays short.
     pub fn set_count(&self) -> usize {
         [
             &self.bg,
@@ -998,12 +1000,12 @@ pub struct EditorConfig {
     /// When true, Ctrl+C/X/V inside the editor use the real OS clipboard
     /// (falling back automatically to the existing OSC 52 mechanism when
     /// the OS clipboard can't be reached, e.g. a headless SSH session with
-    /// no `$DISPLAY`/`$WAYLAND_DISPLAY`) instead of tui-textarea's internal
+    /// no `$DISPLAY`/`$WAYLAND_DISPLAY`) instead of ratatui-textarea's internal
     /// yank register. Off by default since it's an environment-dependent
     /// behavior change, not a pure addition.
     #[serde(default)]
     pub os_clipboard: bool,
-    /// When true, Ctrl+A selects the whole buffer instead of tui-textarea's
+    /// When true, Ctrl+A selects the whole buffer instead of ratatui-textarea's
     /// default Emacs-style "move to start of line". Off by default — this
     /// changes existing muscle-memory behavior rather than adding to it.
     #[serde(default)]
@@ -1015,7 +1017,7 @@ pub struct EditorConfig {
     /// Enables Alt+Click (add a cursor) and Ctrl+D (add the next occurrence
     /// of the current word/selection) for multi-cursor editing. Off by
     /// default: it's the most involved of these behaviors, built as a replay
-    /// layer on top of tui-textarea's single-cursor model rather than
+    /// layer on top of ratatui-textarea's single-cursor model rather than
     /// something the library supports natively.
     #[serde(default)]
     pub multi_cursor: bool,

--- a/shiki-tui/src/keybindings.rs
+++ b/shiki-tui/src/keybindings.rs
@@ -18,8 +18,9 @@ pub enum Action {
     /// Restores the most recently deleted note/folder (or batch) from the
     /// trash — a single level of undo.
     UndoDelete,
-    /// Opens the Settings screen — a read-only summary of the current
-    /// config, with a key to jump straight to editing `config.toml` itself.
+    /// Opens the Settings screen — every config option editable in place,
+    /// grouped by section and paged by tab, with a key to jump straight to
+    /// editing `config.toml` itself for anything not covered.
     ToggleSettings,
     Scratchpad,
     /// Opens the global tasks view: every `- [ ]` checkbox across every


### PR DESCRIPTION
Fixes all drift found by a full documentation↔code coherence audit (13 findings + 3 re-audit follow-ups), plus stale claims on surfaces the audit didn't cover (README, index.html, design principles).

## What changed

**IDEA.md / docs/documentation.html**
- CLI: document `shiki query --saved` and `shiki graph --width`
- Keybindings: add `q` (query panel) / `x` (export) to the global tables; add `query_panel`/`publish`/`export`/`zen_mode` to the `[keybindings.global]` sample; add `outline` to `[keybindings.preview]`
- Config schema: document `[export]` `export_dir`/`ask_export_path`, `[queries]` saved DSL strings (flat map, not sub-tables), `[notebooks]` `hidden`
- Prose: EXPORT tab is three fields, not one

**docs/js/main.js / docs/css/styles.css**
- Fix stale screenshot-comment counts (4 themes without a PNG, not 3/7) and script path

**CHANGELOG.md**
- `[Unreleased]` rows for the Dataview query feature and per-notebook encryption (both shipped but never logged)

**CLAUDE.md**
- Replace the stale "almost no tests yet" paragraph with real counts (~220: 118 core / 13 config / 85 tui / 3 cli)

**Code (follow-ups the fixes surfaced)**
- `shiki-cli`: fix `--saved` doc comment (`[queries.<name>]` → `[queries]`)
- `shiki-config`: add a `[queries]` arm to `section_comment` so generated `config.toml` documents the section

**README.md / docs/index.html / IDEA.md (audit follow-up)**
- Theme count is **16**, not 15 (README ×2, index.html meta ×2 + themes heading)
- README CLI list: add `export`/`publish`/`tasks`/`graph`/`query`
- Settings described as editable in place, not a read-only summary
- README ratatui badge 0.29 → 0.30 (actual dep)
- Drop the tokio badge and the tech-stack/design-principles async claims — tokio is an unused workspace dep, everything is sync (`std::thread` + mpsc)

## Also
- Adds `AGENTS.md` and `.opencode/agent/` definitions (workspace invariants + audit agents)

Verified: `cargo check --workspace`, `cargo test -p shiki-config` (13/13), `cargo clippy --all-targets -- -D warnings` all green.