### PR TITLE
docs: showcase shiki's built-in note templates on the homepage

### DIFF
--- a/docs/css/styles.css
+++ b/docs/css/styles.css
@@ -672,6 +672,69 @@ code, .code {
 }
 
 /* ==========================================================================
+   Template picker section — same chip-row-plus-live-preview shape as the
+   theme swatches above (`.swatch`/`.theme-swatches`), just previewing a
+   template's raw markdown instead of a screenshot. `.template-chip` is a
+   distinct class rather than reusing `.swatch` since it has no color dot
+   and its "active" state doesn't repaint the whole page the way a theme
+   pick does — it only swaps the one preview block below it.
+   ========================================================================== */
+
+.template-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  margin: 28px 0 20px;
+}
+
+.template-chip {
+  padding: 8px 16px;
+  border-radius: 999px;
+  border: 1px solid var(--border);
+  background: var(--statusbar);
+  cursor: pointer;
+  font-size: 0.82rem;
+  font-weight: 700;
+  color: var(--muted);
+  font-family: inherit;
+}
+
+.template-chip:hover {
+  border-color: var(--accent);
+  color: var(--fg);
+}
+
+.template-chip.active {
+  border-color: var(--accent);
+  color: var(--bg);
+  background: var(--accent);
+}
+
+/* Lives inside the same `.term-window` chrome the Themes section's
+   screenshot does (3 dots + titlebar) — a realistic rendered note (real
+   YAML frontmatter + body, `{{title}}`/`{{date}}` already substituted),
+   not the raw `.md` template source, so this matches what actually lands
+   on disk (see `Note::to_file_contents`, shiki-core/src/note.rs). */
+.template-preview {
+  margin: 0;
+  padding: 18px 20px;
+  min-height: 220px;
+  background: var(--bg);
+  font-size: 0.85rem;
+  line-height: 1.65;
+  overflow-x: auto;
+  white-space: pre-wrap;
+}
+
+.template-preview .tpl-frontmatter {
+  color: var(--muted);
+}
+
+.template-preview .tpl-body {
+  color: var(--fg);
+}
+
+/* ==========================================================================
    Install
    ========================================================================== */
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -76,6 +76,7 @@
     <button type="button" class="nav-toggle" id="nav-toggle" aria-label="Toggle navigation" aria-expanded="false" aria-controls="site-nav">☰</button>
     <nav id="site-nav">
       <a href="#themes">Themes</a>
+      <a href="#templates">Templates</a>
       <a href="#features">Features</a>
       <a href="#install">Install</a>
       <a href="documentation.html">Docs</a>
@@ -192,6 +193,28 @@
     </div>
   </section>
 
+  <section id="templates">
+    <div class="container">
+      <span class="eyebrow">Start faster</span>
+      <h2>12 built-in templates — pick a starting point, not a blank page.</h2>
+      <p class="muted" style="max-width: 62ch;">
+        Every template is a plain <code>.md</code> file, and every note shiki writes carries
+        real YAML frontmatter — here's exactly what you'd get.
+      </p>
+
+      <div class="template-chips" id="template-chips"></div>
+
+      <div class="term-window" style="margin-top: 8px;">
+        <div class="term-titlebar">
+          <span class="term-dot red"></span>
+          <span class="term-dot yellow"></span>
+          <span class="term-dot green"></span>
+          <span class="term-title" id="template-preview-title">shiki — template: meeting</span>
+        </div>
+        <pre class="template-preview" id="template-preview-content"></pre>
+      </div>
+    </div>
+  </section>
 
   <section id="features">
     <div class="container">

--- a/docs/js/main.js
+++ b/docs/js/main.js
@@ -125,6 +125,182 @@ function initTheme() {
 }
 
 // ---------------------------------------------------------------------------
