### PR TITLE
Metadata editor, query suggestions/saved queries, tag rename & autocomplete

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,27 @@ semver yet (pre-1.0), but version bumps are still meaningful and tracked here.
   never stored anywhere — not in `config.toml`, not in the repo. Write paths (`shiki new`/`shiki
   daily`) prompt for it; non-interactive read commands (`list`/`tasks`/`graph`/`show`/`search`)
   fail with a clear error against a locked notebook instead of printing garbage.
+- Metadata editor (notes-scope/preview-scope `M`): view and edit a note's tags and custom
+  frontmatter fields (`status`, `priority`, `due`, or anything else) without leaving the TUI —
+  `a` adds a field, `Enter` edits the selected one, `d` deletes it. PREVIEW also gained a
+  read-only header showing the same tags/fields above the note body, so they're visible without
+  opening the editor. Field-value prompts show a suggestions dropdown: built-in defaults for
+  `status`/`priority`/`due`, plus every value already used for that field anywhere in the vault;
+  the `Tags` prompt suggests every tag already in use — `Tab` accepts one and keeps typing,
+  `Enter` still saves the full comma-separated list as typed.
+- Query mode (leader+`q`, or leader+`g` then `!`) now opens straight into a "here's what you can
+  ask" suggestions list generated from your own notes — every distinct value per field, both sort
+  directions, and relative-date variants (`today`, overdue, upcoming, this week, this month) —
+  instead of a blank box, and narrows live as you type. Queries can now be saved from the TUI
+  itself: `Ctrl+S` on a valid query prompts for a name and writes it to `config.toml`'s
+  `[queries]` table (already supported by `shiki query --saved`, but previously CLI-only to
+  manage); saved queries show up first in the suggestions list with a `★`, and `Ctrl+D` on one
+  deletes it.
+- Tag rename/merge (`r` in the tags modal, leader+`T`, level 1): renames a tag across every note
+  in every notebook, not just the current directory being browsed — typing an existing tag's name
+  merges into it instead of creating a duplicate.
+- `scripts/query-demo.sh`: seeds an isolated "demo" notebook with example notes carrying varied
+  frontmatter, for trying out query mode without touching real data.
 
 ### Fixed
 

--- a/scripts/query-demo.sh
+++ b/scripts/query-demo.sh
@@ -1,0 +1,126 @@
+#!/usr/bin/env bash
+# scripts/query-demo.sh — a disposable "shiki-test" playground for trying
+# query mode without touching any real notebook: leader+`q`'s dedicated
+# modal, and leader+`g`'s global search doubling as query mode when the box
+# starts with `!` (see shiki-tui/src/key_handlers.rs::global_search_is_query).
+#
+# Seeds a "demo" notebook with 8 notes carrying varied custom frontmatter
+# (status/priority/project/due) — plain `shiki new` has no flag for custom
+# frontmatter fields, so each note is created normally and then has its
+# extra fields spliced in right after the always-present `template: null`
+# line (every note's frontmatter ends with that line; see note.rs's
+# Frontmatter field order) — plus a "Query examples" note, inside the demo
+# notebook itself, listing ready-to-try DSL strings so they're readable
+# from PREVIEW too, not just this script's own stdout.
+#
+# Uses the exact XDG-override convention CLAUDE.md documents for exercising
+# the CLI without touching real user config/data. The directories are wiped
+# on every run, so re-running this script always starts from the same known
+# state — nothing here is meant to be kept between runs.
+#
+# Usage:
+#   scripts/query-demo.sh          seeds data, launches the TUI
+#   scripts/query-demo.sh --cli    seeds data, runs one `shiki query` example
+#                                   and prints the rest instead of launching
+#                                   the TUI
+
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+export XDG_CONFIG_HOME=/tmp/shiki-test-config
+export XDG_DATA_HOME=/tmp/shiki-test-data
+rm -rf "$XDG_CONFIG_HOME" "$XDG_DATA_HOME"
+
+echo "==> building shiki-cli (debug)"
+cargo build -p shiki-cli --quiet
+BIN=./target/debug/shiki
+
+echo "==> seeding the 'demo' notebook"
+"$BIN" notebook create demo >/dev/null
+
+# Inserts one "key: value" frontmatter line into an already-created note,
+# right after the `template: null` line every note's frontmatter has.
+add_field() {
+    sed -i "/^template: null\$/a $2" "$1"
+}
+
+# $1 = title, $2 = body, then any number of "key: value" extra-field pairs.
+new_note() {
+    local title="$1" body="$2" path
+    shift 2
+    path=$("$BIN" new "$title" -n demo --body "$body" | sed -n 's/^created: //p')
+    for kv in "$@"; do
+        add_field "$path" "$kv"
+    done
+}
+
+in_days() { date -I -d "+$1 days"; }
+ago_days() { date -I -d "-$1 days"; }
+today=$(date -I)
+
+new_note "Fix login bug" \
+    "Users can't log in with SSO after the last deploy." \
+    "status: pending" "priority: high" "project: alpha" "due: $(ago_days 3)"
+new_note "Write onboarding docs" \
+    "Draft the getting-started guide for new hires." \
+    "status: pending" "priority: medium" "project: alpha" "due: $(in_days 2)"
+new_note "Refactor auth module" \
+    "Split the auth module into smaller services." \
+    "status: in-progress" "priority: high" "project: alpha" "due: $(in_days 7)"
+new_note "Update dependencies" \
+    "Bump every outdated crate/package." \
+    "status: done" "priority: low" "project: beta" "due: $(ago_days 10)"
+new_note "Design new landing page" \
+    "Mockups for the redesigned homepage." \
+    "status: pending" "priority: medium" "project: beta" "due: $today"
+new_note "Research competitor pricing" \
+    "Compare pricing tiers across five competitors." \
+    "status: pending" "priority: low" "project: gamma"
+new_note "Client meeting notes" \
+    "Notes from the kickoff call." \
+    "status: done" "priority: high" "project: gamma" "due: $(ago_days 5)"
+new_note "Plan Q3 roadmap" \
+    "Draft goals and milestones for Q3." \
+    "status: pending" "priority: high" "project: alpha" "due: $(in_days 14)"
+
+examples=$(cat <<'EOF'
+Try these in the query modal (leader+q) or global search's query mode
+(leader+g, then type ! first):
+
+  where status = pending
+  where status = pending and priority = high
+  where project = alpha sort due asc
+  where priority = high or priority = medium
+  where due < today
+  where status != done sort due asc
+  where project ~ "al"
+  where contains "landing"
+
+Or from a shell, with `shiki query` (scriptable, --json/--count):
+
+  shiki query 'where status = pending sort due asc'
+  shiki query 'where priority = high' --json
+  shiki query 'where project = alpha' --count
+EOF
+)
+new_note "Query examples" "$examples"
+
+echo
+echo "==> demo notebook ready at \$XDG_DATA_HOME/shiki/demo (8 notes + this cheat sheet)"
+echo
+echo "Example queries to try (leader+q, or leader+g then '!'):"
+echo "  where status = pending"
+echo "  where status = pending and priority = high"
+echo "  where project = alpha sort due asc"
+echo "  where due < today"
+echo "  where status != done sort due asc"
+echo
+
+if [[ "${1:-}" == "--cli" ]]; then
+    echo "==> shiki query 'where status = pending sort due asc'"
+    "$BIN" query 'where status = pending sort due asc'
+    exit 0
+fi
+
+echo "==> launching the TUI (leader is Space by default) — Esc to close a modal, q to quit"
+exec "$BIN"