+// Templates: contents copied verbatim from shiki-core/src/templates.rs's
+// `ensure_defaults()` list (same filename, same literal `{{title}}`/
+// `{{date}}` placeholders, unsubstituted) — same "keep the marketing site's
+// copy in sync with the source of truth" convention the theme palettes and
+// documentation.html's reference tables already follow. If a template is
+// added, removed, or its contents change there, update this array too.
+// ---------------------------------------------------------------------------
+
+const TEMPLATES = [
+  // The picker's actual first entry (`open_template_picker`, shiki-tui/src/
+  // key_handlers.rs) is "(blank, no template)", not the `default.md` file —
+  // an empty body and `frontmatter.template` left `None`/`null`, same as
+  // every other real note. This chip mirrors that, not `default.md`.
+  { id: "blank", label: "Blank", exampleTitle: "Book recommendations", content: "", noTemplate: true },
+  {
+    id: "daily",
+    label: "Daily",
+    // Real daily notes are titled "{date} Daily" (shiki-core/src/daily.rs's
+    // `create_or_open`) — shortened to just "Daily" here since the date
+    // already appears in its own `date:` field right above. The template
+    // body only ever substitutes `{{date}}`, not `{{title}}`, so the H1 and
+    // the frontmatter title genuinely don't match anyway, unlike every
+    // other template here.
+    exampleTitle: "Daily",
+    content: "# {{date}}\n\n## Tasks\n\n- [ ] \n\n## Notes\n\n",
+  },
+  {
+    id: "meeting",
+    label: "Meeting",
+    exampleTitle: "Sprint planning",
+    content:
+      "# {{title}}\n\nDate: {{date}}\n\n## Attendees\n\n## Agenda\n\n## Notes\n\n## Action Items\n\n",
+  },
+  {
+    id: "standup",
+    label: "Standup",
+    exampleTitle: "Daily standup",
+    content: "# {{title}}\n\nDate: {{date}}\n\n## Yesterday\n\n## Today\n\n## Blockers\n\n",
+  },
+  {
+    id: "retro",
+    label: "Retro",
+    exampleTitle: "Sprint 12 retro",
+    content:
+      "# {{title}}\n\nDate: {{date}}\n\n## What Went Well\n\n## What Didn't Go Well\n\n## Action Items\n\n- [ ] \n",
+  },
+  {
+    id: "1on1",
+    label: "1:1",
+    exampleTitle: "1-on-1 with Alex",
+    content:
+      "# {{title}}\n\nDate: {{date}}\n\n## Talking Points\n\n## Notes\n\n## Action Items\n\n- [ ] \n",
+  },
+  {
+    id: "bug",
+    label: "Bug",
+    exampleTitle: "Login button unresponsive on mobile",
+    content:
+      "# {{title}}\n\nDate: {{date}}\nSeverity: \nStatus: Open\n\n## Summary\n\n## Steps to Reproduce\n\n1. \n2. \n3. \n\n## Expected Behavior\n\n## Actual Behavior\n\n## Environment\n\n- \n\n## Fix Notes\n\n",
+  },
+  {
+    id: "spec",
+    label: "Spec",
+    exampleTitle: "Notebook encryption",
+    content:
+      "# {{title}}\n\nDate: {{date}}\nStatus: Draft\n\n## Problem\n\n## Goals\n\n## Non-Goals\n\n## Proposal\n\n## Alternatives Considered\n\n## Open Questions\n\n",
+  },
+  {
+    id: "postmortem",
+    label: "Postmortem",
+    exampleTitle: "API outage, August 3",
+    content:
+      "# {{title}}\n\nDate: {{date}}\nSeverity: \nStatus: Draft\n\n## Summary\n\n## Timeline\n\n## Root Cause\n\n## Impact\n\n## Action Items\n\n- [ ] \n\n## Lessons Learned\n\n",
+  },
+  {
+    id: "review",
+    label: "Review",
+    exampleTitle: "Streaming export pull request",
+    content:
+      "# {{title}}\n\nDate: {{date}}\nPR/MR: \n\n## Summary\n\n## Comments\n\n## Decision\n\n- [ ] Approved\n- [ ] Changes requested\n",
+  },
+  {
+    id: "weekly",
+    label: "Weekly",
+    exampleTitle: "Week 32 update",
+    content:
+      "# {{title}}\n\nWeek of: {{date}}\n\n## Highlights\n\n## Metrics\n\n## Challenges\n\n## Next Week Priorities\n\n- [ ] \n",
+  },
+  {
+    id: "brainstorm",
+    label: "Brainstorm",
+    exampleTitle: "Onboarding flow ideas",
+    content:
+      "# {{title}}\n\nDate: {{date}}\n\n## Problem / Prompt\n\n## Ideas\n\n- \n\n## Next Steps\n\n- [ ] \n",
+  },
+];
+
+const DEFAULT_TEMPLATE_ID = "meeting";
+// Fixed example values a note created "right now" from one of these
+// templates would actually get — matches `Frontmatter::new` (shiki-core/
+// src/note.rs) plus the vars `create_note_with_template` substitutes
+// (shiki-tui/src/key_handlers.rs): `tags`/`links` default to `[]`,
+// `notebook` is whichever notebook is selected, and `template` is set to
+// the template's own filename stem once it's actually applied.
+const TEMPLATE_EXAMPLE_DATE = "2026-08-10";
+const TEMPLATE_EXAMPLE_NOTEBOOK = "personal";
+
+// Same `{{key}}` substitution `Template::render` does (shiki-core/src/
+// templates.rs) — a single left-to-right pass, unknown placeholders left
+// untouched. None of the 12 built-in templates contain a value that itself
+// looks like `{{...}}`, so the simpler non-resubstituting-safe approach
+// there isn't needed here.
+function renderTemplateVars(content, vars) {
+  return content.replace(/\{\{(\w+)\}\}/g, (match, key) =>
+    Object.prototype.hasOwnProperty.call(vars, key) ? vars[key] : match
+  );
+}
+
+// Builds the exact file shiki would write for this template — real YAML
+// frontmatter (field order matches `Frontmatter`'s own declaration order:
+// title, date, tags, notebook, links, template) followed by `---\n\n` and
+// the rendered body, mirroring `Note::to_file_contents` byte-for-byte.
+function renderNoteExample(template) {
+  const vars = {
+    title: template.exampleTitle,
+    date: TEMPLATE_EXAMPLE_DATE,
+    time: "09:30",
+    notebook: TEMPLATE_EXAMPLE_NOTEBOOK,
+  };
+  const body = renderTemplateVars(template.content, vars);
+  const frontmatter = [
+    `title: ${template.exampleTitle}`,
+    `date: ${TEMPLATE_EXAMPLE_DATE}`,
+    `tags: []`,
+    `notebook: ${TEMPLATE_EXAMPLE_NOTEBOOK}`,
+    `links: []`,
+    `template: ${template.noTemplate ? "null" : template.id}`,
+  ].join("\n");
+  return { frontmatter, body };
+}
+
+function applyTemplatePreview(templateId) {
+  const template = TEMPLATES.find((t) => t.id === templateId) || TEMPLATES.find((t) => t.id === DEFAULT_TEMPLATE_ID);
+
+  document.querySelectorAll(".template-chip").forEach((el) => {
+    el.classList.toggle("active", el.dataset.templateId === template.id);
+  });
+
+  const title = document.getElementById("template-preview-title");
+  if (title) title.textContent = `shiki — template: ${template.id}`;
+
+  const pre = document.getElementById("template-preview-content");
+  if (pre) {
+    const { frontmatter, body } = renderNoteExample(template);
+    pre.innerHTML =
+      `<span class="tpl-frontmatter">---\n${escapeHtml(frontmatter)}\n---</span>` +
+      `\n\n<span class="tpl-body">${escapeHtml(body)}</span>`;
+  }
+}
+
+function buildTemplateChips() {
+  const container = document.getElementById("template-chips");
+  if (!container) return; // this script is shared across pages — not every page has the picker
+  TEMPLATES.forEach((template) => {
+    const btn = document.createElement("button");
+    btn.className = "template-chip";
+    btn.type = "button";
+    btn.dataset.templateId = template.id;
+    btn.textContent = template.label;
+    btn.addEventListener("click", () => applyTemplatePreview(template.id));
+    container.appendChild(btn);
+  });
+  applyTemplatePreview(DEFAULT_TEMPLATE_ID);
+}
+
+// ---------------------------------------------------------------------------
 // Changelog: fetched live from CHANGELOG.md on `main` rather than duplicated
 // by hand into this page, so it can never go stale relative to the repo.
 // Only a small hand-rolled subset of Keep a Changelog's actual format is