--- a/scripts/query-feature-demo.sh
+++ b/scripts/query-feature-demo.sh
@@ -1,0 +1,300 @@
+#!/usr/bin/env bash
+# Generates marketing assets for query mode specifically — the "★ saved
+# queries + generated suggestions" work — not a general app tour like
+# scripts/demo-gif.sh (which is already crowded with 19 other phases and
+# would bury this feature in the middle of it). Produces one GIF plus a
+# handful of PNG stills at the exact frames worth using standalone in an
+# announcement post/README section, all from a single scripted recording
+# (VHS's `Screenshot` command grabs a still mid-tape without stopping the
+# recording), so the GIF and the stills can never show a different-looking
+# feature than each other the way two independently-hand-taken sets could.
+#
+# Seeds a single, deliberately realistic "work" notebook (12 notes across 3
+# projects, real people as assignees, a spread of status/priority/due
+# values) — richer than scripts/query-demo.sh's toy 8-note example
+# notebook (that one exists for a developer to *try* query mode locally;
+# this one exists to make query mode *look* powerful on camera), so the
+# suggestions list actually has dozens of real entries to show off instead
+# of a couple of thin ones.
+#
+# Usage: scripts/query-feature-demo.sh [gif-path] [screenshots-dir]
+#   Defaults to docs/assets/query-feature-demo.gif and
+#   docs/assets/query-feature/.
+#
+# Requires (same as scripts/demo-gif.sh): vhs, ttyd, ffmpeg, a Nerd Font.
+#   Arch/CachyOS:   sudo pacman -S vhs
+#   Debian/Ubuntu:  see https://github.com/charmbracelet/vhs#installation
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+GIF_OUT="${1:-$ROOT/docs/assets/query-feature-demo.gif}"
+SHOTS_DIR="${2:-$ROOT/docs/assets/query-feature}"
+WORK="$(mktemp -d)"
+
+cleanup() { rm -rf "$WORK"; }
+trap cleanup EXIT
+
+for tool in vhs ttyd ffmpeg; do
+  command -v "$tool" >/dev/null || {
+    echo "error: $tool not found on \$PATH — see the header of this script for what's needed." >&2
+    exit 1
+  }
+done
+
+# Same fc-list-into-a-variable-first fix scripts/demo-gif.sh/screenshots.sh
+# both already needed — piping straight into grep can SIGPIPE fc-list on a
+# machine with a large installed Nerd Font family.
+FC_LIST_OUTPUT="$(fc-list)"
+NERD_FONT="$(grep -im1 "nerd font mono" <<< "$FC_LIST_OUTPUT" | cut -d: -f2 | sed 's/^ *//' | cut -d, -f1)"
+NERD_FONT="${NERD_FONT:-monospace}"
+
+BIN="$ROOT/target/release/shiki"
+echo "Building release binary..."
+cargo build --release -p shiki-cli --manifest-path "$ROOT/Cargo.toml"
+
+# Relative to the actual recording date, not hardcoded, so "overdue"/
+# "today"/"this week" always mean what they say regardless of when this
+# script runs.
+rel() { date -d "$1 days" +%F 2>/dev/null || date -v"$1"d +%F; }
+
+DATA="$WORK/data/shiki"
+CFG="$WORK/config/shiki"
+mkdir -p "$DATA/work" "$CFG"
+git -C "$DATA/work" init -q
+git -C "$DATA/work" config user.email "demo@shiki.dev"
+git -C "$DATA/work" config user.name "shiki demo"
+
+write_note() {
+  local relpath="$1" title="$2" date="$3" tags="$4" status="$5" priority="$6"
+  local project="$7" assignee="$8" due="$9" body="${10}"
+  cat >"$DATA/work/$relpath" <<EOF
+---
+title: $title
+date: $date
+tags: $tags
+notebook: work
+links: []
+template: null
+status: $status
+priority: $priority
+project: $project
+assignee: $assignee
+due: $due
+---
+
+$body
+EOF
+}
+
+# Three projects, three people, a real spread of status/priority/due — the
+# whole point is that leader+q's suggestions list ends up with dozens of
+# genuinely distinct entries (every status × every project × every
+# assignee value, both sort directions, several due-date variants) rather
+# than the two or three a minimal example would generate.
+write_note "redesign-checkout-flow.md" "Redesign checkout flow" "2026-07-20" "[frontend]" \
+  "in-progress" "high" "Website-Relaunch" "Maria" "$(rel -3)" \
+  "New checkout is down to two steps instead of four. Still need to wire up
+the saved-address autocomplete before this can ship."
+
+write_note "fix-payment-gateway-bug.md" "Fix payment gateway bug" "2026-07-22" "[backend]" \
+  "todo" "high" "Website-Relaunch" "Diego" "$(rel 0)" \
+  "Intermittent 502 from the payment provider's sandbox under load. Waiting
+on their support ticket before we can reproduce it reliably."
+
+write_note "migrate-database-to-postgres.md" "Migrate database to Postgres" "2026-07-18" "[backend]" \
+  "blocked" "high" "Website-Relaunch" "Diego" "$(rel -6)" \
+  "Blocked on the infra team provisioning the new instance. Migration
+script itself is written and tested against a local copy."
+
+write_note "refactor-auth-module.md" "Refactor auth module" "2026-07-21" "[backend]" \
+  "in-progress" "medium" "Website-Relaunch" "Diego" "$(rel 5)" \
+  "Splitting session handling out of the monolithic auth service into its
+own module ahead of the SSO work next quarter."
+
+write_note "write-api-documentation.md" "Write API documentation" "2026-07-19" "[docs]" \
+  "todo" "medium" "Mobile-App" "Maria" "$(rel 3)" \
+  "Covers the three new endpoints from last sprint. OpenAPI spec is close,
+just needs real example payloads."
+
+write_note "set-up-ci-pipeline.md" "Set up CI pipeline" "2026-07-10" "[infra]" \
+  "done" "medium" "Mobile-App" "Diego" "$(rel -9)" \
+  "Fastlane + GitHub Actions, builds both platforms on every PR. Average
+build time is under six minutes."
+
+write_note "design-onboarding-screens.md" "Design onboarding screens" "2026-07-23" "[design]" \
+  "in-progress" "high" "Mobile-App" "Ana" "$(rel 2)" \
+  "Three-screen flow instead of the original five — cut the permissions
+priming screen after the last round of user testing."
+
+write_note "accessibility-audit.md" "Accessibility audit" "2026-07-15" "[design]" \
+  "todo" "low" "Mobile-App" "Maria" "$(rel 10)" \
+  "VoiceOver pass on the new onboarding flow once it's out of design
+review — screen reader labels are still placeholders in a few spots."
+
+write_note "user-interview-synthesis.md" "User interview synthesis" "2026-07-05" "[research]" \
+  "done" "medium" "Mobile-App" "Maria" "$(rel -14)" \
+  "Eight interviews, clear signal that the search feature is undiscoverable
+— it's the top request across every single session."
+
+write_note "q3-budget-review.md" "Q3 budget review" "2026-07-24" "[planning]" \
+  "todo" "low" "Q3-Planning" "Ana" "$(rel 14)" \
+  "Waiting on actuals from finance before this can really start. Draft
+headcount numbers are in the shared sheet."
+
+write_note "prepare-investor-update.md" "Prepare investor update" "2026-07-24" "[planning]" \
+  "todo" "high" "Q3-Planning" "Ana" "$(rel 4)" \
+  "Needs the real Q2 retention numbers once they're finalized — everything
+else in the deck is ready."
+
+write_note "retro-notes-sprint-14.md" "Retro notes — sprint 14" "2026-07-17" "[planning]" \
+  "done" "low" "Q3-Planning" "Ana" "$(rel -8)" \
+  "Main takeaway: estimates keep slipping on anything touching the payment
+gateway specifically — worth its own retro at some point."
+
+git -C "$DATA/work" add -A
+git -C "$DATA/work" commit -q -m "seed demo data"
+
+cat >"$CFG/config.toml" <<EOF
+[general]
+default_notebook = "work"
+
+[theme]
+name = "gruvbox-dark"
+
+[git]
+auto_commit = false
+auto_push = false
+EOF
+
+mkdir -p "$(dirname "$GIF_OUT")" "$SHOTS_DIR"
+rm -f "$SHOTS_DIR"/*.png
+
+TAPE="$WORK/query-demo.tape"
+cat >"$TAPE" <<TAPEEOF
+Output "$GIF_OUT"
+Set Shell "bash"
+Set FontFamily "$NERD_FONT"
+Set FontSize 16
+Set Width 1200
+Set Height 750
+Set Padding 0
+Set TypingSpeed 30ms
+Set WaitTimeout 5s
+
+Hide
+# \`shiki\` resolves via \$PATH here — this script invokes \`vhs\` itself with
+# XDG_CONFIG_HOME/XDG_DATA_HOME/PATH all pointing at this recording's own
+# throwaway data and release binary (see the \`vhs "\$TAPE"\` invocation
+# below), so every command in this whole tape — this launch and the
+# closing CLI segment alike — shares one consistent environment without
+# repeating it inline each time.
+Type "shiki"
+Enter
+Sleep 1200ms
+Show
+
+# --- Phase 1: land in the notebook (single notebook, so Enter goes
+# straight in), glance at the note list to establish there's a real,
+# varied set of work here before jumping to the feature itself.
+Sleep 400ms
+Enter
+Sleep 500ms
+Down@100ms 4
+Sleep 500ms
+Up@100ms 4
+Sleep 300ms
+
+# --- Phase 2: open query mode with an empty box — every generated
+# suggestion (every status/priority/project/assignee value, both sort
+# directions, relative-date ranges) shows immediately, no typing needed.
+Space
+Type "q"
+Sleep 900ms
+Screenshot "$SHOTS_DIR/1-suggestions.png"
+Down@120ms 6
+Sleep 700ms
+
+# --- Phase 3: typing filters the suggestions live — "priority" narrows
+# straight down to only the priority-related ones.
+Up@120ms 6
+Sleep 300ms
+Type "priority"
+Sleep 900ms
+Screenshot "$SHOTS_DIR/2-filtered-suggestions.png"
+
+# --- Phase 4: Enter fills the box with the highlighted suggestion and
+# runs it immediately — real matching notes, not a mockup table.
+Enter
+Sleep 900ms
+Screenshot "$SHOTS_DIR/3-results.png"
+
+# --- Phase 5: clear the box and hand-write a real, multi-condition query
+# — proves this isn't just clicking through canned suggestions.
+Escape
+Sleep 400ms
+Space
+Type "q"
+Sleep 500ms
+Type "where status != done and priority = high sort due asc"
+Sleep 1100ms
+Screenshot "$SHOTS_DIR/4-custom-query.png"
+
+# --- Phase 6: save it — Ctrl+S prompts for a name, writes straight to
+# config.toml's [queries] table.
+Ctrl+S
+Sleep 600ms
+Type "urgent-open-work"
+Sleep 400ms
+Screenshot "$SHOTS_DIR/5-save-query.png"
+Enter
+Sleep 700ms
+
+# --- Phase 7: clear the box again — the saved query now leads the
+# suggestions list with a star, ahead of every generated example.
+Escape
+Sleep 300ms
+Space
+Type "q"
+Sleep 700ms
+Screenshot "$SHOTS_DIR/6-saved-query-suggestion.png"
+Enter
+Sleep 900ms
+Escape
+Sleep 300ms
+
+# --- Phase 8: the same query DSL, reachable a second way — global search
+# doubling as query mode the instant the box starts with "!". Typing a
+# project name jumps straight into a real matching note.
+Space
+Type "g"
+Sleep 400ms
+Type "!where project = Mobile-App"
+Sleep 1000ms
+Screenshot "$SHOTS_DIR/7-global-search-query-mode.png"
+Enter
+Sleep 900ms
+
+# Quit off-screen, back to a bare shell — the closing beat runs the same
+# saved query from the command line, proving it round-trips: a query
+# saved from inside the TUI a few seconds ago is already usable by
+# \`shiki query --saved\`, no restart or re-save needed.
+Hide
+Type "q"
+Sleep 300ms
+Show
+Sleep 300ms
+Type "shiki query --saved urgent-open-work"
+Sleep 300ms
+Enter
+Sleep 900ms
+Screenshot "$SHOTS_DIR/8-cli-saved-query.png"
+Sleep 500ms
+TAPEEOF
+
+echo "Recording with VHS..."
+XDG_CONFIG_HOME="$WORK/config" XDG_DATA_HOME="$WORK/data" PATH="$(dirname "$BIN"):$PATH" \
+  vhs "$TAPE"
+
+echo "Wrote $GIF_OUT"
+echo "Wrote stills to $SHOTS_DIR:"
+ls -1 "$SHOTS_DIR"

--- a/shiki-cli/src/commands/doctor.rs
+++ b/shiki-cli/src/commands/doctor.rs
@@ -361,6 +361,7 @@ fn check_keybinding_health(config: &Config, r: &mut Report) {
                 ("new_folder", kb.notes.new_folder.as_str()),
                 ("visual", kb.notes.visual.as_str()),
                 ("copy_entries", kb.notes.copy_entries.as_str()),
+                ("metadata", kb.notes.metadata.as_str()),
             ],
         ),
         (
@@ -371,6 +372,7 @@ fn check_keybinding_health(config: &Config, r: &mut Report) {
                 ("history", kb.preview.history.as_str()),
                 ("links", kb.preview.links.as_str()),
                 ("outline", kb.preview.outline.as_str()),
+                ("metadata", kb.preview.metadata.as_str()),
             ],
         ),
     ];

--- a/shiki-cli/src/commands/query.rs
+++ b/shiki-cli/src/commands/query.rs
@@ -18,8 +18,20 @@ pub fn run(
     count: bool,
 ) -> Result<()> {
     let today = chrono::Local::now().date_naive();
-    let query = shiki_core::query::parse(dsl).map_err(|e| anyhow::anyhow!("query error: {e}"))?;
     let pool = store.all_notes()?;
+    let query = shiki_core::query::parse(dsl).map_err(|e| {
+        let known = shiki_core::query::known_fields(&pool);
+        let seen = if known.is_empty() {
+            String::new()
+        } else {
+            format!("\n  seen in your notes: {}", known.join(", "))
+        };
+        anyhow::anyhow!(
+            "query error: {e}\n  built-in fields: {}{seen}\n  example: {}",
+            shiki_core::query::BUILTIN_FIELDS,
+            shiki_core::query::EXAMPLE_QUERY,
+        )
+    })?;
     let rows = shiki_core::query::run_query(&pool, &query, notebook, today);
 
     if count {

--- a/shiki-config/src/config.rs
+++ b/shiki-config/src/config.rs
@@ -577,6 +577,12 @@ pub struct NoteKeybindings {
     /// target instead of moving them. Same field-level-default reasoning.
     #[serde(default = "default_copy_entries_key")]
     pub copy_entries: String,
+    /// Opens the metadata modal — tags plus every custom frontmatter field
+    /// (`status`, `priority`, ...), add/edit/delete in place. Same
+    /// field-level-default backward-compatibility reasoning as `tree_view`/
+    /// `toggle_dates`/`new_folder`/`visual`/`copy_entries`.
+    #[serde(default = "default_metadata_key")]
+    pub metadata: String,
 }
 
 impl Default for NoteKeybindings {
@@ -596,8 +602,13 @@ impl Default for NoteKeybindings {
             new_folder: default_new_folder_key(),
             visual: default_visual_key(),
             copy_entries: default_copy_entries_key(),
+            metadata: default_metadata_key(),
         }
     }
+}
+
+fn default_metadata_key() -> String {
+    "M".into()
 }
 
 fn default_visual_key() -> String {
@@ -681,6 +692,10 @@ pub struct PreviewKeybindings {
     /// as `history`.
     #[serde(default = "default_outline_key")]
     pub outline: String,
+    /// Opens the metadata modal — same action as `NoteKeybindings::metadata`,
+    /// bound here too so it also works with PREVIEW focused, not only NOTES.
+    #[serde(default = "default_metadata_key")]
+    pub metadata: String,
 }
 
 impl Default for PreviewKeybindings {
@@ -691,6 +706,7 @@ impl Default for PreviewKeybindings {
             history: default_history_key(),
             links: default_links_key(),
             outline: default_outline_key(),
+            metadata: default_metadata_key(),
         }
     }
 }
@@ -1269,7 +1285,11 @@ pub struct Config {
     /// same reason: an empty `Vec<_>` would serialize as a bare `queries =
     /// []` line that a later hand-added `[queries.foo]`-style table would
     /// conflict with. Ad-hoc (unsaved) queries typed directly into the CLI
-    /// arg or the TUI modal don't touch this map at all.
+    /// arg don't touch this map — the TUI's query modal does, though:
+    /// `Ctrl+S` on a valid query prompts for a name and writes it here
+    /// (`App::confirm_save_query`), and `Ctrl+D` on a highlighted saved
+    /// suggestion removes it, so this file is genuinely round-trippable
+    /// from either the TUI or by hand.
     #[serde(default)]
     pub queries: std::collections::HashMap<String, String>,
 }

--- a/shiki-core/src/lib.rs
+++ b/shiki-core/src/lib.rs
@@ -66,6 +66,11 @@ pub enum Error {
     /// encrypted notebook, or an `age` error setting up encryption.
     #[error("{0}")]
     Encryption(String),
+    /// `tags::rename_tag`'s new name, empty — a bare rename-to-nothing
+    /// would silently become a delete, which isn't what "rename" means;
+    /// removing a tag entirely isn't exposed as a distinct operation yet.
+    #[error("new tag name can't be empty")]
+    EmptyTagName,
 }
 
 pub type Result<T> = std::result::Result<T, Error>;

--- a/shiki-core/src/query.rs
+++ b/shiki-core/src/query.rs
@@ -63,21 +63,23 @@ pub struct Query {
 
 #[derive(Debug, Clone, PartialEq, thiserror::Error)]
 pub enum QueryError {
-    #[error("unterminated string")]
+    #[error("unterminated string — missing a closing '\"'")]
     UnterminatedString,
-    #[error("unexpected character '{0}'")]
+    #[error("unexpected character '{0}' — supported operators are = != > < >= <= ~")]
     UnexpectedChar(char),
-    #[error("expected a field name")]
+    #[error("expected a field name (e.g. title, date, notebook, tag, template, or any custom frontmatter field)")]
     ExpectedField,
-    #[error("expected a comparison operator (=, !=, >, <, >=, <=, ~)")]
+    #[error("expected a comparison operator (=, !=, >, <, >=, <=, ~) after the field name")]
     ExpectedOperator,
-    #[error("expected a value")]
+    #[error(
+        "expected a value after the operator — a word, \"quoted string\", a number, or `today`"
+    )]
     ExpectedValue,
     #[error("expected a closing ')'")]
     ExpectedCloseParen,
-    #[error("unexpected trailing input")]
+    #[error("unexpected trailing input — did you forget `and`/`or` between conditions?")]
     TrailingTokens,
-    #[error("empty query")]
+    #[error("empty query — try something like: where status = pending sort due asc")]
     Empty,
 }
 
@@ -505,6 +507,163 @@ pub fn run_query(
         .collect()
 }
 
+/// Every custom frontmatter field name actually present across `pool`'s
+/// notes (their `extra` maps) — deduped, sorted. Used to build a "here's
+/// what you can actually query on" hint next to a parse error, in both the
+/// CLI (`shiki query`) and the TUI query modals — pool-driven rather than a
+/// fixed list, since custom fields are whatever a user happened to write.
+pub fn known_fields(pool: &[(Notebook, Note)]) -> Vec<String> {
+    let mut fields: Vec<String> = pool
+        .iter()
+        .flat_map(|(_, note)| note.frontmatter.extra.keys())
+        .filter_map(|k| k.as_str().map(str::to_string))
+        .collect();
+    fields.sort();
+    fields.dedup();
+    fields
+}
+
+/// The always-available fields (not stored per-note) plus the DSL's basic
+/// shape — shown alongside `known_fields` so the hint is useful even for a
+/// notebook with no custom frontmatter fields at all yet.
+pub const BUILTIN_FIELDS: &str = "title, date, notebook, tag, template";
+pub const EXAMPLE_QUERY: &str = "where status = pending sort due asc";
+
+/// Every distinct value actually seen for exactly `field` across `pool`'s
+/// notes (their `extra` maps) — deduped, sorted. Unlike `known_fields`
+/// (field *names*, across every field) or `suggest_queries` (whole example
+/// DSL strings), this answers "what have I already put in this one field
+/// before" — used by the TUI's metadata editor to suggest previously-used
+/// values (e.g. every `project` name used anywhere) when editing a field.
+pub fn field_values(pool: &[(Notebook, Note)], field: &str) -> Vec<String> {
+    let mut values: Vec<String> = pool
+        .iter()
+        .filter_map(|(_, note)| note.frontmatter.extra.get(field))
+        .map(yaml_value_to_string)
+        .filter(|v| !v.is_empty())
+        .collect();
+    values.sort();
+    values.dedup();
+    values
+}
+
+fn quote_if_needed(v: &str) -> String {
+    if !v.is_empty()
+        && v.chars()
+            .all(|c| c.is_alphanumeric() || c == '-' || c == '_')
+    {
+        v.to_string()
+    } else {
+        format!("{v:?}")
+    }
+}
+
+/// A big, varied set of ready-to-run example queries generated from the
+/// fields and values actually present in `pool` — shown the moment query
+/// mode opens (before anything's typed), and used as a live "did you mean"
+/// list while an in-progress query doesn't parse yet (see the TUI's
+/// `refresh_query`/`refresh_global_search`). Genuinely reads what's in the
+/// notes rather than being a fixed hardcoded example, so it stays useful
+/// for a notebook with a completely different set of custom fields —
+/// deliberately generous rather than a curated top few: `App::
+/// matching_suggestions` already narrows this live as the user types, so a
+/// long list here costs nothing once someone's typing "proj" and only the
+/// project-related ones remain, but *not* generating a value (e.g. every
+/// distinct `project` name, not just the two most common) would make that
+/// filtering come up empty for exactly the thing being typed.
+pub fn suggest_queries(pool: &[(Notebook, Note)]) -> Vec<String> {
+    let mut values: std::collections::BTreeMap<String, Vec<String>> =
+        std::collections::BTreeMap::new();
+    for (_, note) in pool {
+        for (k, v) in note.frontmatter.extra.iter() {
+            let Some(key) = k.as_str() else { continue };
+            let val = yaml_value_to_string(v);
+            if val.is_empty() {
+                continue;
+            }
+            let entry = values.entry(key.to_string()).or_default();
+            if !entry.contains(&val) {
+                entry.push(val);
+            }
+        }
+    }
+
+    // Fields with more distinct values sort first — a field with only one
+    // value everywhere still gets its `where`/`sort` examples, just later
+    // in the list, since a single-value field is still meaningful to sort
+    // or combine with `and`/`or`, just not as interesting to filter alone.
+    let mut fields: Vec<(&String, &Vec<String>)> = values.iter().collect();
+    fields.sort_by(|a, b| b.1.len().cmp(&a.1.len()).then(a.0.cmp(b.0)));
+
+    let today = chrono::Local::now().date_naive();
+    let mut examples = Vec::new();
+
+    for (field, vals) in &fields {
+        // Every distinct value gets its own example — "por todos los
+        // projects", not just the top couple — so typing any real value
+        // this notebook actually uses finds a matching suggestion.
+        for val in vals.iter() {
+            examples.push(format!("where {field} = {}", quote_if_needed(val)));
+        }
+        // Sorting is meaningful for any field, not just dates — both
+        // directions, since "asc"/"desc" are themselves things a user
+        // might type looking for a sort example.
+        examples.push(format!("sort {field} asc"));
+        examples.push(format!("sort {field} desc"));
+
+        if vals.iter().any(|v| is_iso_date(v)) {
+            let in_a_week = (today + chrono::Duration::days(7)).format("%Y-%m-%d");
+            let in_a_month = (today + chrono::Duration::days(30)).format("%Y-%m-%d");
+            examples.push(format!("where {field} = today"));
+            examples.push(format!("where {field} < today"));
+            examples.push(format!("where {field} > today"));
+            examples.push(format!("where {field} >= today and {field} <= {in_a_week}"));
+            examples.push(format!(
+                "where {field} >= today and {field} <= {in_a_month}"
+            ));
+        }
+    }
+
+    // Combine the two most-varied fields, and offer an `or` between the
+    // top field's own two most common values.
+    if let [(f1, v1), (f2, v2), ..] = fields.as_slice() {
+        if let (Some(a), Some(b)) = (v1.first(), v2.first()) {
+            examples.push(format!(
+                "where {f1} = {} and {f2} = {}",
+                quote_if_needed(a),
+                quote_if_needed(b)
+            ));
+        }
+    }
+    if let Some((field, vals)) = fields.first() {
+        if let [a, b, ..] = vals.as_slice() {
+            examples.push(format!(
+                "where {field} = {} or {field} = {}",
+                quote_if_needed(a),
+                quote_if_needed(b)
+            ));
+        }
+    }
+
+    for word in pool
+        .iter()
+        .flat_map(|(_, n)| n.frontmatter.title.split_whitespace())
+        .filter(|w| w.len() > 3 && w.chars().all(|c| c.is_alphanumeric()))
+        .take(3)
+    {
+        examples.push(format!("where contains \"{}\"", word.to_lowercase()));
+    }
+
+    let mut seen = std::collections::HashSet::new();
+    examples.retain(|e| seen.insert(e.clone()));
+    examples.truncate(60);
+    examples
+}
+
+fn is_iso_date(s: &str) -> bool {
+    NaiveDate::parse_from_str(s, "%Y-%m-%d").is_ok()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -705,5 +864,136 @@ mod tests {
         let rows = run_query(&pool, &q, Some("nb"), today());
         assert_eq!(rows.len(), 1);
         assert_eq!(rows[0].notebook, "nb");
+    }
+
+    #[test]
+    fn suggested_queries_use_real_fields_and_values_from_the_pool() {
+        let pool = pool_with(vec![
+            note_with(
+                "Fix login bug",
+                &[
+                    ("status", "pending".into()),
+                    ("priority", "high".into()),
+                    ("due", "2026-08-07".into()),
+                ],
+                &[],
+            ),
+            note_with(
+                "Update dependencies",
+                &[
+                    ("status", "done".into()),
+                    ("priority", "low".into()),
+                    ("due", "2026-07-30".into()),
+                ],
+                &[],
+            ),
+        ]);
+        let suggestions = suggest_queries(&pool);
+        assert!(!suggestions.is_empty());
+        // Every generated example must itself be a valid, parseable query —
+        // a suggestion that doesn't parse would be worse than none at all.
+        for s in &suggestions {
+            assert!(parse(s).is_ok(), "suggestion {s:?} failed to parse");
+        }
+        assert!(suggestions.iter().any(|s| s.contains("status")));
+        assert!(suggestions.iter().any(|s| s.starts_with("sort due")));
+    }
+
+    #[test]
+    fn suggested_queries_cover_every_distinct_value_and_sort_both_directions() {
+        let pool = pool_with(vec![
+            note_with(
+                "A",
+                &[
+                    ("status", "pending".into()),
+                    ("project", "alpha".into()),
+                    ("due", "2026-08-07".into()),
+                ],
+                &[],
+            ),
+            note_with(
+                "B",
+                &[
+                    ("status", "in-progress".into()),
+                    ("project", "beta".into()),
+                    ("due", "2026-07-30".into()),
+                ],
+                &[],
+            ),
+            note_with(
+                "C",
+                &[
+                    ("status", "done".into()),
+                    ("project", "gamma".into()),
+                    ("due", "2026-06-01".into()),
+                ],
+                &[],
+            ),
+        ]);
+        let suggestions = suggest_queries(&pool);
+        for s in &suggestions {
+            assert!(parse(s).is_ok(), "suggestion {s:?} failed to parse");
+        }
+        // Every distinct status/project value gets its own example, not
+        // just the top couple — this is the whole point of the richer
+        // generation ("por todos los projects").
+        for status in ["pending", "in-progress", "done"] {
+            assert!(
+                suggestions.contains(&format!("where status = {status}")),
+                "missing suggestion for status = {status}"
+            );
+        }
+        for project in ["alpha", "beta", "gamma"] {
+            assert!(
+                suggestions.contains(&format!("where project = {project}")),
+                "missing suggestion for project = {project}"
+            );
+        }
+        // Both sort directions, for a plain (non-date) field.
+        assert!(suggestions.contains(&"sort status asc".to_string()));
+        assert!(suggestions.contains(&"sort status desc".to_string()));
+        // Relative-date variety: today, overdue, upcoming, week, month.
+        assert!(suggestions.contains(&"where due = today".to_string()));
+        assert!(suggestions.contains(&"where due < today".to_string()));
+        assert!(suggestions.contains(&"where due > today".to_string()));
+        assert!(suggestions
+            .iter()
+            .any(|s| s.starts_with("where due >= today and due <=")));
+        // No duplicates.
+        let mut sorted = suggestions.clone();
+        sorted.sort();
+        sorted.dedup();
+        assert_eq!(sorted.len(), suggestions.len());
+    }
+
+    #[test]
+    fn suggested_queries_is_empty_for_a_pool_with_no_custom_fields() {
+        let pool = pool_with(vec![note_with("Plain note", &[], &[])]);
+        // No `extra` fields anywhere to build a `where`/`sort` example from
+        // — still shouldn't panic, just yields nothing (or a `contains`
+        // example only, if the title has a word long enough).
+        let suggestions = suggest_queries(&pool);
+        for s in &suggestions {
+            assert!(parse(s).is_ok(), "suggestion {s:?} failed to parse");
+        }
+    }
+
+    #[test]
+    fn field_values_deduped_and_sorted_scoped_to_one_field() {
+        let pool = pool_with(vec![
+            note_with(
+                "A",
+                &[("project", "alpha".into()), ("priority", "high".into())],
+                &[],
+            ),
+            note_with("B", &[("project", "beta".into())], &[]),
+            note_with("C", &[("project", "alpha".into())], &[]),
+        ]);
+        assert_eq!(
+            field_values(&pool, "project"),
+            vec!["alpha".to_string(), "beta".to_string()]
+        );
+        assert_eq!(field_values(&pool, "priority"), vec!["high".to_string()]);
+        assert!(field_values(&pool, "nonexistent").is_empty());
     }
 }

--- a/shiki-core/src/tags.rs
+++ b/shiki-core/src/tags.rs
@@ -2,6 +2,7 @@ use std::collections::BTreeMap;
 use std::path::PathBuf;
 
 use crate::note::Note;
+use crate::notebook::Notebook;
 
 /// Index of tags -> notes containing them, for the tag-filtering panel.
 #[derive(Debug, Default, Clone)]
@@ -38,6 +39,71 @@ impl TagIndex {
     pub fn is_empty(&self) -> bool {
         self.index.is_empty()
     }
+}
+
+/// Every distinct tag used anywhere across `pool` — deduped, sorted. Used
+/// by the TUI's metadata editor to suggest existing tags while typing new
+/// ones (so "cliente" and "clientes" don't quietly become two different
+/// tags by accident), and as the candidate list `rename_tag`'s target
+/// could plausibly be one of.
+pub fn all_tags(pool: &[(Notebook, Note)]) -> Vec<String> {
+    let mut tags: Vec<String> = pool
+        .iter()
+        .flat_map(|(_, note)| note.frontmatter.tags.iter().cloned())
+        .collect();
+    tags.sort();
+    tags.dedup();
+    tags
+}
+
+/// Renames (or merges, if `new` already exists on some of the same notes)
+/// tag `old` to `new` across every note in `pool` that carries it — writes
+/// each affected note back to disk immediately, using its own notebook's
+/// crypto if that notebook is encrypted. A note that already has `new` as
+/// well as `old` just drops `old` rather than ending up with a duplicate.
+/// Walks the whole pool (typically `NotebookStore::all_notes()`, every
+/// notebook) rather than being scoped to one notebook or folder — a typo'd
+/// tag is just as likely to have spread across the whole vault as to be
+/// contained to wherever it was first typed, and there is no cheaper
+/// "rename it here for now" version of fixing that. Returns the number of
+/// notes actually rewritten and the distinct notebook names touched (for
+/// the caller to feed into whatever per-notebook change-tracking it does —
+/// see the TUI's `App::note_changed`) — a no-op (`old` not used anywhere)
+/// returns `Ok((0, vec![]))`, not an error.
+pub fn rename_tag(
+    pool: &[(Notebook, Note)],
+    old: &str,
+    new: &str,
+) -> crate::Result<(usize, Vec<String>)> {
+    let new = new.trim();
+    if new.is_empty() {
+        return Err(crate::Error::EmptyTagName);
+    }
+    let mut notes_updated = 0;
+    let mut notebooks_touched = Vec::new();
+    for (nb, note) in pool {
+        if !note.frontmatter.tags.iter().any(|t| t == old) {
+            continue;
+        }
+        let mut updated = note.clone();
+        let mut tags: Vec<String> = updated
+            .frontmatter
+            .tags
+            .iter()
+            .filter(|t| t.as_str() != old)
+            .cloned()
+            .collect();
+        if !tags.iter().any(|t| t == new) {
+            tags.push(new.to_string());
+        }
+        updated.frontmatter.tags = tags;
+        updated.save_with_crypto(nb.crypto.as_ref())?;
+        notes_updated += 1;
+        if !notebooks_touched.contains(&nb.name) {
+            notebooks_touched.push(nb.name.clone());
+        }
+    }
+    Ok((notes_updated, notebooks_touched))
 }
 
 #[cfg(test)]
@@ -90,5 +156,102 @@ mod tests {
         let index = TagIndex::build(&notes);
         let tags: Vec<&String> = index.tags().collect();
         assert_eq!(tags, vec!["alpha", "mid", "zeta"]);
+    }
+
+    fn test_notebook(root: &std::path::Path, name: &str) -> Notebook {
+        let path = root.join(name);
+        std::fs::create_dir_all(&path).unwrap();
+        Notebook::new(name, path)
+    }
+
+    #[test]
+    fn all_tags_deduped_and_sorted_across_notes() {
+        let nb = Notebook::new("nb", PathBuf::from("/tmp/nb"));
+        let notes = vec![
+            note_with_tags("a.md", &["zeta", "work"]),
+            note_with_tags("b.md", &["work", "alpha"]),
+        ];
+        let pool: Vec<(Notebook, Note)> = notes.into_iter().map(|n| (nb.clone(), n)).collect();
+        assert_eq!(
+            all_tags(&pool),
+            vec!["alpha".to_string(), "work".to_string(), "zeta".to_string()]
+        );
+    }
+
+    #[test]
+    fn rename_tag_rewrites_every_note_that_carries_it_across_notebooks() {
+        let tmp = tempfile::tempdir().unwrap();
+        let a = test_notebook(tmp.path(), "a");
+        let b = test_notebook(tmp.path(), "b");
+
+        let mut n1 = a.create_note("One", "body").unwrap();
+        n1.frontmatter.tags = vec!["proyecto".to_string()];
+        n1.save().unwrap();
+
+        let mut n2 = b.create_note("Two", "body").unwrap();
+        n2.frontmatter.tags = vec!["proyecto".to_string(), "urgent".to_string()];
+        n2.save().unwrap();
+
+        let mut n3 = a.create_note("Three", "body").unwrap();
+        n3.frontmatter.tags = vec!["other".to_string()];
+        n3.save().unwrap();
+
+        let pool = vec![
+            (a.clone(), Note::from_file(&n1.path).unwrap()),
+            (b.clone(), Note::from_file(&n2.path).unwrap()),
+            (a.clone(), Note::from_file(&n3.path).unwrap()),
+        ];
+
+        let (count, mut notebooks) = rename_tag(&pool, "proyecto", "proyectos").unwrap();
+        assert_eq!(count, 2);
+        notebooks.sort();
+        assert_eq!(notebooks, vec!["a".to_string(), "b".to_string()]);
+
+        assert_eq!(
+            Note::from_file(&n1.path).unwrap().frontmatter.tags,
+            vec!["proyectos".to_string()]
+        );
+        assert_eq!(
+            Note::from_file(&n2.path).unwrap().frontmatter.tags,
+            vec!["urgent".to_string(), "proyectos".to_string()]
+        );
+        // Untouched — never had the old tag.
+        assert_eq!(
+            Note::from_file(&n3.path).unwrap().frontmatter.tags,
+            vec!["other".to_string()]
+        );
+    }
+
+    #[test]
+    fn rename_tag_merges_into_an_existing_tag_without_duplicating() {
+        let tmp = tempfile::tempdir().unwrap();
+        let a = test_notebook(tmp.path(), "a");
+        let mut n = a.create_note("One", "body").unwrap();
+        n.frontmatter.tags = vec!["proyecto".to_string(), "proyectos".to_string()];
+        n.save().unwrap();
+
+        let pool = vec![(a.clone(), Note::from_file(&n.path).unwrap())];
+        let (count, _) = rename_tag(&pool, "proyecto", "proyectos").unwrap();
+        assert_eq!(count, 1);
+        assert_eq!(
+            Note::from_file(&n.path).unwrap().frontmatter.tags,
+            vec!["proyectos".to_string()]
+        );
+    }
+
+    #[test]
+    fn rename_tag_rejects_empty_new_name() {
+        let nb = Notebook::new("nb", PathBuf::from("/tmp/nb"));
+        let pool = vec![(nb, note_with_tags("a.md", &["proyecto"]))];
+        assert!(rename_tag(&pool, "proyecto", "   ").is_err());
+    }
+
+    #[test]
+    fn rename_tag_is_a_no_op_when_the_old_tag_is_unused() {
+        let nb = Notebook::new("nb", PathBuf::from("/tmp/nb"));
+        let pool = vec![(nb, note_with_tags("a.md", &["other"]))];
+        let (count, notebooks) = rename_tag(&pool, "proyecto", "proyectos").unwrap();
+        assert_eq!(count, 0);
+        assert!(notebooks.is_empty());
     }
 }

--- a/shiki-tui/src/app.rs
+++ b/shiki-tui/src/app.rs
@@ -131,6 +131,20 @@ pub(crate) enum PendingInput {
     NewFolder,
     RenameNote,
     RenameNotebook,
+    /// Renames (or merges into an existing tag) whichever tag is selected
+    /// in the tags modal's level 1 — the old name lives in
+    /// `App.pending_rename_tag`, same "one variant, the real state lives
+    /// alongside it" shape as `NotebookPassphrase`/`PassphrasePurpose`.
+    /// Operates across every notebook (`shiki_core::tags::rename_tag`),
+    /// not just the current directory the tags modal itself browses —
+    /// see that function's own doc comment for why.
+    RenameTag,
+    /// A name to save the query modal's current (already-valid) DSL text
+    /// under (`Ctrl+S`, `App.pending_save_query_dsl` carries the DSL
+    /// itself). Typing an existing saved query's name overwrites it,
+    /// same "typing an existing tag's name merges" precedent `RenameTag`
+    /// already set for "this name already means something, reuse it."
+    SaveQuery,
     Search,
     SetRemote,
     /// Editing a notebook's remote from inside the Settings modal's
@@ -192,6 +206,67 @@ pub(crate) enum PendingInput {
     /// same "tracked separately, this stays a plain unit variant" reasoning
     /// as `SettingsNotebookRemote`.
     NotebookPassphrase,
+    /// Any step of the metadata modal's prompts (tags, a new field's key,
+    /// a new or existing field's value) — which step is `App.metadata_prompt`,
+    /// same "one variant, the real state lives alongside it" shape as
+    /// `NotebookPassphrase`/`PassphrasePurpose` above, since the metadata
+    /// modal's own multi-step "key, then value" flow for a brand-new field
+    /// needs exactly the same kind of chaining that one already does.
+    Metadata,
+}
+
+/// Which step of the metadata modal's editing flow a `PendingInput::Metadata`
+/// prompt answers — see `App::start_metadata_prompt`/`App::confirm_input`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum MetadataPrompt {
+    /// Comma-separated tags, prefilled with the note's current ones.
+    Tags,
+    /// A brand-new field's key — chains straight into `NewFieldValue` once
+    /// confirmed, the same way `PassphrasePurpose::Enable` chains into
+    /// `EnableConfirm`.
+    NewFieldKey,
+    /// The new field's value, once its key (carried here) is known.
+    NewFieldValue(String),
+    /// An existing field's value, prefilled with its current one — the
+    /// field's key never changes, only editing what it's set to.
+    FieldValue(String),
+}
+
+/// One entry in the query modal's suggestions dropdown — `display` is what
+/// the list shows (a saved query's `★ name`, or, for a generated example,
+/// just the DSL itself, same string as `dsl`), `dsl` is what actually gets
+/// filled into the input box and run. Kept as two separate strings rather
+/// than one, unlike the plain generated examples this replaced, specifically
+/// so a saved query's *name* can be searched/displayed without that name
+/// ever being mistaken for part of the query text that gets executed.
+#[derive(Debug, Clone)]
+pub(crate) struct QuerySuggestion {
+    pub display: String,
+    pub dsl: String,
+    /// `Some(name)` for a saved query (its key in `Config.queries`) —
+    /// `None` for a generated example, which can't be deleted from here
+    /// since there's nothing saved to delete. `App::handle_query_key`'s
+    /// `Ctrl+D` uses this to know whether the highlighted suggestion is
+    /// even a valid delete target.
+    pub saved_name: Option<String>,
+}
+
+impl QuerySuggestion {
+    pub(crate) fn generated(dsl: String) -> Self {
+        Self {
+            display: dsl.clone(),
+            dsl,
+            saved_name: None,
+        }
+    }
+
+    pub(crate) fn saved(name: &str, dsl: String) -> Self {
+        Self {
+            display: format!("{} {name}", crate::icons::STAR),
+            dsl,
+            saved_name: Some(name.to_string()),
+        }
+    }
 }
 
 /// What a `PendingInput::NotebookPassphrase` prompt's answer will be used
@@ -227,6 +302,8 @@ impl PendingInput {
             PendingInput::NewNotebook => " New notebook ",
             PendingInput::NewFolder => " New folder ",
             PendingInput::RenameNote | PendingInput::RenameNotebook => " Rename ",
+            PendingInput::RenameTag => " Rename/merge tag ",
+            PendingInput::SaveQuery => " Save query as ",
             PendingInput::Search => " Jump to note ",
             PendingInput::SetRemote => " Git remote (URL or local path) ",
             PendingInput::SettingsNotebookRemote => " Git remote (URL or local path) ",
@@ -240,6 +317,7 @@ impl PendingInput {
             PendingInput::ExportNotebook => " Export path (.html or .md) ",
             PendingInput::PublishPath => " Save PDF as ",
             PendingInput::NotebookPassphrase => " Passphrase ",
+            PendingInput::Metadata => " Metadata ",
         }
     }
 
@@ -258,6 +336,14 @@ impl PendingInput {
             PendingInput::ExportNotebook => {
                 Some("Format is inferred from the extension — .md/.markdown for Markdown, anything else for HTML.")
             }
+            PendingInput::RenameTag => Some(
+                "Applies to every note in every notebook that has this tag, not just here. \
+                 Typing an existing tag's name merges into it instead of creating a duplicate.",
+            ),
+            PendingInput::SaveQuery => Some(
+                "Saves to config.toml under [queries] — shows up as a ★ suggestion (in either \
+                 query surface) from now on. An existing name overwrites that saved query.",
+            ),
             _ => None,
         }
     }
@@ -371,20 +457,24 @@ pub(crate) enum DeleteTarget {
     Notebook,
 }
 
-/// `(note path, [fg, accent, muted, link, bg], content width, formatted
+/// `(note path, [fg, accent, muted, link, bg, tag], content width, formatted
 /// lines, source-line-per-row)` — see `App::note_preview_cache`'s own doc
-/// comment for what each element means. `bg` rides along in the same array
-/// purely so it participates in the cache-key equality check (it drives
-/// `render::is_dark_color`, which picks the syntect syntax-highlighting
-/// theme for code fences) without a whole extra tuple field. Named only to
-/// keep clippy's `type_complexity` lint quiet; still just a plain tuple
-/// everywhere it's used.
+/// comment for what each element means. `bg`/`tag` ride along in the same
+/// array purely so they participate in the cache-key equality check (`bg`
+/// drives `render::is_dark_color`, which picks the syntect syntax-
+/// highlighting theme for code fences; `tag` colors the metadata header's
+/// `#tag` spans — see `panel_preview::metadata_lines`) without two more
+/// tuple fields. Named only to keep clippy's `type_complexity` lint quiet;
+/// still just a plain tuple everywhere it's used. Source-line-per-row is
+/// `None` for the metadata header's own rows (there's no corresponding
+/// `note.body` line to jump to on click) and `Some(line)` for every real
+/// body row, same as before.
 type NotePreviewCache = (
     std::path::PathBuf,
-    [Color; 5],
+    [Color; 6],
     u16,
     Vec<Line<'static>>,
-    Vec<usize>,
+    Vec<Option<usize>>,
 );
 
 /// Which of the find/replace bar's two fields is currently typed into —
@@ -460,6 +550,11 @@ pub struct App {
     /// Index into the *filtered* notes list, only meaningful while
     /// `tags_viewing.is_some()`.
     pub tags_notes_selected: usize,
+    /// The tag being renamed/merged — captured up front when the
+    /// `PendingInput::RenameTag` prompt opens (`r` on level 1), same
+    /// eager-capture reasoning `pending_batch` uses: by confirm time
+    /// `tags_selected`/the tag list could in principle have changed.
+    pub(crate) pending_rename_tag: Option<String>,
     pub show_outline: bool,
     /// Snapshotted the instant the outline opens (`open_outline`) — from
     /// the selected note's saved body normally, or the live editor buffer
@@ -727,6 +822,51 @@ pub struct App {
     /// place of the results list (which is cleared) rather than a crash;
     /// the user can keep typing until the query becomes valid again.
     pub(crate) query_error: Option<String>,
+    /// Custom frontmatter field names actually seen across whichever pool
+    /// was last loaded (`open_query`/`open_global_search`) — shown next to
+    /// a parse error as "here's what you can actually query on", instead of
+    /// leaving the user to guess field names blind.
+    pub(crate) query_known_fields: Vec<String>,
+    /// Ready-to-run example queries generated from whichever pool was last
+    /// loaded (`shiki_core::query::suggest_queries`), with every saved
+    /// query (`Config.queries`) prepended ahead of them — the full set, not
+    /// filtered by anything typed yet. Recomputed on open, same lifetime as
+    /// `query_pool`/`query_known_fields`.
+    pub(crate) query_suggestions: Vec<QuerySuggestion>,
+    /// The subset of `query_suggestions` actually shown right now — every
+    /// one of them when the box is empty (so opening query mode
+    /// immediately shows "here's what you can ask" instead of a blank
+    /// screen), or whichever still contain the in-progress text once the
+    /// DSL fails to parse (a live "did you mean" list) — empty once the
+    /// text parses into a real query, at which point the results table
+    /// takes over instead. Shared by both query surfaces (the dedicated
+    /// leader+`q` modal and global search's `!`-prefixed mode) exactly like
+    /// `query_known_fields`, since only one is ever open at a time.
+    pub(crate) query_suggestions_visible: Vec<QuerySuggestion>,
+    /// The DSL text being saved, captured up front the instant `Ctrl+S` is
+    /// pressed in the query modal (before `PendingInput::SaveQuery` even
+    /// opens) — same eager-capture reasoning `pending_batch`/
+    /// `pending_rename_tag` use, since the query modal is hidden (and its
+    /// own input box repurposed) while the name prompt is up.
+    pub(crate) pending_save_query_dsl: Option<String>,
+    /// The metadata modal (notes-scope/preview-scope `M`) — the selected
+    /// note's tags plus every custom frontmatter field, add/edit/delete in
+    /// place. See `App::metadata_rows`/`handle_metadata_key`.
+    pub show_metadata: bool,
+    pub(crate) metadata_selected: usize,
+    /// Which step of the modal's prompt flow a `PendingInput::Metadata`
+    /// answer belongs to — `None` while the modal itself is just being
+    /// browsed, not prompting for anything.
+    pub(crate) metadata_prompt: Option<MetadataPrompt>,
+    /// Suggestions for whichever field a `MetadataPrompt::FieldValue`/
+    /// `NewFieldValue` prompt is currently editing — built-in defaults
+    /// (`status`/`priority`/`due` each have their own, see
+    /// `App::default_metadata_value_suggestions`) plus every value already
+    /// used for that exact field anywhere (`shiki_core::query::field_values`).
+    /// Empty for `Tags`/`NewFieldKey`, which don't get a suggestions
+    /// dropdown — see `App::metadata_value_query`.
+    pub(crate) metadata_value_options: Vec<String>,
+    pub(crate) metadata_value_selected: usize,
     /// True right after the leader key is pressed, waiting for the next key
     /// to resolve against the `global` scope.
     pub leader_pending: bool,
@@ -761,6 +901,15 @@ pub struct App {
     pub(crate) global_search_input: InputBox,
     pub(crate) global_search_results: Vec<SearchHit>,
     pub(crate) global_search_selected: usize,
+    /// Populated instead of `global_search_results` whenever
+    /// `global_search_input` starts with `!` — the global search modal
+    /// doubling as the query DSL's entry point (`shiki_core::query`),
+    /// same pool, same box, just a different mode signaled by the leading
+    /// `!` and rendered in the theme's warning color instead of accent.
+    pub(crate) global_search_query_rows: Vec<shiki_core::query::QueryRow>,
+    /// Set when the `!`-prefixed text fails to parse as a query — mirrors
+    /// `query_error` from the dedicated leader+`q` modal.
+    pub(crate) global_search_query_error: Option<String>,
     pub(crate) search_engine: SearchEngine,
     pub(crate) keymaps: KeyMaps,
     pub(crate) logs_selected: usize,
@@ -1079,6 +1228,7 @@ impl App {
             tags_selected: 0,
             tags_viewing: None,
             tags_notes_selected: 0,
+            pending_rename_tag: None,
             show_outline: false,
             outline_headings: Vec::new(),
             outline_selected: 0,
@@ -1150,6 +1300,15 @@ impl App {
             query_rows: Vec::new(),
             query_selected: 0,
             query_error: None,
+            query_known_fields: Vec::new(),
+            query_suggestions: Vec::new(),
+            query_suggestions_visible: Vec::new(),
+            pending_save_query_dsl: None,
+            show_metadata: false,
+            metadata_selected: 0,
+            metadata_prompt: None,
+            metadata_value_options: Vec::new(),
+            metadata_value_selected: 0,
             leader_pending: false,
             preview_scroll: 0,
             preview_selection: None,
@@ -1167,6 +1326,8 @@ impl App {
             global_search_input: InputBox::default(),
             global_search_results: Vec::new(),
             global_search_selected: 0,
+            global_search_query_rows: Vec::new(),
+            global_search_query_error: None,
             search_engine: SearchEngine::new(),
             keymaps,
             logs_selected: 0,
@@ -1942,6 +2103,7 @@ impl App {
             hex_to_color(&self.theme.muted),
             hex_to_color(&self.theme.link),
             hex_to_color(&self.theme.bg),
+            hex_to_color(&self.theme.tag),
         ];
         let width = layout::split(self.last_frame_area, self.focus, self.zen_mode)
             .preview
@@ -1962,10 +2124,14 @@ impl App {
         let (source_indices, plain_lines): (Vec<usize>, Vec<Line<'static>>) =
             indexed.into_iter().unzip();
         let grouped = crate::wrap::wrap_lines_grouped(&plain_lines, width);
-        let mut lines = Vec::with_capacity(plain_lines.len());
-        let mut sources = Vec::with_capacity(plain_lines.len());
+        let meta_lines = panel_preview::metadata_lines(note, colors[2], colors[5]);
+        let mut lines = Vec::with_capacity(meta_lines.len() + plain_lines.len());
+        let mut sources = Vec::with_capacity(meta_lines.len() + plain_lines.len());
+        let meta_len = meta_lines.len();
+        lines.extend(meta_lines);
+        sources.extend(std::iter::repeat_n(None, meta_len));
         for (src, rows) in source_indices.into_iter().zip(grouped) {
-            sources.extend(std::iter::repeat_n(src, rows.len()));
+            sources.extend(std::iter::repeat_n(Some(src), rows.len()));
             lines.extend(rows);
         }
         self.note_preview_cache = Some((path, colors, width, lines, sources));
@@ -2028,7 +2194,7 @@ impl App {
     pub(crate) fn note_preview_source_line(&self, row: usize) -> Option<usize> {
         self.note_preview_cache
             .as_ref()
-            .and_then(|(_, _, _, _, sources)| sources.get(row).copied())
+            .and_then(|(_, _, _, _, sources)| sources.get(row).copied().flatten())
     }
 
     /// The cached revision count for whichever note is currently selected,

--- a/shiki-tui/src/draw.rs
+++ b/shiki-tui/src/draw.rs
@@ -5,8 +5,8 @@ use crate::app::{
 use crate::icons;
 use crate::render::{hex_to_color, panel_block};
 use crate::{
-    layout, panel_drawer, panel_notebooks, panel_notes, panel_outline, panel_preview, panel_query,
-    panel_settings, panel_tags, panel_tasks, status_bar, which,
+    layout, panel_drawer, panel_metadata, panel_notebooks, panel_notes, panel_outline,
+    panel_preview, panel_query, panel_settings, panel_tags, panel_tasks, status_bar, which,
 };
 use ratatui::layout::{Constraint, Layout, Rect};
 use ratatui::style::{Modifier, Style};
@@ -105,6 +105,44 @@ pub fn draw(frame: &mut Frame, app: &App) {
                 state.select(Some(app.quick_template_selected));
             }
             frame.render_stateful_widget(list, list_area, &mut state);
+        } else if app.metadata_value_query().is_some() {
+            // Same stacked-dropdown shape as the `@`-quick-template one
+            // above, just for the metadata modal's field-value prompt
+            // (`due`/`status`/`priority`/anything with prior history) —
+            // see `App::metadata_value_query`/`metadata_value_filtered`.
+            let filtered = app.metadata_value_filtered();
+            let list_height = (filtered.len() as u16 + 2)
+                .min(frame.area().height / 2)
+                .max(3);
+            let popup_area = centered_rect(frame.area(), width, 3 + list_height);
+            frame.render_widget(Clear, popup_area);
+            let [input_area, list_area] =
+                Layout::vertical([Constraint::Length(3), Constraint::Length(list_height)])
+                    .areas(popup_area);
+            app.input
+                .render(frame, input_area, title, hex_to_color(&app.theme.accent));
+
+            let items: Vec<ListItem> = filtered.iter().map(|s| ListItem::new(s.clone())).collect();
+            let highlight_symbol = format!("{}", icons::ARROW);
+            let list_title = if app.is_tags_prompt() {
+                format!(" {}Existing tags  ·  tab adds it, keep typing ", icons::TAG)
+            } else {
+                format!(" {}Suggestions ", icons::TAG)
+            };
+            let list = List::new(items)
+                .block(panel_block(Line::from(list_title), true, &app.theme))
+                .highlight_style(
+                    Style::default()
+                        .bg(hex_to_color(&app.theme.selection))
+                        .fg(hex_to_color(&app.theme.accent))
+                        .add_modifier(Modifier::BOLD),
+                )
+                .highlight_symbol(highlight_symbol.as_str());
+            let mut state = ListState::default();
+            if !filtered.is_empty() {
+                state.select(Some(app.metadata_value_selected.min(filtered.len() - 1)));
+            }
+            frame.render_stateful_widget(list, list_area, &mut state);
         } else if let Some(hint) = kind.hint().filter(|_| app.config.general.show_hints) {
             // Stacked under the input box's own fixed 3 rows, same idea as
             // the quick-template dropdown above — the hint is informational
@@ -138,18 +176,36 @@ pub fn draw(frame: &mut Frame, app: &App) {
     }
 
     if app.show_tags {
-        let rows = match &app.tags_viewing {
-            None => app.tag_index().len(),
-            Some(tag) => app
-                .notes
-                .iter()
-                .filter(|n| n.frontmatter.tags.iter().any(|t| t == tag))
-                .count()
-                .max(1),
+        // Level 1 gets an extra row for its hint footer (`r` rename/merge)
+        // — level 2 has no actions of its own beyond navigating/jumping,
+        // so it stays exactly as tall as its row count, same as before.
+        let (rows, footer_rows) = match &app.tags_viewing {
+            None => (app.tag_index().len(), 1),
+            Some(tag) => (
+                app.notes
+                    .iter()
+                    .filter(|n| n.frontmatter.tags.iter().any(|t| t == tag))
+                    .count()
+                    .max(1),
+                0,
+            ),
         };
-        let popup_area = centered_rect(frame.area(), 40, (rows as u16 + 2).max(3));
+        let popup_area = centered_rect(
+            frame.area(),
+            40,
+            (rows as u16 + footer_rows + 2).max(3 + footer_rows),
+        );
         frame.render_widget(Clear, popup_area);
         panel_tags::render(frame, popup_area, app);
+    }
+
+    if app.show_metadata {
+        let rows = app.metadata_rows().len().max(1);
+        // +2 for the block's own top/bottom border, +1 for the hint footer
+        // row `panel_metadata::render` splits out of the inner area.
+        let popup_area = centered_rect(frame.area(), 60, (rows as u16 + 3).max(5));
+        frame.render_widget(Clear, popup_area);
+        panel_metadata::render(frame, popup_area, app);
     }
 
     if app.show_outline {
@@ -307,10 +363,20 @@ fn render_global_search(frame: &mut Frame, frame_area: Rect, app: &App) {
     frame.render_widget(Clear, popup_area);
     let (input_area, list_area) = global_search_layout(popup_area);
 
+    // A leading `!` flips this box into the query DSL (see
+    // `App::global_search_is_query`) — the warning color (the same one
+    // `status_bar`'s mode label already uses to flag "you're in a
+    // different mode now") is the only visual cue, since the box and
+    // popup are otherwise identical in both modes.
+    if app.global_search_is_query() {
+        render_global_search_query(frame, input_area, list_area, app);
+        return;
+    }
+
     app.global_search_input.render(
         frame,
         input_area,
-        &format!(" {}Search all notes ", icons::SEARCH),
+        &format!(" {}Search all notes  ·  ! for query mode ", icons::SEARCH),
         hex_to_color(&app.theme.accent),
     );
 
@@ -345,6 +411,36 @@ fn render_global_search(frame: &mut Frame, frame_area: Rect, app: &App) {
         state.select(Some(app.global_search_selected));
     }
     frame.render_stateful_widget(list, list_area, &mut state);
+}
+
+/// Query mode of the global search modal (typed `!` first — see
+/// `App::global_search_is_query`) — same input box and popup as the plain
+/// text search above, warning-colored instead of accent-colored so it
+/// reads as a distinct mode, with the DSL's own results `Table` (shared
+/// with the dedicated leader+`q` modal via `panel_query::render_result_table`)
+/// instead of the plain-search `List`.
+fn render_global_search_query(frame: &mut Frame, input_area: Rect, list_area: Rect, app: &App) {
+    let warning = hex_to_color(&app.theme.warning);
+    app.global_search_input.render(
+        frame,
+        input_area,
+        &format!(
+            " {}Query  —  where field = value [and/or ...] [sort field [asc|desc]] ",
+            icons::FILTER
+        ),
+        warning,
+    );
+    panel_query::render_result_table(
+        frame,
+        list_area,
+        app,
+        &app.global_search_query_rows,
+        &app.query_suggestions_visible,
+        app.global_search_selected,
+        app.global_search_query_error.as_deref(),
+        warning,
+        false,
+    );
 }
 
 fn render_update(frame: &mut Frame, frame_area: Rect, app: &App) {

--- a/shiki-tui/src/icons.rs
+++ b/shiki-tui/src/icons.rs
@@ -102,3 +102,4 @@ pub const PDF: Icon = Icon('\u{f1c1}', "", true); // file-pdf-o, publish-to-PDF 
 pub const EXPAND: Icon = Icon('\u{f065}', "", true); // arrows-alt (expand), zen mode
 pub const REPEAT: Icon = Icon('\u{f01e}', "", true); // repeat, recurring task indicator
 pub const FILTER: Icon = Icon('\u{f0b0}', "", true); // filter, query modal
+pub const STAR: Icon = Icon('\u{f005}', "*", true); // star, saved queries

--- a/shiki-tui/src/key_handlers.rs
+++ b/shiki-tui/src/key_handlers.rs
@@ -5,13 +5,15 @@ use shiki_core::{wikilinks, Note, Notebook};
 use crate::app::{
     drawer_area, global_search_layout, global_search_popup_area, is_notebook_git_action,
     looks_like_git_url, looks_like_path, relative_folder, shift, App, BatchOp, ConflictView,
-    DeleteTarget, EditorFindState, FindField, Focus, Mode, PassphrasePurpose, PendingInput,
-    PreviewSelection, QuickCommand, SelectedEntry, TrashedEntry, UpdateMsg, UpdateState,
+    DeleteTarget, EditorFindState, FindField, Focus, MetadataPrompt, Mode, PassphrasePurpose,
+    PendingInput, PreviewSelection, QuerySuggestion, QuickCommand, SelectedEntry, TrashedEntry,
+    UpdateMsg, UpdateState,
 };
 use crate::editor::InlineEditor;
 use crate::icons;
 use crate::input::InputBox;
 use crate::keybindings::{Action, WhichKeyRow};
+use crate::panel_query;
 use crate::render::{hex_to_color, panel_block};
 use crate::{
     confirm, layout, panel_drawer, panel_notebooks, panel_notes, panel_preview, slash_menu,
@@ -2289,53 +2291,140 @@ impl App {
         self.query_error = None;
         self.query_rows.clear();
         self.query_pool = self.store.all_notes().unwrap_or_default();
+        self.query_known_fields = shiki_core::query::known_fields(&self.query_pool);
+        self.query_suggestions = self.build_query_suggestions(&self.query_pool);
+        self.query_suggestions_visible = self.query_suggestions.clone();
         self.show_query = true;
+    }
+    /// Every saved query (`Config.queries`, alphabetical by name) first,
+    /// then the generated examples (`shiki_core::query::suggest_queries`
+    /// over `pool`) — saved ones lead since they're a deliberate choice the
+    /// user already made, more relevant than an auto-generated guess at
+    /// what might be useful. Takes `pool` explicitly (rather than reading
+    /// `self.query_pool`) so both query surfaces can call this against
+    /// their own already-loaded pool (`query_pool`/`global_search_pool`)
+    /// without one having to shadow the other's field first.
+    fn build_query_suggestions(
+        &self,
+        pool: &[(shiki_core::Notebook, shiki_core::Note)],
+    ) -> Vec<QuerySuggestion> {
+        let mut saved: Vec<(&String, &String)> = self.config.queries.iter().collect();
+        saved.sort_by_key(|(name, _)| name.to_lowercase());
+        let mut list: Vec<QuerySuggestion> = saved
+            .into_iter()
+            .map(|(name, dsl)| QuerySuggestion::saved(name, dsl.clone()))
+            .collect();
+        list.extend(
+            shiki_core::query::suggest_queries(pool)
+                .into_iter()
+                .map(QuerySuggestion::generated),
+        );
+        list
+    }
+    /// Filters `query_suggestions` down to ones whose display text or
+    /// underlying DSL contains `text` — used both for the immediate
+    /// "here's what you can ask" list (empty text, so every suggestion
+    /// matches) and, once typing starts, as a live "did you mean" list for
+    /// whatever's in progress but doesn't parse yet. Shared by
+    /// `refresh_query` and `refresh_global_search`'s query mode so the two
+    /// can't drift into filtering differently.
+    fn matching_suggestions(&self, text: &str) -> Vec<QuerySuggestion> {
+        let needle = text.trim().to_lowercase();
+        self.query_suggestions
+            .iter()
+            .filter(|s| {
+                needle.is_empty()
+                    || s.display.to_lowercase().contains(&needle)
+                    || s.dsl.to_lowercase().contains(&needle)
+            })
+            .cloned()
+            .collect()
     }
     /// Re-parses and re-evaluates the DSL against the already-loaded
     /// `query_pool` — pure in-memory work, safe to redo on every keystroke.
-    /// An empty box clears results without showing an error (nothing typed
-    /// yet isn't the same as an invalid query); a genuinely malformed DSL
-    /// clears the results and shows the parse error in their place instead
-    /// of crashing or silently keeping stale rows on screen.
+    /// An empty box shows every suggestion (the "here's what you can ask"
+    /// list) rather than a blank screen; a query that doesn't parse yet
+    /// shows whichever suggestions still match what's typed so far instead
+    /// of a bare error, falling back to the real parse error (with its own
+    /// field hint, see `panel_query::render_result_table`) only once no
+    /// suggestion matches either.
     fn refresh_query(&mut self) {
-        let text = self.query_input.value.trim();
+        let text = self.query_input.value.trim().to_string();
         if text.is_empty() {
             self.query_error = None;
             self.query_rows.clear();
+            self.query_suggestions_visible = self.query_suggestions.clone();
             self.query_selected = 0;
             return;
         }
         let today = chrono::Local::now().date_naive();
-        match shiki_core::query::parse(text) {
+        match shiki_core::query::parse(&text) {
             Ok(q) => {
                 self.query_error = None;
+                self.query_suggestions_visible.clear();
                 self.query_rows = shiki_core::query::run_query(&self.query_pool, &q, None, today);
             }
             Err(e) => {
-                self.query_error = Some(e.to_string());
                 self.query_rows.clear();
+                let matches = self.matching_suggestions(&text);
+                if matches.is_empty() {
+                    self.query_error = Some(e.to_string());
+                    self.query_suggestions_visible.clear();
+                } else {
+                    self.query_error = None;
+                    self.query_suggestions_visible = matches;
+                }
             }
         }
-        self.query_selected = self
-            .query_selected
-            .min(self.query_rows.len().saturating_sub(1));
+        let visible_len = if self.query_suggestions_visible.is_empty() {
+            self.query_rows.len()
+        } else {
+            self.query_suggestions_visible.len()
+        };
+        self.query_selected = self.query_selected.min(visible_len.saturating_sub(1));
     }
     /// Navigation is arrows/PageUp/PageDown/Home/End only, deliberately no
     /// `j`/`k` — same reasoning as `which.rs`: those letters need to be
     /// typeable into the query itself.
     fn handle_query_key(&mut self, key: KeyEvent) {
+        let showing_suggestions = !self.query_suggestions_visible.is_empty();
+        let len = if showing_suggestions {
+            self.query_suggestions_visible.len()
+        } else {
+            self.query_rows.len()
+        };
+        let ctrl = key.modifiers.contains(KeyModifiers::CONTROL);
         match key.code {
+            KeyCode::Char('s') if ctrl => self.start_save_query_prompt(),
+            KeyCode::Char('d') if ctrl && showing_suggestions => {
+                if let Some(name) = self
+                    .query_suggestions_visible
+                    .get(self.query_selected)
+                    .and_then(|s| s.saved_name.clone())
+                {
+                    self.delete_saved_query(&name);
+                }
+            }
             KeyCode::Esc => self.show_query = false,
-            KeyCode::Enter => self.jump_to_query_note(),
+            KeyCode::Enter => {
+                if showing_suggestions {
+                    if let Some(s) = self.query_suggestions_visible.get(self.query_selected) {
+                        self.query_input.value = s.dsl.clone();
+                        self.refresh_query();
+                    }
+                } else {
+                    self.jump_to_query_note();
+                }
+            }
             KeyCode::Down => {
-                if self.query_selected + 1 < self.query_rows.len() {
+                if self.query_selected + 1 < len {
                     self.query_selected += 1;
                 }
             }
             KeyCode::Up => self.query_selected = self.query_selected.saturating_sub(1),
             KeyCode::PageDown => {
-                self.query_selected = (self.query_selected + self.page_step() as usize)
-                    .min(self.query_rows.len().saturating_sub(1));
+                self.query_selected =
+                    (self.query_selected + self.page_step() as usize).min(len.saturating_sub(1));
             }
             KeyCode::PageUp => {
                 self.query_selected = self
@@ -2343,7 +2432,7 @@ impl App {
                     .saturating_sub(self.page_step() as usize);
             }
             KeyCode::Home => self.query_selected = 0,
-            KeyCode::End => self.query_selected = self.query_rows.len().saturating_sub(1),
+            KeyCode::End => self.query_selected = len.saturating_sub(1),
             KeyCode::Backspace => {
                 self.query_input.backspace();
                 self.refresh_query();
@@ -2354,6 +2443,63 @@ impl App {
             }
             _ => {}
         }
+    }
+    /// `Ctrl+S` in the query modal — only a query that already parses is
+    /// worth saving (a broken one saved under a name would just replay the
+    /// same parse error every time it's picked from the suggestions list
+    /// later). Hides the modal and opens the name prompt, same "hide
+    /// yourself, restore after" convention as `start_metadata_prompt`/
+    /// `handle_tags_key`'s `r`.
+    fn start_save_query_prompt(&mut self) {
+        let text = self.query_input.value.trim().to_string();
+        if text.is_empty() || self.query_error.is_some() {
+            self.set_status("type a valid query first".into());
+            return;
+        }
+        self.pending_save_query_dsl = Some(text);
+        self.show_query = false;
+        self.start_input(PendingInput::SaveQuery, String::new());
+    }
+    /// Removes a saved query and immediately rebuilds the suggestions list
+    /// so it stops showing up — reuses `refresh_query` afterward rather
+    /// than hand-patching `query_suggestions_visible`, since the deleted
+    /// entry might currently be the *filtered* list shown, not just the
+    /// full one.
+    fn delete_saved_query(&mut self, name: &str) {
+        self.config.queries.remove(name);
+        self.save_config();
+        self.query_suggestions = self.build_query_suggestions(&self.query_pool);
+        self.refresh_query();
+        self.set_status(format!("deleted saved query '{name}'"));
+    }
+    /// Writes `pending_save_query_dsl` into `config.queries` under the
+    /// typed name and persists it — an existing name overwrites (reported
+    /// distinctly from a fresh save, so overwriting isn't a silent
+    /// surprise). Reopens the query modal either way, same as
+    /// `confirm_rename_tag` does for its own modal.
+    fn confirm_save_query(&mut self, value: String) {
+        let Some(dsl) = self.pending_save_query_dsl.take() else {
+            self.show_query = true;
+            return;
+        };
+        let name = value.trim().to_string();
+        if name.is_empty() {
+            self.set_status("save cancelled (name can't be empty)".into());
+        } else {
+            let overwritten = self.config.queries.contains_key(&name);
+            self.config.queries.insert(name.clone(), dsl);
+            self.save_config();
+            self.query_suggestions = self.build_query_suggestions(&self.query_pool);
+            self.set_status(format!(
+                "{} query '{name}'",
+                if overwritten {
+                    "updated saved"
+                } else {
+                    "saved"
+                }
+            ));
+        }
+        self.show_query = true;
     }
     /// Cross-notebook jump to the selected result's note — same shape as
     /// `jump_to_task_note`/`jump_to_global_hit`.
@@ -2378,6 +2524,334 @@ impl App {
             }
         }
         self.show_query = false;
+    }
+    /// Opens the metadata modal for the selected note — a no-op with a
+    /// status message rather than a blank modal when nothing's selected
+    /// (e.g. NOTES is on an empty notebook).
+    fn open_metadata(&mut self) {
+        if self.selected_note().is_none() {
+            self.set_status("select a note first".into());
+            return;
+        }
+        self.metadata_selected = 0;
+        self.show_metadata = true;
+    }
+    /// `tags` is always the first row, even when empty — it's the one
+    /// always-present, always-discoverable place to add tags without a
+    /// separate mechanism. Every other row is one `extra` frontmatter
+    /// field, in the YAML file's own order (a `serde_yaml::Mapping`
+    /// preserves insertion order, so this matches what's actually on disk).
+    pub(crate) fn metadata_rows(&self) -> Vec<(String, String)> {
+        let Some(note) = self.selected_note() else {
+            return Vec::new();
+        };
+        let mut rows = vec![("tags".to_string(), note.frontmatter.tags.join(", "))];
+        for (k, v) in note.frontmatter.extra.iter() {
+            if let Some(key) = k.as_str() {
+                rows.push((key.to_string(), panel_query::yaml_cell_text(v)));
+            }
+        }
+        rows
+    }
+    /// Hides the modal and opens the shared `PendingInput::Metadata` prompt
+    /// — every metadata edit funnels through here so hiding/restoring
+    /// `show_metadata` and stamping an explicit `pending_input_title` (this
+    /// prompt's meaning changes per step, unlike most `PendingInput`
+    /// variants — see `MetadataPrompt`) can't be forgotten in one call site
+    /// but not another.
+    fn start_metadata_prompt(&mut self, kind: MetadataPrompt, title: String, prefill: String) {
+        self.show_metadata = false;
+        let pool = self.store.all_notes().unwrap_or_default();
+        let input_value = match &kind {
+            // Tags keeps its prefill (the note's current comma-separated
+            // list) — unlike a single-value field, there's nothing to
+            // "select instead of the current value", only more to append,
+            // so the box starts exactly where editing naturally continues.
+            MetadataPrompt::Tags => {
+                self.metadata_value_options = shiki_core::tags::all_tags(&pool);
+                self.metadata_value_selected = 0;
+                prefill
+            }
+            MetadataPrompt::NewFieldKey => {
+                self.metadata_value_options = Vec::new();
+                self.metadata_value_selected = 0;
+                prefill
+            }
+            MetadataPrompt::FieldValue(field) | MetadataPrompt::NewFieldValue(field) => {
+                let options = Self::metadata_value_suggestions(&pool, field);
+                // When there are suggestions, the box starts *empty* rather
+                // than prefilled with the current value — prefilling it
+                // would make the live substring filter immediately narrow
+                // the dropdown down to just that one value (nothing else
+                // contains it), defeating the point of seeing every option
+                // at once. The current value isn't lost: `metadata_value_
+                // selected` points at its position in the list instead, so
+                // it's already highlighted and a bare `Enter` with nothing
+                // typed keeps it unchanged, same safety a real prefill
+                // would have given.
+                let value = if options.is_empty() {
+                    self.metadata_value_selected = 0;
+                    prefill
+                } else {
+                    self.metadata_value_selected = options
+                        .iter()
+                        .position(|o| o.eq_ignore_ascii_case(&prefill))
+                        .unwrap_or(0);
+                    String::new()
+                };
+                self.metadata_value_options = options;
+                value
+            }
+        };
+        self.metadata_prompt = Some(kind);
+        self.start_input(PendingInput::Metadata, input_value);
+        self.pending_input_title = Some(title);
+    }
+    /// `true` while the prompt currently open is specifically the `Tags`
+    /// one — the one case where the box holds several comma-separated
+    /// values instead of one, so the suggestions dropdown has to filter/
+    /// insert against just the segment being typed, not the whole box (see
+    /// `metadata_value_query`/`metadata_value_filtered` and the `Tab`
+    /// handling in `handle_insert_key`).
+    pub(crate) fn is_tags_prompt(&self) -> bool {
+        matches!(self.metadata_prompt, Some(MetadataPrompt::Tags))
+    }
+    /// Built-in suggestions for the handful of field names that have an
+    /// obvious convention — `due` in particular resolves relative to *now*
+    /// (never cached), so re-opening the prompt tomorrow suggests tomorrow's
+    /// dates, not stale ones from whenever the app started. Any other field
+    /// name (e.g. `project`) has no universal default; it's suggested purely
+    /// from history via `metadata_value_suggestions`.
+    fn default_metadata_value_suggestions(field: &str) -> Vec<String> {
+        let today = chrono::Local::now().date_naive();
+        match field.to_ascii_lowercase().as_str() {
+            "status" => ["pending", "in-progress", "done"]
+                .into_iter()
+                .map(String::from)
+                .collect(),
+            "priority" => ["high", "medium", "low"]
+                .into_iter()
+                .map(String::from)
+                .collect(),
+            "due" => [
+                today,
+                today.succ_opt().unwrap_or(today),
+                today + chrono::Duration::days(7),
+            ]
+            .into_iter()
+            .map(|d| d.format("%Y-%m-%d").to_string())
+            .collect(),
+            _ => Vec::new(),
+        }
+    }
+    /// Built-in defaults first (the common, "hasn't been used yet" case),
+    /// then every value already used for `field` anywhere across every
+    /// notebook (`shiki_core::query::field_values`, deduped against the
+    /// defaults) — `pool` is passed in (rather than fetched here) so
+    /// `start_metadata_prompt` only walks every notebook once regardless of
+    /// which kind of prompt it's opening.
+    fn metadata_value_suggestions(
+        pool: &[(shiki_core::Notebook, shiki_core::Note)],
+        field: &str,
+    ) -> Vec<String> {
+        let mut values = Self::default_metadata_value_suggestions(field);
+        for v in shiki_core::query::field_values(pool, field) {
+            if !values.iter().any(|d| d.eq_ignore_ascii_case(&v)) {
+                values.push(v);
+            }
+        }
+        values
+    }
+    /// `Some` only while a `PendingInput::Metadata` prompt has suggestions
+    /// to show (`NewFieldKey` never does — see `start_metadata_prompt`) —
+    /// gates the suggestions dropdown in `handle_insert_key`/`draw.rs`,
+    /// same shape as `quick_template_query`. For `Tags`, this is only the
+    /// segment after the last comma (whatever's currently being typed),
+    /// not the whole box — matching several already-picked tags against
+    /// "what's typed" would filter the dropdown down to nothing the moment
+    /// there's more than one tag.
+    pub(crate) fn metadata_value_query(&self) -> Option<&str> {
+        if self.pending_input != Some(PendingInput::Metadata)
+            || self.metadata_value_options.is_empty()
+        {
+            return None;
+        }
+        Some(if self.is_tags_prompt() {
+            self.input
+                .value
+                .rsplit(',')
+                .next()
+                .unwrap_or("")
+                .trim_start()
+        } else {
+            self.input.value.as_str()
+        })
+    }
+    /// `metadata_value_options` narrowed to whatever's typed so far
+    /// (case-insensitive substring, same filter shape as
+    /// `App::matching_suggestions` for the query modal) — empty input
+    /// shows every suggestion, exactly like that one too. For `Tags`,
+    /// additionally drops any tag already picked earlier in the same
+    /// comma-separated list, so a half-finished "work, wor" doesn't offer
+    /// "work" again as if it were a fresh option.
+    pub(crate) fn metadata_value_filtered(&self) -> Vec<String> {
+        let Some(query) = self.metadata_value_query() else {
+            return Vec::new();
+        };
+        let needle = query.to_lowercase();
+        let already_picked: Vec<String> = if self.is_tags_prompt() {
+            self.input
+                .value
+                .split(',')
+                .rev()
+                .skip(1)
+                .map(|s| s.trim().to_lowercase())
+                .collect()
+        } else {
+            Vec::new()
+        };
+        self.metadata_value_options
+            .iter()
+            .filter(|v| {
+                (needle.is_empty() || v.to_lowercase().contains(&needle))
+                    && !already_picked.contains(&v.to_lowercase())
+            })
+            .cloned()
+            .collect()
+    }
+    /// `Tab`-only (see `handle_insert_key`): replaces the segment currently
+    /// being typed (after the last comma) with `suggestion` and appends a
+    /// fresh `", "` separator, ready to keep typing the next tag — doesn't
+    /// touch or confirm the rest of the box, unlike a single-value field's
+    /// `Enter` (`self.input.value = s`), since there can be other
+    /// already-picked tags before it that must survive untouched.
+    fn apply_tag_suggestion(&mut self, suggestion: &str) {
+        match self.input.value.rfind(',') {
+            Some(pos) => {
+                self.input.value.truncate(pos + 1);
+                self.input.value.push(' ');
+            }
+            None => self.input.value.clear(),
+        }
+        self.input.value.push_str(suggestion);
+        self.input.value.push_str(", ");
+        self.metadata_value_selected = 0;
+    }
+    fn handle_metadata_key(&mut self, key: KeyEvent) {
+        let rows = self.metadata_rows();
+        match key.code {
+            KeyCode::Esc | KeyCode::Char('q') => self.show_metadata = false,
+            KeyCode::Char('j') | KeyCode::Down => {
+                if self.metadata_selected + 1 < rows.len() {
+                    self.metadata_selected += 1;
+                }
+            }
+            KeyCode::Char('k') | KeyCode::Up => {
+                self.metadata_selected = self.metadata_selected.saturating_sub(1);
+            }
+            KeyCode::Char('a') => {
+                self.start_metadata_prompt(
+                    MetadataPrompt::NewFieldKey,
+                    " New field name ".into(),
+                    String::new(),
+                );
+            }
+            KeyCode::Enter => {
+                if let Some((key, value)) = rows.get(self.metadata_selected).cloned() {
+                    if key == "tags" {
+                        self.start_metadata_prompt(
+                            MetadataPrompt::Tags,
+                            " Tags (comma-separated) ".into(),
+                            value,
+                        );
+                    } else {
+                        self.start_metadata_prompt(
+                            MetadataPrompt::FieldValue(key.clone()),
+                            format!(" Value for '{key}' (current: {value}) "),
+                            value,
+                        );
+                    }
+                }
+            }
+            KeyCode::Char('d') => {
+                if let Some((key, _)) = rows.get(self.metadata_selected).cloned() {
+                    if let Some(mut note) = self.selected_note().cloned() {
+                        if key == "tags" {
+                            note.frontmatter.tags.clear();
+                        } else {
+                            note.frontmatter
+                                .extra
+                                .remove(serde_yaml::Value::String(key));
+                        }
+                        self.save_metadata_note(note);
+                        self.metadata_selected = self
+                            .metadata_selected
+                            .min(self.metadata_rows().len().saturating_sub(1));
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+    /// Resolves whichever step of the metadata prompt flow just confirmed
+    /// (see `MetadataPrompt`) — `NewFieldKey` is the one non-terminal step,
+    /// chaining straight into `NewFieldValue` via `start_metadata_prompt`
+    /// again instead of saving anything yet; every other step is terminal
+    /// and restores `show_metadata` once it's done.
+    fn confirm_metadata_prompt(&mut self, value: String) {
+        match self.metadata_prompt.take() {
+            Some(MetadataPrompt::Tags) => {
+                if let Some(mut note) = self.selected_note().cloned() {
+                    note.frontmatter.tags = value
+                        .split(',')
+                        .map(|t| t.trim().to_string())
+                        .filter(|t| !t.is_empty())
+                        .collect();
+                    self.save_metadata_note(note);
+                }
+                self.show_metadata = true;
+            }
+            Some(MetadataPrompt::NewFieldKey) => {
+                let key = value.trim().to_string();
+                if key.is_empty() {
+                    self.set_status("metadata field cancelled (name can't be empty)".into());
+                    self.show_metadata = true;
+                } else {
+                    self.start_metadata_prompt(
+                        MetadataPrompt::NewFieldValue(key.clone()),
+                        format!(" Value for '{key}' "),
+                        String::new(),
+                    );
+                }
+            }
+            Some(MetadataPrompt::NewFieldValue(key)) | Some(MetadataPrompt::FieldValue(key)) => {
+                if let Some(mut note) = self.selected_note().cloned() {
+                    note.frontmatter.extra.insert(
+                        serde_yaml::Value::String(key),
+                        serde_yaml::Value::String(value),
+                    );
+                    self.save_metadata_note(note);
+                }
+                self.show_metadata = true;
+            }
+            None => {}
+        }
+    }
+    /// Every metadata edit funnels through here — same crypto-aware save
+    /// path `save_and_exit_edit` uses for the note's body, just for
+    /// frontmatter instead. Refreshes the same caches a body edit would
+    /// (`note_changed` for auto-sync's counter, `refresh_notes_preserve_selection`
+    /// so PREVIEW's metadata header reflects the change immediately).
+    fn save_metadata_note(&mut self, note: shiki_core::Note) {
+        let crypto = self.selected_notebook().and_then(|nb| nb.crypto.clone());
+        match note.save_with_crypto(crypto.as_ref()) {
+            Ok(_) => {
+                self.note_changed(&note.frontmatter.notebook);
+                self.refresh_notes_preserve_selection();
+                self.set_status("metadata saved".into());
+            }
+            Err(e) => self.set_status(format!("could not save metadata: {e}")),
+        }
     }
     /// The tags modal has two levels: the tag list itself, and (after
     /// drilling into one) the notes that carry it — reset to level 1 every
@@ -2408,6 +2882,13 @@ impl App {
                     if let Some(tag) = tags.get(self.tags_selected) {
                         self.tags_viewing = Some(tag.clone());
                         self.tags_notes_selected = 0;
+                    }
+                }
+                KeyCode::Char('r') => {
+                    if let Some(tag) = tags.get(self.tags_selected).cloned() {
+                        self.pending_rename_tag = Some(tag.clone());
+                        self.show_tags = false;
+                        self.start_input(PendingInput::RenameTag, tag);
                     }
                 }
                 _ => {}
@@ -2453,17 +2934,105 @@ impl App {
         self.show_tags = false;
         self.tags_viewing = None;
     }
+    /// Renames (or merges) `pending_rename_tag` across every notebook —
+    /// see `shiki_core::tags::rename_tag`'s own doc comment for why this
+    /// deliberately isn't scoped to the current directory the tags modal
+    /// itself browses. Reopens the tags modal either way (success or
+    /// error), same "restore what hid you" convention every other
+    /// modal-launched prompt in this codebase follows.
+    fn confirm_rename_tag(&mut self, value: String) {
+        let Some(old) = self.pending_rename_tag.take() else {
+            self.show_tags = true;
+            return;
+        };
+        let new = value.trim();
+        if new.is_empty() || new == old {
+            self.set_status("tag rename cancelled".into());
+            self.show_tags = true;
+            return;
+        }
+        let pool = self.store.all_notes().unwrap_or_default();
+        match shiki_core::tags::rename_tag(&pool, &old, new) {
+            Ok((count, notebooks)) => {
+                for nb in &notebooks {
+                    self.note_changed(nb);
+                }
+                self.refresh_notes_preserve_selection();
+                self.set_status(format!(
+                    "renamed tag '{old}' \u{2192} '{new}' in {count} note{}",
+                    if count == 1 { "" } else { "s" }
+                ));
+            }
+            Err(e) => self.set_status(format!("could not rename tag: {e}")),
+        }
+        self.show_tags = true;
+    }
     /// Loads every note from every notebook and opens the global search modal.
     fn open_global_search(&mut self) {
         self.global_search_pool = self.store.all_notes().unwrap_or_default();
         self.global_search_input = InputBox::default();
+        self.global_search_query_rows.clear();
+        self.global_search_query_error = None;
+        self.query_known_fields = shiki_core::query::known_fields(&self.global_search_pool);
+        self.query_suggestions = self.build_query_suggestions(&self.global_search_pool);
+        self.query_suggestions_visible.clear();
         self.refresh_global_search();
         self.show_global_search = true;
     }
+    /// A leading `!` switches the box from plain text search into the query
+    /// DSL (`shiki_core::query`) — same box, same pool, one extra character
+    /// to opt in, so there's no separate modal to remember a binding for.
+    pub(crate) fn global_search_is_query(&self) -> bool {
+        self.global_search_input.value.starts_with('!')
+    }
     /// Re-scores `global_search_pool` against the current query (title +
     /// body + notebook name, so this behaves like a grep across all notes,
-    /// not just a title filter).
+    /// not just a title filter) — or, in query mode (see
+    /// `global_search_is_query`), re-parses and re-evaluates the DSL
+    /// against the same pool instead, mirroring `refresh_query` exactly
+    /// (including the suggestions list — see `matching_suggestions`).
     fn refresh_global_search(&mut self) {
+        if self.global_search_is_query() {
+            self.global_search_results.clear();
+            let text = self.global_search_input.value[1..].trim().to_string();
+            if text.is_empty() {
+                self.global_search_query_error = None;
+                self.global_search_query_rows.clear();
+                self.query_suggestions_visible = self.query_suggestions.clone();
+            } else {
+                let today = chrono::Local::now().date_naive();
+                match shiki_core::query::parse(&text) {
+                    Ok(q) => {
+                        self.global_search_query_error = None;
+                        self.query_suggestions_visible.clear();
+                        self.global_search_query_rows =
+                            shiki_core::query::run_query(&self.global_search_pool, &q, None, today);
+                    }
+                    Err(e) => {
+                        self.global_search_query_rows.clear();
+                        let matches = self.matching_suggestions(&text);
+                        if matches.is_empty() {
+                            self.global_search_query_error = Some(e.to_string());
+                            self.query_suggestions_visible.clear();
+                        } else {
+                            self.global_search_query_error = None;
+                            self.query_suggestions_visible = matches;
+                        }
+                    }
+                }
+            }
+            let visible_len = if self.query_suggestions_visible.is_empty() {
+                self.global_search_query_rows.len()
+            } else {
+                self.query_suggestions_visible.len()
+            };
+            self.global_search_selected = self
+                .global_search_selected
+                .min(visible_len.saturating_sub(1));
+            return;
+        }
+        self.global_search_query_rows.clear();
+        self.global_search_query_error = None;
         let query = self.global_search_input.value.clone();
         let haystacks: Vec<String> = self
             .global_search_pool
@@ -2477,10 +3046,29 @@ impl App {
         self.global_search_selected = 0;
     }
     fn handle_global_search_key(&mut self, key: KeyEvent) {
+        let is_query = self.global_search_is_query();
+        let showing_suggestions = is_query && !self.query_suggestions_visible.is_empty();
+        let len = if showing_suggestions {
+            self.query_suggestions_visible.len()
+        } else if is_query {
+            self.global_search_query_rows.len()
+        } else {
+            self.global_search_results.len()
+        };
         match key.code {
             KeyCode::Esc => self.show_global_search = false,
             KeyCode::Enter => {
-                if let Some(hit) = self
+                if showing_suggestions {
+                    if let Some(s) = self
+                        .query_suggestions_visible
+                        .get(self.global_search_selected)
+                    {
+                        self.global_search_input.value = format!("!{}", s.dsl);
+                        self.refresh_global_search();
+                    }
+                } else if is_query {
+                    self.jump_to_global_search_query_note();
+                } else if let Some(hit) = self
                     .global_search_results
                     .get(self.global_search_selected)
                     .copied()
@@ -2489,7 +3077,7 @@ impl App {
                 }
             }
             KeyCode::Down => {
-                if self.global_search_selected + 1 < self.global_search_results.len() {
+                if self.global_search_selected + 1 < len {
                     self.global_search_selected += 1;
                 }
             }
@@ -2499,7 +3087,7 @@ impl App {
             KeyCode::PageDown => {
                 self.global_search_selected = (self.global_search_selected
                     + self.page_step() as usize)
-                    .min(self.global_search_results.len().saturating_sub(1));
+                    .min(len.saturating_sub(1));
             }
             KeyCode::PageUp => {
                 self.global_search_selected = self
@@ -2507,9 +3095,7 @@ impl App {
                     .saturating_sub(self.page_step() as usize);
             }
             KeyCode::Home => self.global_search_selected = 0,
-            KeyCode::End => {
-                self.global_search_selected = self.global_search_results.len().saturating_sub(1)
-            }
+            KeyCode::End => self.global_search_selected = len.saturating_sub(1),
             KeyCode::Backspace => {
                 self.global_search_input.backspace();
                 self.refresh_global_search();
@@ -2537,6 +3123,34 @@ impl App {
             }
             self.focus = Focus::Preview;
             self.set_status(format!("opened '{}'", note.frontmatter.title));
+        }
+        self.show_global_search = false;
+    }
+    /// Cross-notebook jump to a query-mode result — same shape as
+    /// `jump_to_global_hit`/`jump_to_query_note`, just resolving by path
+    /// against `global_search_pool` since `QueryRow` carries no pool index.
+    fn jump_to_global_search_query_note(&mut self) {
+        let Some(row) = self
+            .global_search_query_rows
+            .get(self.global_search_selected)
+        else {
+            return;
+        };
+        let notebook = row.notebook.clone();
+        let note_path = row.path.clone();
+        if let Some(nb_idx) = self.notebooks.iter().position(|n| n.name == notebook) {
+            self.selected_notebook = nb_idx;
+            let nb_path = self.notebooks[nb_idx].path.clone();
+            self.notes_path = relative_folder(&note_path, &nb_path);
+            self.reload_notes();
+            if let Some(idx) = self.notes.iter().position(|n| n.path == note_path) {
+                self.selected_note = self.folders.len() + idx;
+            }
+            self.focus = Focus::Preview;
+            if let Some(note) = self.selected_note() {
+                let title = note.frontmatter.title.clone();
+                self.set_status(format!("opened '{title}'"));
+            }
         }
         self.show_global_search = false;
     }
@@ -2702,9 +3316,14 @@ impl App {
     }
     fn on_mouse_down(&mut self, column: u16, row: u16) {
         if self.show_global_search {
-            if let Some(index) = self.global_search_hit_at(column, row) {
-                if let Some(hit) = self.global_search_results.get(index).copied() {
-                    self.jump_to_global_hit(hit.index);
+            // Query mode renders a `Table` (with its own header row), not
+            // the plain `List` this hit-test's math assumes — clicking is
+            // a no-op there rather than risk jumping to the wrong row.
+            if !self.global_search_is_query() {
+                if let Some(index) = self.global_search_hit_at(column, row) {
+                    if let Some(hit) = self.global_search_results.get(index).copied() {
+                        self.jump_to_global_hit(hit.index);
+                    }
                 }
             }
             return;
@@ -3061,6 +3680,7 @@ impl App {
             && !self.show_update
             && !self.show_settings
             && !self.show_which_key
+            && !self.show_metadata
             && self.confirm.is_none()
     }
     /// Best-effort: a browser failing to launch (no GUI, headless SSH
@@ -3833,6 +4453,7 @@ impl App {
             Action::Scratchpad => self.start_scratchpad(),
             Action::ToggleTasks => self.open_tasks(),
             Action::ToggleQuery => self.open_query(),
+            Action::EditMetadata => self.open_metadata(),
             Action::PublishNotebook => self.publish_notebook(),
             Action::ExportNotebook => self.start_export_notebook(),
             Action::ToggleZenMode => self.toggle_zen_mode(),
@@ -4378,6 +4999,9 @@ impl App {
                 }
             }
             Some(PendingInput::NotebookPassphrase) => self.confirm_notebook_passphrase(),
+            Some(PendingInput::Metadata) => self.confirm_metadata_prompt(value),
+            Some(PendingInput::RenameTag) => self.confirm_rename_tag(value),
+            Some(PendingInput::SaveQuery) => self.confirm_save_query(value),
             None => {}
         }
         // A guard, not a no-op: `confirm_notebook_passphrase`'s `Enable`
@@ -4662,6 +5286,62 @@ impl App {
                 _ => return,
             }
         }
+        // The metadata field-value suggestions dropdown (`due`/`status`/
+        // `priority`/any field with prior history) — deliberately doesn't
+        // intercept `Esc`, unlike the `@`-dropdown above: there's no typed
+        // trigger substring to strip first, so the very first `Esc` should
+        // fall straight through to the ordinary cancel-the-whole-prompt
+        // handling below (which reopens `show_metadata` for `Metadata`).
+        if self.metadata_value_query().is_some() {
+            match key.code {
+                // `Tags` holds several comma-separated values, so `Enter`
+                // always submits whatever's literally typed — overwriting
+                // it with just the highlighted suggestion (the single-value
+                // fields' behavior) would silently drop every other tag
+                // already picked. `Tab` is the accept-a-suggestion key
+                // there instead (see `apply_tag_suggestion`), the same role
+                // a real shell/editor completion binds it to.
+                KeyCode::Tab if self.is_tags_prompt() => {
+                    let filtered = self.metadata_value_filtered();
+                    if let Some(s) = filtered.get(self.metadata_value_selected).cloned() {
+                        self.apply_tag_suggestion(&s);
+                    }
+                    return;
+                }
+                KeyCode::Enter => {
+                    if !self.is_tags_prompt() {
+                        let filtered = self.metadata_value_filtered();
+                        if let Some(s) = filtered.get(self.metadata_value_selected).cloned() {
+                            self.input.value = s;
+                        }
+                    }
+                    self.confirm_input();
+                    return;
+                }
+                KeyCode::Down => {
+                    let len = self.metadata_value_filtered().len();
+                    if self.metadata_value_selected + 1 < len {
+                        self.metadata_value_selected += 1;
+                    }
+                    return;
+                }
+                KeyCode::Up => {
+                    self.metadata_value_selected = self.metadata_value_selected.saturating_sub(1);
+                    return;
+                }
+                KeyCode::Backspace => {
+                    self.input.backspace();
+                    self.metadata_value_selected = 0;
+                    return;
+                }
+                KeyCode::Char(c) => {
+                    self.input.push(c);
+                    self.metadata_value_selected = 0;
+                    return;
+                }
+                _ => {}
+            }
+        }
         match key.code {
             KeyCode::Esc => {
                 let kind = self.pending_input.take();
@@ -4702,6 +5382,24 @@ impl App {
                         self.reopen_settings_after_passphrase = false;
                         self.show_settings = true;
                     }
+                }
+                // Cancelling any step of the metadata modal's prompt flow —
+                // including mid-chain, on the `NewFieldKey` -> `NewFieldValue`
+                // hop — reopens the metadata modal exactly like confirming
+                // one does, rather than dropping back to bare NOTES/PREVIEW.
+                if kind == Some(PendingInput::Metadata) {
+                    self.metadata_prompt = None;
+                    self.metadata_value_options.clear();
+                    self.show_metadata = true;
+                }
+                // Same reopen-on-cancel reasoning as `Metadata` above.
+                if kind == Some(PendingInput::RenameTag) {
+                    self.pending_rename_tag = None;
+                    self.show_tags = true;
+                }
+                if kind == Some(PendingInput::SaveQuery) {
+                    self.pending_save_query_dsl = None;
+                    self.show_query = true;
                 }
             }
             KeyCode::Enter => self.confirm_input(),
@@ -6417,6 +7115,10 @@ impl App {
         }
         if self.show_settings {
             self.handle_settings_key(key);
+            return;
+        }
+        if self.show_metadata {
+            self.handle_metadata_key(key);
             return;
         }
         match self.mode {

--- a/shiki-tui/src/keybindings.rs
+++ b/shiki-tui/src/keybindings.rs
@@ -79,6 +79,13 @@ pub enum Action {
     /// inside `Mode::Edit` itself (bound directly in `handle_edit_key`,
     /// not through this scoped map).
     ShowOutline,
+    /// Opens the metadata modal — the selected note's tags plus every
+    /// custom frontmatter field (`status`, `priority`, ...), add/edit/
+    /// delete in place. Bound in both `notes` and `preview` scope, same as
+    /// `ShowLinks`'s global+preview double-binding, since "the selected
+    /// note's metadata" is a concept independent of which panel happens to
+    /// have focus.
+    EditMetadata,
 }
 
 /// Translates a config string (e.g. `"enter"`, `"tab"`, `"a"`, `"space"`) into a `KeyCode`.
@@ -196,6 +203,7 @@ impl KeyMaps {
         bind(&mut notes, &cfg.notes.toggle_dates, Action::ToggleDates);
         bind(&mut notes, &cfg.notes.visual, Action::ToggleVisual);
         bind(&mut notes, &cfg.notes.copy_entries, Action::CopyEntries);
+        bind(&mut notes, &cfg.notes.metadata, Action::EditMetadata);
 
         let mut preview = HashMap::new();
         bind(&mut preview, &cfg.preview.edit_inline, Action::EditInline);
@@ -207,6 +215,7 @@ impl KeyMaps {
         bind(&mut preview, &cfg.preview.history, Action::ShowHistory);
         bind(&mut preview, &cfg.preview.links, Action::ShowLinks);
         bind(&mut preview, &cfg.preview.outline, Action::ShowOutline);
+        bind(&mut preview, &cfg.preview.metadata, Action::EditMetadata);
 
         Self {
             leader,
@@ -409,6 +418,7 @@ pub fn action_label(action: Action) -> &'static str {
         Action::ExportNotebook => "export notebook to HTML/Markdown",
         Action::ToggleZenMode => "zen mode (full-screen, hide side panels)",
         Action::ShowOutline => "outline (jump to a heading)",
+        Action::EditMetadata => "metadata (tags / frontmatter fields)",
     }
 }
 
@@ -447,5 +457,6 @@ pub fn action_icon(action: Action) -> crate::icons::Icon {
         Action::ExportNotebook => crate::icons::NOTE,
         Action::ToggleZenMode => crate::icons::EXPAND,
         Action::ShowOutline => crate::icons::TREE,
+        Action::EditMetadata => crate::icons::TAG,
     }
 }

--- a/shiki-tui/src/lib.rs
+++ b/shiki-tui/src/lib.rs
@@ -11,6 +11,7 @@ pub mod layout;
 pub mod links_panel;
 pub(crate) mod multicursor;
 pub mod panel_drawer;
+pub mod panel_metadata;
 pub mod panel_notebooks;
 pub mod panel_notes;
 pub mod panel_outline;

--- a/shiki-tui/src/panel_metadata.rs
+++ b/shiki-tui/src/panel_metadata.rs
@@ -1,0 +1,87 @@
+use ratatui::layout::{Alignment, Constraint, Layout, Rect};
+use ratatui::style::{Modifier, Style};
+use ratatui::text::{Line, Span};
+use ratatui::widgets::{List, ListItem, ListState, Paragraph};
+use ratatui::Frame;
+
+use crate::app::App;
+use crate::icons;
+use crate::render::{hex_to_color, panel_block};
+
+/// The metadata modal (notes-scope/preview-scope `M`) — a flat list, unlike
+/// the tags modal's two levels, since there's only ever one note's fields
+/// to show: `tags` first (always present, even empty, so it's the one
+/// always-discoverable place to add tags), then every custom frontmatter
+/// field. `App::handle_metadata_key` drives editing; this only reads state.
+///
+/// The key hints used to be crammed into the title string itself
+/// (`" Metadata: {title}  ·  enter edit · a add · d delete · esc close "`)
+/// — that's exactly why `a` (add a field) was invisible in practice: a
+/// `ratatui::widgets::Block` title is truncated to whatever fits the
+/// popup's own border width, and a real note title plus that whole hint
+/// string never did. Hints now live in their own dedicated, always-visible
+/// footer row inside the same border instead — the block is rendered
+/// separately (not via `.block()` on the list) specifically so its inner
+/// area can be split into a list row area and a one-line footer, the same
+/// "render the border once, split what's inside it" shape `panel_preview`
+/// uses for its own metadata header.
+pub fn render(frame: &mut Frame, area: Rect, app: &App) {
+    let fg = hex_to_color(&app.theme.fg);
+    let tag_color = hex_to_color(&app.theme.tag);
+    let muted = hex_to_color(&app.theme.muted);
+
+    let rows = app.metadata_rows();
+    let title = match app.selected_note() {
+        Some(note) => format!(" {}Metadata: {} ", icons::TAG, note.frontmatter.title),
+        None => format!(" {}Metadata ", icons::TAG),
+    };
+
+    let block = panel_block(Line::from(title), true, &app.theme);
+    let inner = block.inner(area);
+    frame.render_widget(block, area);
+
+    let [list_area, hint_area] =
+        Layout::vertical([Constraint::Min(1), Constraint::Length(1)]).areas(inner);
+
+    let items: Vec<ListItem> = rows
+        .iter()
+        .map(|(key, value)| {
+            let color = if key == "tags" { tag_color } else { fg };
+            let value = if value.is_empty() {
+                "—"
+            } else {
+                value.as_str()
+            };
+            ListItem::new(format!("{key:<12} {value}")).style(Style::default().fg(color))
+        })
+        .collect();
+
+    let list = List::new(items)
+        .highlight_style(
+            Style::default()
+                .bg(hex_to_color(&app.theme.selection))
+                .fg(tag_color)
+                .add_modifier(Modifier::BOLD),
+        )
+        .highlight_symbol(format!("{} ", icons::ARROW));
+
+    let mut state = ListState::default();
+    if !rows.is_empty() {
+        state.select(Some(app.metadata_selected.min(rows.len() - 1)));
+    }
+    frame.render_stateful_widget(list, list_area, &mut state);
+
+    let key_style = Style::default().fg(tag_color).add_modifier(Modifier::BOLD);
+    let label_style = Style::default().fg(muted);
+    let hint = Line::from(vec![
+        Span::styled("a", key_style),
+        Span::styled(" add   ", label_style),
+        Span::styled("enter", key_style),
+        Span::styled(" edit   ", label_style),
+        Span::styled("d", key_style),
+        Span::styled(" delete   ", label_style),
+        Span::styled("esc", key_style),
+        Span::styled(" close", label_style),
+    ]);
+    frame.render_widget(Paragraph::new(hint).alignment(Alignment::Center), hint_area);
+}

--- a/shiki-tui/src/panel_preview.rs
+++ b/shiki-tui/src/panel_preview.rs
@@ -8,6 +8,59 @@ use crate::app::{App, Focus};
 use crate::icons;
 use crate::render::{borrow_lines, hex_to_color, panel_block, panel_block_reading};
 
+/// A small read-only header — tags (one combined line), then every custom
+/// frontmatter field (`status`, `priority`, whatever a note's own YAML
+/// happens to carry, via `Frontmatter::extra`) one per line — prepended to
+/// the note's body by `App::refresh_note_preview_cache`. Deliberately part
+/// of the same scrollable, wrapped, cached document as the body rather than
+/// a separate fixed-height area above it: reusing the exact same row/scroll/
+/// mouse-hit-test math the body already has (`preview_row_at`,
+/// `note_preview_source_line`) means this needed no new offset arithmetic
+/// anywhere, at the cost of the header scrolling away with the rest of the
+/// note instead of staying pinned — an acceptable trade for a modal-free,
+/// always-visible view of metadata that previously had no in-app view at
+/// all (only visible before by opening the raw file in an external editor).
+/// Empty when there's nothing to show (no tags, no extra fields) — the
+/// common case, which must look exactly like a note with no header at all.
+pub(crate) fn metadata_lines(
+    note: &shiki_core::Note,
+    muted: Color,
+    tag_color: Color,
+) -> Vec<Line<'static>> {
+    let mut lines = Vec::new();
+    if !note.frontmatter.tags.is_empty() {
+        let mut spans = vec![Span::styled(
+            format!("{} ", icons::TAG),
+            Style::default().fg(tag_color),
+        )];
+        for (i, t) in note.frontmatter.tags.iter().enumerate() {
+            if i > 0 {
+                spans.push(Span::raw(" "));
+            }
+            spans.push(Span::styled(
+                format!("#{t}"),
+                Style::default().fg(tag_color),
+            ));
+        }
+        lines.push(Line::from(spans));
+    }
+    for (k, v) in note.frontmatter.extra.iter() {
+        let Some(key) = k.as_str() else { continue };
+        let val = crate::panel_query::yaml_cell_text(v);
+        lines.push(Line::from(vec![
+            Span::styled(
+                format!("{key}: "),
+                Style::default().fg(muted).add_modifier(Modifier::ITALIC),
+            ),
+            Span::styled(val, Style::default().fg(muted)),
+        ]));
+    }
+    if !lines.is_empty() {
+        lines.push(Line::from(""));
+    }
+    lines
+}
+
 pub fn render(frame: &mut Frame, area: Rect, app: &App) {
     let focused = app.focus == Focus::Preview;
     let muted = hex_to_color(&app.theme.muted);

--- a/shiki-tui/src/panel_query.rs
+++ b/shiki-tui/src/panel_query.rs
@@ -9,15 +9,15 @@
 
 use ratatui::layout::{Constraint, Layout, Rect};
 use ratatui::style::{Modifier, Style};
-use ratatui::text::Line;
-use ratatui::widgets::{Cell, Clear, Row, Table, TableState};
+use ratatui::text::{Line, Span};
+use ratatui::widgets::{Cell, Clear, List, ListItem, ListState, Row, Table, TableState};
 use ratatui::Frame;
 
 use crate::app::{centered_rect, App};
 use crate::icons;
 use crate::render::{hex_to_color, panel_block};
 
-fn yaml_cell_text(v: &serde_yaml::Value) -> String {
+pub(crate) fn yaml_cell_text(v: &serde_yaml::Value) -> String {
     match v {
         serde_yaml::Value::String(s) => s.clone(),
         serde_yaml::Value::Number(n) => n.to_string(),
@@ -39,8 +39,6 @@ pub fn render(frame: &mut Frame, frame_area: Rect, app: &App) {
         Layout::vertical([Constraint::Length(3), Constraint::Min(1)]).areas(popup_area);
 
     let accent = hex_to_color(&app.theme.accent);
-    let muted = hex_to_color(&app.theme.muted);
-    let error = hex_to_color(&app.theme.error);
 
     app.query_input.render(
         frame,
@@ -52,24 +50,117 @@ pub fn render(frame: &mut Frame, frame_area: Rect, app: &App) {
         accent,
     );
 
-    if let Some(err) = &app.query_error {
+    render_result_table(
+        frame,
+        list_area,
+        app,
+        &app.query_rows,
+        &app.query_suggestions_visible,
+        app.query_selected,
+        app.query_error.as_deref(),
+        accent,
+        true,
+    );
+}
+
+/// The query DSL's results table — a `Table` (not a `List`, since this is
+/// genuinely tabular, multi-column data), shared by the dedicated query
+/// modal (leader+`q`, above) and the global search modal's own `!`-prefixed
+/// query mode (`draw.rs::render_global_search_query`), so a query means the
+/// same thing and renders the same way in either place. `suggestions`
+/// (`shiki_core::query::suggest_queries`, filtered live by
+/// `App::matching_suggestions`) takes priority over both the table and the
+/// error message whenever it's non-empty — either nothing's been typed yet
+/// (every suggestion shows, as a "here's what you can ask" starting point)
+/// or what's in progress doesn't parse yet but still resembles something
+/// real (a live "did you mean" list) — the raw parse error only surfaces
+/// once no suggestion matches either.
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn render_result_table(
+    frame: &mut Frame,
+    area: Rect,
+    app: &App,
+    rows: &[shiki_core::query::QueryRow],
+    suggestions: &[crate::app::QuerySuggestion],
+    selected: usize,
+    error: Option<&str>,
+    accent: ratatui::style::Color,
+    can_manage_saved: bool,
+) {
+    let muted = hex_to_color(&app.theme.muted);
+    let error_color = hex_to_color(&app.theme.error);
+
+    if !suggestions.is_empty() {
+        // `Ctrl+S`/`Ctrl+D` (save/delete a saved query) only exist in the
+        // dedicated leader+`q` modal, not global search's `!`-prefixed
+        // mode — the hint says so only where it's actually true, rather
+        // than advertising a shortcut that would silently do nothing here.
+        let title = if can_manage_saved {
+            format!(
+                " {}try one of these, from your own notes  ·  enter fills it in \u{B7} ctrl+s save \u{B7} ctrl+d delete saved ",
+                icons::FILTER
+            )
+        } else {
+            format!(
+                " {}try one of these, from your own notes  ·  enter fills it in ",
+                icons::FILTER
+            )
+        };
+        let items: Vec<ListItem> = suggestions
+            .iter()
+            .map(|s| ListItem::new(s.display.as_str()))
+            .collect();
+        let list = List::new(items)
+            .block(panel_block(Line::from(title), true, &app.theme))
+            .highlight_style(
+                Style::default()
+                    .bg(hex_to_color(&app.theme.selection))
+                    .fg(accent)
+                    .add_modifier(Modifier::BOLD),
+            )
+            .highlight_symbol(format!("{} ", icons::ARROW));
+        let mut state = ListState::default();
+        state.select(Some(selected.min(suggestions.len().saturating_sub(1))));
+        frame.render_stateful_widget(list, area, &mut state);
+        return;
+    }
+
+    if let Some(err) = error {
         let block = panel_block(Line::from(" Query "), true, &app.theme);
-        let msg = ratatui::widgets::Paragraph::new(err.as_str())
-            .style(Style::default().fg(error))
+        let mut lines = vec![Line::from(Span::styled(
+            err.to_string(),
+            Style::default().fg(error_color),
+        ))];
+        lines.push(Line::from(""));
+        lines.push(Line::from(Span::styled(
+            format!("built-in fields: {}", shiki_core::query::BUILTIN_FIELDS),
+            Style::default().fg(muted),
+        )));
+        if !app.query_known_fields.is_empty() {
+            lines.push(Line::from(Span::styled(
+                format!("seen in your notes: {}", app.query_known_fields.join(", ")),
+                Style::default().fg(muted),
+            )));
+        }
+        lines.push(Line::from(Span::styled(
+            format!("example: {}", shiki_core::query::EXAMPLE_QUERY),
+            Style::default().fg(muted),
+        )));
+        let msg = ratatui::widgets::Paragraph::new(lines)
+            .wrap(ratatui::widgets::Wrap { trim: true })
             .block(block);
-        frame.render_widget(msg, list_area);
+        frame.render_widget(msg, area);
         return;
     }
 
     let title = format!(
         " {}{} note{} matched ",
         icons::FILTER,
-        app.query_rows.len(),
-        if app.query_rows.len() == 1 { "" } else { "s" }
+        rows.len(),
+        if rows.len() == 1 { "" } else { "s" }
     );
 
-    let rows: Vec<Row> = app
-        .query_rows
+    let table_rows: Vec<Row> = rows
         .iter()
         .map(|r| {
             let fields = r
@@ -97,7 +188,7 @@ pub fn render(frame: &mut Frame, frame_area: Rect, app: &App) {
         Constraint::Percentage(25),
     ];
 
-    let table = Table::new(rows, widths)
+    let table = Table::new(table_rows, widths)
         .header(header)
         .block(panel_block(Line::from(title), true, &app.theme))
         .row_highlight_style(
@@ -109,8 +200,8 @@ pub fn render(frame: &mut Frame, frame_area: Rect, app: &App) {
         .highlight_symbol(format!("{} ", icons::ARROW));
 
     let mut state = TableState::default();
-    if !app.query_rows.is_empty() {
-        state.select(Some(app.query_selected));
+    if !rows.is_empty() {
+        state.select(Some(selected));
     }
-    frame.render_stateful_widget(table, list_area, &mut state);
+    frame.render_stateful_widget(table, area, &mut state);
 }

--- a/shiki-tui/src/panel_tags.rs
+++ b/shiki-tui/src/panel_tags.rs
@@ -1,7 +1,7 @@
-use ratatui::layout::Rect;
+use ratatui::layout::{Alignment, Constraint, Layout, Rect};
 use ratatui::style::{Modifier, Style};
-use ratatui::text::Line;
-use ratatui::widgets::{List, ListItem, ListState};
+use ratatui::text::{Line, Span};
+use ratatui::widgets::{List, ListItem, ListState, Paragraph};
 use ratatui::Frame;
 
 use crate::app::App;
@@ -11,59 +11,85 @@ use crate::render::{hex_to_color, panel_block};
 /// Tag-filtering popup (leader+`T`) — two levels: the tag list itself
 /// (`app.tags_viewing.is_none()`), and after drilling into one (`Enter`),
 /// the notes that carry it. `App::handle_tags_key` drives which level this
-/// renders; this function only reads state, never mutates it.
+/// renders; this function only reads state, never mutates it. Level 1 gets
+/// a dedicated hint footer row for `r` (rename/merge) — same "don't cram
+/// shortcuts into the title" fix `panel_metadata` needed: a title-embedded
+/// hint gets silently truncated by the block's own border the moment the
+/// title is long enough, which is exactly why `a` (add a metadata field)
+/// went unnoticed for a while. Level 2 has no actions of its own beyond
+/// navigating/jumping, so it keeps the plain single-block layout.
 pub fn render(frame: &mut Frame, area: Rect, app: &App) {
     let fg = hex_to_color(&app.theme.fg);
     let tag_color = hex_to_color(&app.theme.tag);
     let muted = hex_to_color(&app.theme.muted);
 
-    let (title, items, selected): (String, Vec<ListItem>, usize) = match &app.tags_viewing {
-        None => {
-            let tags = app.tag_index();
-            let items = tags
-                .tags()
-                .map(|tag| {
-                    ListItem::new(format!(
-                        "{}{tag} ({})",
-                        icons::TAG,
-                        tags.notes_for(tag).len()
-                    ))
-                    .style(Style::default().fg(fg))
-                })
-                .collect();
-            (
-                format!(" {}Tags [{}] ", icons::TAG, tags.len()),
-                items,
-                app.tags_selected,
+    let Some(tag) = &app.tags_viewing else {
+        let tags = app.tag_index();
+        let items: Vec<ListItem> = tags
+            .tags()
+            .map(|tag| {
+                ListItem::new(format!(
+                    "{}{tag} ({})",
+                    icons::TAG,
+                    tags.notes_for(tag).len()
+                ))
+                .style(Style::default().fg(fg))
+            })
+            .collect();
+        let title = format!(" {}Tags [{}] ", icons::TAG, tags.len());
+
+        let block = panel_block(Line::from(title), true, &app.theme);
+        let inner = block.inner(area);
+        frame.render_widget(block, area);
+        let [list_area, hint_area] =
+            Layout::vertical([Constraint::Min(1), Constraint::Length(1)]).areas(inner);
+
+        let list = List::new(items)
+            .highlight_style(
+                Style::default()
+                    .bg(hex_to_color(&app.theme.selection))
+                    .fg(tag_color)
+                    .add_modifier(Modifier::BOLD),
             )
+            .highlight_symbol(format!("{} ", icons::ARROW));
+        let mut state = ListState::default();
+        if !tags.is_empty() {
+            state.select(Some(app.tags_selected));
         }
-        Some(tag) => {
-            let notes: Vec<_> = app
-                .notes
-                .iter()
-                .filter(|n| n.frontmatter.tags.iter().any(|t| t == tag))
-                .collect();
-            let items = if notes.is_empty() {
-                vec![ListItem::new("  no notes with this tag here")
-                    .style(Style::default().fg(muted))]
-            } else {
-                notes
-                    .iter()
-                    .map(|n| {
-                        ListItem::new(format!("{}{}", icons::NOTE, n.frontmatter.title))
-                            .style(Style::default().fg(fg))
-                    })
-                    .collect()
-            };
-            (
-                format!(" {}{tag} [{}]  (h/esc back) ", icons::TAG, notes.len()),
-                items,
-                app.tags_notes_selected,
-            )
-        }
+        frame.render_stateful_widget(list, list_area, &mut state);
+
+        let key_style = Style::default().fg(tag_color).add_modifier(Modifier::BOLD);
+        let label_style = Style::default().fg(muted);
+        let hint = Line::from(vec![
+            Span::styled("enter", key_style),
+            Span::styled(" open   ", label_style),
+            Span::styled("r", key_style),
+            Span::styled(" rename/merge   ", label_style),
+            Span::styled("esc", key_style),
+            Span::styled(" close", label_style),
+        ]);
+        frame.render_widget(Paragraph::new(hint).alignment(Alignment::Center), hint_area);
+        return;
     };
 
-    let highlight_symbol = format!("{}", icons::ARROW);
+    let notes: Vec<_> = app
+        .notes
+        .iter()
+        .filter(|n| n.frontmatter.tags.iter().any(|t| t == tag))
+        .collect();
+    let items = if notes.is_empty() {
+        vec![ListItem::new("  no notes with this tag here").style(Style::default().fg(muted))]
+    } else {
+        notes
+            .iter()
+            .map(|n| {
+                ListItem::new(format!("{}{}", icons::NOTE, n.frontmatter.title))
+                    .style(Style::default().fg(fg))
+            })
+            .collect()
+    };
+    let title = format!(" {}{tag} [{}]  (h/esc back) ", icons::TAG, notes.len());
+
     let list = List::new(items)
         .block(panel_block(Line::from(title), true, &app.theme))
         .highlight_style(
@@ -72,9 +98,9 @@ pub fn render(frame: &mut Frame, area: Rect, app: &App) {
                 .fg(tag_color)
                 .add_modifier(Modifier::BOLD),
         )
-        .highlight_symbol(highlight_symbol.as_str());
+        .highlight_symbol(format!("{} ", icons::ARROW));
 
     let mut state = ListState::default();
-    state.select(Some(selected));
+    state.select(Some(app.tags_notes_selected));
     frame.render_stateful_widget(list, area, &mut state);
 }


### PR DESCRIPTION
## Summary
- **Metadata editor** (notes/preview-scope `M`): view and edit a note's tags and custom frontmatter fields (`status`, `priority`, `due`, or anything else) without leaving the TUI — `a` adds a field, `Enter` edits the selected one, `d` deletes it. PREVIEW gained a read-only header showing the same tags/fields above the note body. Field-value prompts show a suggestions dropdown: built-in defaults for `status`/`priority`/`due`, plus every value already used for that field anywhere in the vault; the `Tags` prompt suggests existing tags (`Tab` accepts, `Enter` still saves the full list as typed).
- **Query mode** (leader+`q`, or leader+`g` then `!`) now opens straight into a generated "here's what you can ask" suggestions list — every distinct field value, both sort directions, and relative-date variants (today/overdue/upcoming/this week/this month) — instead of a blank box, narrowing live as you type. Queries can now be **saved from the TUI**: `Ctrl+S` on a valid query prompts for a name and writes it to `config.toml`'s `[queries]` table; saved queries show up first with a `★`, and `Ctrl+D` deletes one.
- **Tag rename/merge** (`r` in the tags modal, leader+`T`): fixes a typo'd or duplicate tag across every note in every notebook at once, not just the current directory.
- `scripts/query-demo.sh`: seeds an isolated "demo" notebook with example notes for trying out query mode without touching real data.

## Test plan
- [x] `cargo fmt --all` / `cargo clippy --workspace --all-targets` clean
- [x] `cargo test --workspace` — 227 tests green (new: `tags::rename_tag`/`all_tags`, `query::suggest_queries`/`field_values`)
- [x] Verified live via tmux against `scripts/query-demo.sh`'s demo notebook: metadata add/edit/delete + suggestions dropdown, PREVIEW header, tag rename/merge across notebooks, tag autocomplete (`Tab`), saved-query save/run/delete + persistence across a relaunch

🤖 Generated with [Claude Code](https://claude.com/claude-code)