@@ -771,6 +947,7 @@ function initNavToggle(versionPopover) {
 document.addEventListener("DOMContentLoaded", () => {
   buildSwatches();
   initTheme();
+  buildTemplateChips();
   loadChangelog();
   loadLatestRelease();
   initQuickInstall();


### PR DESCRIPTION
## Summary

Adds a **Templates** section to the marketing homepage (`docs/index.html`), showing off the 12 built-in note templates shiki ships with. It mirrors the existing Themes section's pattern: a row of chips, and picking one shows the exact `.md` file shiki would actually write for that template inside the same terminal-window chrome the theme screenshots use — real YAML frontmatter (`title`/`date`/`tags`/`notebook`/`links`/`template`, in the same field order `Frontmatter` serializes them in) plus the body, with `{{title}}`/`{{date}}` already substituted, not the raw unsubstituted template source.

Docs-only change — no Rust code touched.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Documentation
- [ ] Refactor / internal change (no behavior change)
- [ ] CI / build / packaging

## Checklist

- [ ] `cargo fmt --all` run — N/A, no Rust changed
- [ ] `cargo clippy --workspace --all-targets` clean — N/A, no Rust changed
- [ ] `cargo test --workspace` passing — N/A, no Rust changed
- [ ] `CHANGELOG.md` updated under `## [Unreleased]` — N/A; `CHANGELOG.md` tracksy, and this is a marketing-site-only change with no app version bump (consistentwith how other `docs/**`-only commits in this repo are handled)
- [x] Verified manually (see below)

## How was this tested?

- `node --check docs/js/main.js` — passes.
- Wrote a throwaway script diffing every template's content string in the new `TEMPLATES` array in `main.js` against the actual `pub const *_TEMPLATE` values in `shiki-core/src/templates.rs` —
all 12 matched byte-for-byte.
- Traced `create_note_with_template` (`shiki-tui/src/key_handlers.rs`) and `Frontmatter`/`Note::to_file_contents` (`shiki-core/src/note.rs`) by hand to confirm the generated preview's frontmatter shape (field order, `tags: []`/`links: []` defaults, `template: <name>` vs. `template: null` for the blank option) matches what shiki actually writes to disk.
- Ran the page's `renderNoteExample`/`renderTemplateVars` logic directly under Nomeeting`, `daily`, `bug`, `blank`) and eyeballed the output against the real fileformat.

## Additional context                                                                                                                                                                           
- Chip/preview markup and styling deliberately reuse the Themes section's existing `.term-window`/`.term-titlebar` chrome and CSS custom properties (`--muted`/`--fg`/`--bg`/`--accent`) rather than introducing new visual language, so it re-themes live along with the rest of
- Scope was deliberately kept to the homepage teaser — no changes to `documentation.html`'s existing template reference material.