### PR TITLE
feat: add shiki capture + optional TUI capture daemon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,15 @@ semver yet (pre-1.0), but version bumps are still meaningful and tracked here.
   `general.default_notebook` by default (`-n <notebook>` overrides), auto-generates a timestamped
   title. `general.enable_capture_daemon` (off by default, toggle from Settings → GENERAL) lets a
   running TUI pick up captures live over a local loopback socket instead of only writing to disk;
-  `shiki capture` always works with or without it.
+  `shiki capture` always works with or without it. Also supports: reading the text from stdin when
+  no argument is given; `--tags` (same format as `shiki new --tags`); `--daily` (append as a bullet
+  to today's daily note instead of creating a new one); `--json` (machine-readable output); and
+  `--check` (reports whether a daemon is reachable, for status-bar modules, exits non-zero if not);
+  `--folder` (create the note inside a subfolder instead of the notebook root); content-prefix
+  routing (`shiki capture "work: call Ana"` routes into the `work` notebook automatically when no
+  `-n` is given); and `--undo` (reverses the single most recent capture — trash for a plain note,
+  strips the bullet back off for a `--daily` append). Every daemon-handled capture is also recorded
+  in the TUI's log history (`leader` then `l`).
 - Writing-comfort improvements to the native note editor (`Mode::Edit`), each independently
   toggleable from the EDITOR tab in Settings (`leader` then `s`): list/checkbox auto-continuation
   on `Enter` (with ordered-list auto-increment, empty-item exit, and `Backspace` cleanup),

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ semver yet (pre-1.0), but version bumps are still meaningful and tracked here.
 
 ### Added
 
+- `shiki capture "text"`: near-instant note capture with no `$EDITOR` and no TUI drawn — meant for
+  scripts, launchers (rofi/waybar/Raycast/AutoHotkey), or an OS hotkey. Targets
+  `general.default_notebook` by default (`-n <notebook>` overrides), auto-generates a timestamped
+  title. `general.enable_capture_daemon` (off by default, toggle from Settings → GENERAL) lets a
+  running TUI pick up captures live over a local loopback socket instead of only writing to disk;
+  `shiki capture` always works with or without it.
 - Writing-comfort improvements to the native note editor (`Mode::Edit`), each independently
   toggleable from the EDITOR tab in Settings (`leader` then `s`): list/checkbox auto-continuation
   on `Enter` (with ordered-list auto-increment, empty-item exit, and `Backspace` cleanup),

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,7 +21,7 @@ cargo fmt --all                      # format (run after editing, before checkin
 cargo run -p shiki-cli -- <args>     # run the binary, e.g. `-- new "titulo"`, `-- daily`, no args launches the TUI
 ```
 
-There are ~234 `#[test]`s: 127 in `shiki-core`, 13 in `shiki-config`, 87 in `shiki-tui`, 7 in
+There are ~256 `#[test]`s: 131 in `shiki-core`, 17 in `shiki-config`, 95 in `shiki-tui`, 13 in
 `shiki-cli` — `cargo test --workspace` is green. They're all inline `#[cfg(test)]` modules inside
 the source files (no `tests/` dirs, no `#[ignore]`, no fixture setup), so the pattern set by
 `panel_drawer::tests` (`shiki-tui/src/panel_drawer.rs`) — covering `drawer_hit_at`'s mouse
@@ -1437,3 +1437,99 @@ the note or confuse the user about which passphrase prompt they're about to hit 
 other daemon error (`daemon disabled`, a timeout, connection refused) as "nothing to connect to"
 and falls through to the direct-write path, where an encrypted notebook prompts interactively via
 the existing `unlock_if_encrypted`, same as `shiki new` always has.
+
+**The wire protocol grew a second request kind (`PING`) and a small text header block on `CAPTURE`,
+once `--daily`/`--tags` and a `--check` health-check flag were added — still no JSON, on purpose.**
+`shiki-tui/src/capture.rs::parse_request` is the single pure/testable parser both request shapes go
+through: `PING\n\n` (no body) and `CAPTURE\n<zero-or-more key=value header lines>\n\n<raw body>` —
+headers end at the *first* blank line, so the body (the capture text itself) is free to contain its
+own blank lines/newlines without confusing the parser, since everything after that first `\n\n` is
+taken verbatim regardless of what it contains. `daily=1`/`tags=a,b,c` are the only two header keys
+today; an absent header just means "false"/"no tags," so the common case (a plain capture, no
+flags) is still just a two-line request. **`PING` is answered directly inside the accept-loop
+thread, without ever touching the `capture_tx`/`App` channel at all** — a health check only needs
+to read the `Arc<AtomicBool>` the thread already holds its own clone of, so routing it through the
+main thread (and its 5s timeout safety net) would just be unnecessary latency for something that's
+supposed to answer "are you there" as fast as the TCP handshake itself. Reply is always `OK
+enabled`/`OK disabled`, never `ERR` — being asked for status isn't itself a failure state, unlike an
+actual capture attempt.
+
+**`--daily` reuses `shiki_core::daily::create_or_open` on both sides of the daemon boundary
+(`shiki-tui/src/capture.rs::capture_into_daily` and `shiki-cli/src/commands/capture.rs::
+capture_into_daily`, two call sites, same underlying primitive)** — same template/agenda-on-
+creation behavior the `t` keybinding and `shiki daily` already have, since a daily note capture is
+just "open or create today's daily the normal way, then append one more line." The agenda section
+is still only injected on first creation, never on an append to an already-existing daily, per
+`create_or_open`'s own existing contract — appending a bullet is not a "recreate the daily" event.
+`--tags` is silently ignored when `--daily` is also given, rather than erroring: an appended bullet
+line has no frontmatter of its own to carry tags on, and rejecting the combination outright would
+be friction for no real benefit (a script that always passes both flags shouldn't need a special
+case for whichever target it happens to be capturing into that day).
+
+**`--check` (`shiki capture --check`) exits `0` the moment *anything* answers the `PING`, regardless
+of whether it says enabled or disabled** — "reachable" means a TUI process exists at all, which is
+the fact a status-bar module actually wants to gate on; "enabled" is separately reported (in the
+`--json` shape or the plain-text parenthetical) for a module that wants to distinguish "no TUI
+running" from "TUI running, daemon toggled off" as two different icons/colors. `--check` never
+reads stdin and never calls `try_daemon` with a `CAPTURE` request — it's a dead-simple three-branch
+function (`run_check`) that exists specifically so composing it in a script (`shiki capture --check
+&& ...`) can't accidentally block waiting on a terminal that isn't there.
+
+**Every daemon-handled capture calls `App::set_status`, not just on success — `perform_capture`'s
+error branches call it too**, so a locked-notebook refusal or a notebook-creation failure that
+happened while nobody was looking at the screen still shows up in the logs modal (`leader` then
+`l`) afterward, not just as a `capture failed: ...` line in the CLI's own stderr that only the
+script/launcher process ever saw. The standalone (no-daemon) fallback path has no equivalent — there
+is no running `App`/log history to write into in that case, which is an accepted, unavoidable gap
+rather than a missed case: a capture with no TUI running has nothing to log into.
+
+**`shiki capture --undo`/`--folder`/content-prefix routing landed together, since undo and folder
+targeting both needed the wire protocol's `CAPTURE` header block extended anyway, and routing
+shares its notebook-resolution call site with both.** `RequestKind` (`shiki-tui/src/capture.rs`)
+replaced the old flat `CaptureRequest{text}` shape with an enum (`Capture{text, daily, tags,
+notebook, folder}` / `Undo`) — `notebook`/`folder` are `Option<String>`, only populated from a
+`notebook=`/`folder=` header line when the client actually sent one, same "absent header means
+default behavior" convention `daily=`/`tags=` already established. A third wire command, `UNDO\n\n`
+(no body), joins `PING`/`CAPTURE`; like `CAPTURE` (and unlike `PING`) it's routed through
+`capture_tx`/`App` rather than answered inline, since undoing needs real `App` state (`trash_root`,
+`resolved_notebook_crypto`, `note_changed`, live refresh) that the listener thread doesn't hold.
+
+**Content-prefix routing (`shiki_core::notebook::route_by_prefix`) lives in `shiki-core`, not
+duplicated per crate, because both `shiki-tui/src/capture.rs::perform_capture` and
+`shiki-cli/src/commands/capture.rs::run`'s standalone fallback need the identical decision — "does
+`text` start with `<real notebook>: `?" — and `shiki-core` is the one crate both already depend on.
+It only ever runs when the caller has no explicit override (`-n`, or the wire's `notebook=` header)
+at all; an explicit target is never second-guessed by trying to parse the text it's about to save.
+`--folder`'s path validation (`shiki_core::notebook::validate_relative_path`) rejects the whole
+path on the first bad segment (`..`, empty, embedded separator) — same per-component rule
+`validate_name` already enforces for a single notebook/folder name, just applied across every `/`-
+separated segment of a multi-level path, so `--folder ../../etc` fails loudly instead of writing
+somewhere outside the notebook.
+
+**`LastCapture` (`shiki-config/src/last_capture.rs`) is a one-slot record, not a stack — undoing
+only ever reverses the single most recent capture, matching the TUI's own `leader+u` (undo delete),
+which is also one level deep.** It's a plain TOML file (`Config::default_last_capture_path()`,
+same collision reasoning as every other fixed file in the config dir), written by *both*
+`perform_capture` (daemon) and the CLI's standalone fallback to the exact same path — this is what
+makes `--undo` work identically regardless of which one performed the original capture, without
+either side needing to know which path the other took. Two variants: `Note { notebook, path }` (a
+whole new note — undo moves it to trash via the existing `shiki_core::trash::move_to_trash`, so
+it's still recoverable by hand afterward, same safety net every other delete in this app already
+has) and `DailyAppend { notebook, path, appended }` (undo re-reads the daily note, verifies its
+body still ends with `appended` *verbatim*, and only then truncates it off — an edit made to the
+daily note in between capture and undo means undo refuses with a clear error rather than silently
+destroying content the user actually meant to keep, since a `--daily` capture is an append into a
+file that could easily have other, unrelated edits after it). The record is cleared
+(`LastCapture::clear`) immediately after a successful undo, so a second `--undo` reports "nothing
+to undo" instead of either silently no-op'ing (`Note`, file already gone) or re-attempting a body
+suffix strip that would now legitimately fail (`DailyAppend`) with a confusing error instead of a
+clean one.
+
+**`shiki capture --undo` tries the daemon first, for the same live-refresh reason `CAPTURE` does,
+but falls back to reversing it directly through the identical `LastCapture` file if nothing
+answers** (`shiki-cli/src/commands/capture.rs::run_undo` → `run_undo_standalone`) — since the
+record is shared, the standalone path reports the exact same outcome a live daemon would have, just
+without refreshing a TUI that isn't running anyway. Only a `locked: ...` daemon response skips the
+fallback outright (same reasoning as `CAPTURE`'s own locked-notebook handling) — every other daemon
+answer (unreachable, disabled, "nothing to undo") falls through, since re-reading the same shared
+file standalone can't produce a worse or different answer than the daemon already gave.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,7 +21,7 @@ cargo fmt --all                      # format (run after editing, before checkin
 cargo run -p shiki-cli -- <args>     # run the binary, e.g. `-- new "titulo"`, `-- daily`, no args launches the TUI
 ```
 
-There are ~220 `#[test]`s: 118 in `shiki-core`, 13 in `shiki-config`, 85 in `shiki-tui`, 3 in
+There are ~234 `#[test]`s: 127 in `shiki-core`, 13 in `shiki-config`, 87 in `shiki-tui`, 7 in
 `shiki-cli` — `cargo test --workspace` is green. They're all inline `#[cfg(test)]` modules inside
 the source files (no `tests/` dirs, no `#[ignore]`, no fixture setup), so the pattern set by
 `panel_drawer::tests` (`shiki-tui/src/panel_drawer.rs`) — covering `drawer_hit_at`'s mouse
@@ -1380,3 +1380,60 @@ the freshly-installed binary as a child process before `should_quit = true` unwi
 child inherits the parent's now-restored-to-normal terminal and does its own completely ordinary
 `enable_raw_mode`/`EnterAlternateScreen` startup — from the user's perspective it just looks like
 shiki restarted itself onto the new version.
+
+**`shiki capture "text"` (`shiki-cli/src/commands/capture.rs`) plus the optional in-TUI capture
+daemon (`shiki-tui/src/capture.rs`, `general.enable_capture_daemon`, off by default) exist so
+external launchers — rofi/waybar/polybar, Raycast/Alfred, AutoHotkey, a bare OS hotkey — have one
+command to shell out to for near-instant note capture, with or without a TUI open.** `shiki
+capture` itself never depends on the daemon: it always falls all the way back to a direct
+`Notebook::create_note` write (the exact same path `shiki new`/`daily.rs` already use, auto-
+creating the target notebook if missing) when nothing answers. The daemon only exists to make an
+*already-running* TUI find out about a capture immediately instead of only picking it up on the
+next manual reload.
+
+**Transport is a TCP loopback socket (`127.0.0.1`, OS-assigned ephemeral port), not a Unix domain
+socket** — the deciding factor was that shiki genuinely ships and CI-tests Windows binaries
+(`release.yml`/`ci.yml`), and a Unix-socket-only daemon would silently have no equivalent on that
+platform. `std::net::TcpListener`/`TcpStream` alone cover Linux/macOS/Windows identically, no new
+dependency. The bound port is written to `Config::default_capture_port_path()`
+(`~/.config/shiki/capture.port`, config dir — same collision reasoning as `shiki.log`/`trash/`/
+`session.toml`: the data dir's top level is user-named notebooks) every time the daemon starts, so
+a crashed process never leaves a stale port number for the next `shiki capture` to hang against —
+confirmed live: `kill -9`ing the TUI and immediately running `shiki capture` falls back to a direct
+write in single-digit milliseconds, since connecting to a now-unbound port fails instantly rather
+than timing out.
+
+**The listener thread, once spawned, is never torn down — toggling `enable_capture_daemon` off
+just flips a shared `Arc<AtomicBool>` (`CaptureDaemonHandle::enabled`) that the thread checks per
+connection, replying `ERR daemon disabled` without ever touching the main-thread channel.**
+Toggling back on flips the same flag rather than rebinding a new port. This mirrors the "no
+shutdown/rejoin mechanism anywhere in this codebase" reality `spawn_git_op`/self-update already
+live with — inventing one here for a boolean would be new complexity with no precedent.
+`App::ensure_capture_daemon_spawned` (called from `App::new` when the config already says on, and
+from `App::set_capture_daemon_enabled` the first time the Settings toggle turns it on) is the only
+place the thread actually gets created; a bind/IO failure reverts `enable_capture_daemon` to
+`false` and reports why via `set_status`, rather than pretending the daemon is running.
+
+**The listener thread is a dumb pipe — it never touches `Notebook`/`NotebookStore`/`App` itself.**
+Per connection it reads the request to EOF (not line-delimited; the capture text may itself contain
+newlines), bundles a fresh one-shot `mpsc::Sender<CaptureReply>` into a `CaptureRequest` sent over
+the long-lived `App::capture_tx` → `capture_rx` channel, and blocks on that one-shot receiver
+(`recv_timeout(5s)` as a safety net, not the normal path — the main loop's `poll_capture_channel`,
+called once per `run()` iteration right next to `poll_update_channel`/`poll_sync_channel`, drains
+every pending request well within that window). All real work — resolving/creating the target
+notebook, checking encryption, `Notebook::create_note`, `refresh_notes_preserve_selection`,
+`note_changed` — runs in `capture::perform_capture` on the *main* thread, reusing the exact same
+note-creation path every other capture route already uses. This is what makes panel refresh and
+auto-sync counting "just work" for a capture that arrived from an external process, with no
+duplicated business logic on the background thread.
+
+**A capture into an encrypted notebook never blocks on a passphrase from the daemon path.**
+`perform_capture` calls the existing `App::resolved_notebook_crypto` — if the target notebook is
+configured as encrypted but nothing's been typed in this session (`None`), it replies with an error
+prefixed `locked: ...` rather than hanging (a background thread has no way to pop up a prompt) or
+silently writing plaintext. `shiki capture`'s client side treats this prefix as authoritative and
+does *not* fall back to a direct write in that case — falling back there could otherwise duplicate
+the note or confuse the user about which passphrase prompt they're about to hit — but treats every
+other daemon error (`daemon disabled`, a timeout, connection refused) as "nothing to connect to"
+and falls through to the direct-write path, where an encrypted notebook prompts interactively via
+the existing `unlock_if_encrypted`, same as `shiki new` always has.

--- a/IDEA.md
+++ b/IDEA.md
@@ -380,6 +380,14 @@ shiki edit <note>         # edit with $EDITOR
 shiki search <query>      # search and show results
 shiki capture "quick idea"       # near-instant note capture, no $EDITOR, no TUI drawn
 shiki capture "text" -n work     # capture into a specific notebook instead of default_notebook
+echo "piped idea" | shiki capture      # reads the text from stdin when no argument is given
+shiki capture "call Ana" --tags work,idea   # comma-separated tags, same flag as `shiki new`
+shiki capture "call Ana" --daily      # appends as a bullet to today's daily note instead of a new note
+shiki capture "call Ana" --json       # emits {"path":..,"daemon":..,"daily":..} for scripts
+shiki capture --check                 # is a capture daemon reachable right now? exits non-zero if not
+shiki capture "meeting notes" --folder work/meetings -n work   # into a subfolder, not the notebook root
+shiki capture "work: call Ana"        # no -n given -> routed into the "work" notebook automatically
+shiki capture --undo                  # reverses the single most recent capture (any kind)
 shiki new "title" --body "text"     # create non-interactively, no $EDITOR spawned
 shiki new "title" --stdin --tags work,idea  # body piped in, tags attached, still no $EDITOR
 shiki list --json         # list/search/show all take --json for scripting (list/search: array, show: object)
@@ -439,12 +447,34 @@ those launchers just needs to call.
 By default it targets `general.default_notebook` (auto-created if it doesn't exist yet, same as
 `shiki new`), with an auto-generated title (`Capture 2026-08-10 15:35`, no title prompt) so there's
 nothing to type but the note's actual content. `-n <notebook>` overrides the target, same flag as
-`shiki new`/`shiki daily`.
+`shiki new`/`shiki daily`. The text itself is a plain positional argument; omit it entirely and
+shiki reads it from stdin instead (`echo "idea" | shiki capture`), for wiring into another
+program's own output rather than typing a literal string.
 
 ```
 shiki capture "buy milk"          # -> personal/capture-2026-08-10-15-35.md
 shiki capture "call Ana" -n work  # -> work/capture-....md instead
 ```
+
+`--tags work,idea` sets tags on the created note, same flag/format as `shiki new --tags`.
+`--daily` changes the target entirely: instead of a new note, the text is appended as a `- ` bullet
+under today's daily note (created via the same `shiki_core::daily::create_or_open` the `t`
+keybinding/`shiki daily` already use — template + agenda section included on first creation, an
+already-existing daily is just opened and appended to) — for treating the daily note as a running
+inbox for the whole day rather than one note per capture. `--tags` is ignored when `--daily` is
+also given, since an appended bullet has no frontmatter of its own to carry tags on.
+`--json` emits `{"path": "...", "daemon": true|false, "daily": true|false}` instead of the plain
+sentence, for a script or browser extension that wants to act on the result without string-matching
+`"captured (daemon): "`. `--folder work/meetings` creates the note inside that subfolder of the
+notebook instead of its root (each path segment validated the same way a notebook/folder name is —
+no `..`/empty segments); ignored when `--daily` is given, since a daily note's path is always fixed.
+
+**Content-prefix routing**: if no `-n` was given and the text itself looks like `"<notebook>:
+<rest>"` where `<notebook>` case-insensitively matches a real, existing notebook, that notebook is
+used automatically and the prefix is stripped from the saved text — `shiki capture "work: call
+Ana"` needs no `-n work` at all. An explicit `-n` always wins outright and skips this check
+entirely, so a genuine note that happens to start with `"word: "` is never mis-routed as long as a
+target was actually given.
 
 **The optional daemon** (`general.enable_capture_daemon`, off by default — toggle it from
 `leader+s` → GENERAL → `enable_capture_daemon`) makes a *running* TUI aware of captures the instant
@@ -466,6 +496,28 @@ a TUI running; the toggle only controls whether an already-open TUI finds out im
 it back on later reuses the same listener thread rather than restarting anything — the daemon, once
 started this session, never actually shuts down; off just means it answers "disabled" to new
 connections instead of processing them.
+
+`shiki capture --check` reports whether a daemon is reachable right now without capturing anything
+(and without touching stdin) — meant for a status-bar module or launcher script that wants to show
+"capture: on"/"capture: off", or decide something differently, before committing to a real capture.
+It exits `0` when a daemon answered (regardless of whether it said enabled or disabled — reachable
+at all means a TUI process exists) and non-zero otherwise, so `shiki capture --check && ...`
+composes naturally in a script; `--json` emits `{"reachable": true|false, "enabled": true|false}`.
+Every capture handled by the daemon (not the standalone fallback — there's no running `App` to log
+into in that case) is also recorded in the TUI's own log history (`leader` then `l`), so a capture
+that happened while nobody was watching the screen still leaves a trace, the same way a background
+git sync result does.
+
+`shiki capture --undo` reverses the single most recent capture — a plain note is moved to trash
+(restorable exactly like any other deleted note); a `--daily` append instead strips exactly the
+bullet that was added off the end of the daily note's body, and only if the body still ends with it
+verbatim — if the daily note was edited in between, undo refuses rather than risk removing content
+you actually meant to keep. This is a *one-slot* undo, not a stack, same simplicity level as
+`leader+u` (undo delete): a second `--undo` in a row reports "nothing to undo" rather than reaching
+further back. The record backing it (`~/.config/shiki/last-capture.toml`) is shared between the
+daemon and the standalone fallback, so undo works the same regardless of which one made the
+original capture — it tries the daemon first (for a live TUI refresh if the reverted item was on
+screen), then falls back to reversing it directly.
 
 Capturing into an **encrypted** notebook only works through the daemon if that notebook is already
 unlocked in the running TUI this session — the background listener thread can't itself pop up a
@@ -581,6 +633,7 @@ file's mtime. It only gains real frontmatter once you touch it through shiki
 ├── theme.toml             # custom theme (optional)
 ├── shiki.log              # persistent status/log history (leader+l to view, x to clear)
 ├── capture.port           # port the capture daemon is listening on (only while a TUI has it enabled)
+├── last-capture.toml      # backs `shiki capture --undo` — removed once undone
 ├── trash/                 # deleted notes/folders, restorable with leader+u (see below)
 │   └── <notebook>/
 └── templates/             # templates

--- a/IDEA.md
+++ b/IDEA.md
@@ -378,6 +378,8 @@ shiki list -n work        # list notes in "work"
 shiki show <note>         # show rendered content (ANSI)
 shiki edit <note>         # edit with $EDITOR
 shiki search <query>      # search and show results
+shiki capture "quick idea"       # near-instant note capture, no $EDITOR, no TUI drawn
+shiki capture "text" -n work     # capture into a specific notebook instead of default_notebook
 shiki new "title" --body "text"     # create non-interactively, no $EDITOR spawned
 shiki new "title" --stdin --tags work,idea  # body piped in, tags attached, still no $EDITOR
 shiki list --json         # list/search/show all take --json for scripting (list/search: array, show: object)
@@ -422,6 +424,55 @@ given.
 matching an existing notebook; `data_dir` being a real directory, not just existing; two notebooks
 resolving to the same path on disk; `git.remote_template` containing its `{notebook}` placeholder;
 and `git.sign_commits` having an actual signing key configured (`git config user.signingkey`).
+
+---
+
+## Quick capture (`shiki capture` + optional daemon)
+
+`shiki capture "some text"` creates a note with no ceremony — no `$EDITOR` spawned, no TUI drawn,
+just a single line of output. It's meant to be wired into things *outside* shiki entirely: a rofi/
+wofi prompt bound to an OS hotkey, a waybar/polybar click action, a Raycast/Alfred script command,
+an AutoHotkey shortcut on Windows — anything that can shell out. Shiki doesn't (and can't, from a
+terminal app) register a global OS hotkey itself; `shiki capture` is the one command every one of
+those launchers just needs to call.
+
+By default it targets `general.default_notebook` (auto-created if it doesn't exist yet, same as
+`shiki new`), with an auto-generated title (`Capture 2026-08-10 15:35`, no title prompt) so there's
+nothing to type but the note's actual content. `-n <notebook>` overrides the target, same flag as
+`shiki new`/`shiki daily`.
+
+```
+shiki capture "buy milk"          # -> personal/capture-2026-08-10-15-35.md
+shiki capture "call Ana" -n work  # -> work/capture-....md instead
+```
+
+**The optional daemon** (`general.enable_capture_daemon`, off by default — toggle it from
+`leader+s` → GENERAL → `enable_capture_daemon`) makes a *running* TUI aware of captures the instant
+they happen, instead of only writing to disk unnoticed until the next manual reload. With it on,
+the TUI listens on a local TCP loopback port (`127.0.0.1`, OS-assigned, recorded in
+`~/.config/shiki/capture.port`); `shiki capture` tries that socket first, and if a TUI answers, the
+new note appears live in NOTES (when you're already looking at that notebook's root) with no
+keypress needed. The command's own output tells you which path it took:
+
+```
+$ shiki capture "buy milk"
+captured (daemon): /home/you/notes/personal/capture-2026-08-10-15-35.md   # a running TUI picked it up live
+$ shiki capture "buy milk"
+captured: /home/you/notes/personal/capture-2026-08-10-15-35.md            # written straight to disk, no TUI (or daemon off) noticed
+```
+
+Turning the daemon off doesn't turn *capture* off — `shiki capture` always works, with or without
+a TUI running; the toggle only controls whether an already-open TUI finds out immediately. Toggling
+it back on later reuses the same listener thread rather than restarting anything — the daemon, once
+started this session, never actually shuts down; off just means it answers "disabled" to new
+connections instead of processing them.
+
+Capturing into an **encrypted** notebook only works through the daemon if that notebook is already
+unlocked in the running TUI this session — the background listener thread can't itself pop up a
+passphrase prompt, so it replies with a clear "locked" error instead of hanging or writing
+plaintext, and `shiki capture` reports that error rather than silently falling back. Run
+`shiki capture` from a plain terminal (no daemon involved) against an encrypted, locked notebook
+and it prompts for the passphrase interactively instead, same as `shiki new`.
 
 ---
 
@@ -529,6 +580,7 @@ file's mtime. It only gains real frontmatter once you touch it through shiki
 ├── keybindings.toml       # custom shortcuts (optional)
 ├── theme.toml             # custom theme (optional)
 ├── shiki.log              # persistent status/log history (leader+l to view, x to clear)
+├── capture.port           # port the capture daemon is listening on (only while a TUI has it enabled)
 ├── trash/                 # deleted notes/folders, restorable with leader+u (see below)
 │   └── <notebook>/
 └── templates/             # templates
@@ -604,6 +656,12 @@ daily_template = "daily"
 # When true, `i` opens the OS's detected favorite editor (env $VISUAL/$EDITOR,
 # then the desktop's default text/plain handler) instead of the inline editor.
 use_favorite_editor = false
+# When true, the TUI listens on a local loopback port so external
+# `shiki capture "text"` invocations land here live instead of only
+# writing to disk unnoticed. `shiki capture` itself always works either
+# way — this only controls whether an already-open TUI finds out
+# immediately. Off by default; toggle from leader+s -> GENERAL.
+enable_capture_daemon = false
 # When true, click-and-drag over a note's body in PREVIEW selects text and
 # copies it to the clipboard (OSC 52, same mechanism as the logs modal's
 # `y`/`c`) as soon as the mouse button is released.

--- a/docs/documentation.html
+++ b/docs/documentation.html
@@ -576,45 +576,55 @@ shiki doctor              # environment check: config, data dir, git, editor, te
   <section id="capture">
     <div class="container">
       <h2>Quick capture (<code>shiki capture</code> + optional daemon)</h2>
+
+      <h3>The idea</h3>
       <p style="max-width:70ch;">
-        <code>shiki capture "some text"</code> creates a note with no ceremony — no
-        <code>$EDITOR</code> spawned, no TUI drawn, just a single line of output. It's meant to be
-        wired into things <em>outside</em> shiki entirely: a rofi/wofi prompt bound to an OS
-        hotkey, a waybar/polybar click action, a Raycast/Alfred script command, an AutoHotkey
-        shortcut on Windows — anything that can shell out. Shiki can't register a global OS hotkey
-        itself from a terminal app; <code>shiki capture</code> is the one command every one of
-        those launchers just needs to call.
+        Opening the full TUI just to jot down one line is friction — navigate to a notebook, press
+        <code>a</code>, type a title, type the body, save. <code>shiki capture "some text"</code>
+        skips all of it: no <code>$EDITOR</code> spawned, no TUI drawn, just a single line of
+        output. It's designed to be wired into things <em>outside</em> shiki entirely — a rofi/wofi
+        prompt bound to an OS hotkey, a waybar/polybar click action, a Raycast/Alfred script
+        command, an AutoHotkey shortcut on Windows, a browser extension, a cron job, another
+        program's own generated output piped in. Shiki can't register a global OS hotkey itself
+        from a terminal app, and deliberately doesn't try to — <code>shiki capture</code> is the
+        one command every one of those launchers just needs to call; see
+        <a href="#capture-recipes">Wiring it into external launchers</a> below for copy-pasteable
+        examples of exactly that.
       </p>
       <p style="max-width:70ch;">
-        By default it targets <code>general.default_notebook</code> (auto-created if it doesn't
-        exist yet, same as <code>shiki new</code>), with an auto-generated title
-        (<code>Capture 2026-08-10 15:35</code>, no title prompt) so there's nothing to type but the
-        note's actual content. <code>-n &lt;notebook&gt;</code> overrides the target, same flag as
-        <code>shiki new</code>/<code>shiki daily</code>. The text itself is a plain positional
-        argument; omit it entirely and shiki reads it from stdin instead
-        (<code>echo "idea" | shiki capture</code>), for wiring into another program's own output
-        rather than typing a literal string.
+        The design is layered on purpose: the plain command always works standalone (writes
+        straight to disk, works from a cold shell with no shiki process anywhere), and an
+        <em>entirely optional</em> daemon on top makes an already-running TUI aware of a capture
+        the instant it happens instead of finding out on the next manual reload. Nothing about
+        capture requires the daemon — it's an enhancement, never a dependency.
+      </p>
+
+      <h3>What it does by default</h3>
+      <p style="max-width:70ch;">
+        With no flags, it targets <code>general.default_notebook</code> (auto-created if it
+        doesn't exist yet, same as <code>shiki new</code>), with an auto-generated title
+        (<code>Capture 2026-08-10 15:35</code> — a timestamp, never a prompt) so there's nothing to
+        type but the note's actual content.
       </p>
       <pre class="code">shiki capture "buy milk"          # -> personal/capture-2026-08-10-15-35.md
-shiki capture "call Ana" -n work  # -> work/capture-....md instead</pre>
-      <p style="max-width:70ch;">
-        <code>--tags work,idea</code> sets tags on the created note, same flag/format as
-        <code>shiki new --tags</code>. <code>--daily</code> changes the target entirely: instead of
-        a new note, the text is appended as a <code>- </code> bullet under today's daily note
-        (created via the same machinery the <code>t</code> keybinding/<code>shiki daily</code>
-        already use — template + agenda section included on first creation, an already-existing
-        daily is just opened and appended to) — for treating the daily note as a running inbox for
-        the whole day rather than one note per capture. <code>--tags</code> is ignored when
-        <code>--daily</code> is also given, since an appended bullet has no frontmatter of its own
-        to carry tags on. <code>--json</code> emits
-        <code>{"path": "...", "daemon": true|false, "daily": true|false}</code> instead of the
-        plain sentence, for a script or browser extension that wants to act on the result without
-        string-matching <code>"captured (daemon): "</code>. <code>--folder work/meetings</code>
-        creates the note inside that subfolder of the notebook instead of its root (each path
-        segment validated the same way a notebook/folder name is — no <code>..</code>/empty
-        segments); ignored when <code>--daily</code> is given, since a daily note's path is
-        always fixed.
-      </p>
+shiki capture "call Ana" -n work  # -> work/capture-....md instead
+echo "piped idea" | shiki capture # no argument at all -> reads the text from stdin</pre>
+
+      <h3>Every parameter, in detail</h3>
+      <table class="ref-table">
+        <thead><tr><th>Flag</th><th>What it does</th></tr></thead>
+        <tbody>
+          <tr><td><code>&lt;text&gt;</code> <span class="muted">(positional)</span></td><td>The text to capture. Omit it entirely to read from stdin instead (<code>echo "idea" | shiki capture</code>) — useful for piping another program's own output straight in rather than typing a literal string. Not read at all when <code>--check</code> or <code>--undo</code> is given.</td></tr>
+          <tr><td><code>-n, --notebook &lt;name&gt;</code></td><td>Overrides both <code>general.default_notebook</code> <em>and</em> content-prefix routing (below) — an explicit target always wins outright, no exceptions. Auto-creates the notebook if it doesn't exist yet, same as <code>shiki new</code>.</td></tr>
+          <tr><td><code>--tags a,b,c</code></td><td>Comma-separated tags set on the created note's frontmatter — identical format to <code>shiki new --tags</code>. Ignored when <code>--daily</code> is also given: an appended bullet has no frontmatter of its own to carry tags on.</td></tr>
+          <tr><td><code>--daily</code></td><td>Changes the target entirely — instead of a new note, the text is appended as a <code>- </code> bullet under <em>today's</em> daily note, via the same machinery the <code>t</code> keybinding/<code>shiki daily</code> already use (template + agenda section included only on first creation; an already-existing daily is just opened and appended to). For treating the daily note as a running inbox for the whole day instead of one note per capture.</td></tr>
+          <tr><td><code>--folder work/meetings</code></td><td>Creates the note inside that subfolder of the notebook instead of its root — any depth (<code>work/meetings/q3</code> works too). Each path segment is validated the same way a single notebook/folder name is (no <code>..</code>, no empty segments, no embedded separators) — a typo'd <code>--folder ../../etc</code> fails loudly rather than writing somewhere unintended. Ignored when <code>--daily</code> is given, since a daily note's filesystem path is always fixed.</td></tr>
+          <tr><td><code>--json</code></td><td>Emits a single machine-readable line instead of a sentence — <code>{"path": "...", "daemon": true|false, "daily": true|false}</code> on success. For a script or browser extension that wants to act on the exact result without string-matching <code>"captured (daemon): "</code>.</td></tr>
+          <tr><td><code>--check</code></td><td>Reports whether a capture daemon is reachable right now and exits immediately — doesn't capture anything, doesn't touch stdin at all. Exits <code>0</code> if <em>any</em> daemon answered (reachable at all means a TUI process exists, regardless of whether it said enabled or disabled) and non-zero otherwise, so <code>shiki capture --check &amp;&amp; ...</code> composes naturally in a script. <code>--json</code> emits <code>{"reachable": true|false, "enabled": true|false}</code>. Conflicts with <code>--undo</code>.</td></tr>
+          <tr><td><code>--undo</code></td><td>Reverses the single most recent capture, whichever kind it was — see <a href="#capture-undo">Undo</a> below for the full behavior. Doesn't touch <code>&lt;text&gt;</code>/stdin/<code>--tags</code>/<code>--daily</code>/<code>--folder</code> at all.</td></tr>
+        </tbody>
+      </table>
+
       <div class="doc-callout">
         <strong>Content-prefix routing</strong>
         <p>
@@ -625,20 +635,37 @@ shiki capture "call Ana" -n work  # -> work/capture-....md instead</pre>
           <code>shiki capture "work: call Ana"</code> needs no <code>-n work</code> at all. An
           explicit <code>-n</code> always wins outright and skips this check entirely, so a
           genuine note that happens to start with <code>"word: "</code> is never mis-routed as
-          long as a target was actually given.
+          long as a target was actually given. The exact same check runs whether the capture ends
+          up going through the daemon or the standalone fallback, so routing behaves identically
+          either way.
         </p>
       </div>
+
+      <h3>How the optional daemon works</h3>
       <p style="max-width:70ch;">
-        <strong>The optional daemon</strong> (<code>general.enable_capture_daemon</code>, off by
-        default — toggle it from <code>leader+s</code> → GENERAL →
-        <code>enable_capture_daemon</code>) makes a <em>running</em> TUI aware of captures the
-        instant they happen, instead of only writing to disk unnoticed until the next manual
-        reload. With it on, the TUI listens on a local TCP loopback port
-        (<code>127.0.0.1</code>, OS-assigned, recorded in
-        <code>~/.config/shiki/capture.port</code>); <code>shiki capture</code> tries that socket
-        first, and if a TUI answers, the new note appears live in NOTES (when you're already
-        looking at that notebook's root) with no keypress needed. The command's own output tells
-        you which path it took:
+        <code>general.enable_capture_daemon</code> (off by default — toggle it from
+        <code>leader+s</code> → GENERAL → <code>enable_capture_daemon</code>) makes a
+        <em>running</em> TUI listen for captures instead of only finding out about them on its next
+        manual reload. When it's on, the TUI binds a local TCP socket on <code>127.0.0.1</code>
+        with an OS-assigned ephemeral port (not a fixed one, and not a Unix domain socket — a plain
+        TCP loopback socket is the one transport that works identically on Linux, macOS, <em>and</em>
+        Windows with zero extra dependencies, and shiki genuinely ships Windows binaries, so this
+        wasn't a hypothetical concern). Whichever port it bound is written to
+        <code>~/.config/shiki/capture.port</code>, rewritten every time the daemon starts — so a
+        crashed shiki process never leaves a stale port number behind for the next
+        <code>shiki capture</code> to hang against; connecting to a genuinely dead port fails
+        instantly instead of timing out.
+      </p>
+      <p style="max-width:70ch;">
+        Every <code>shiki capture</code> invocation tries that socket first. If a TUI answers, the
+        new note appears live in NOTES (when you're already looking at that notebook's root) with
+        no keypress needed, and the capture is recorded in the TUI's own log history
+        (<code>leader</code> then <code>l</code>) — so a capture that happened while nobody was
+        watching the screen still leaves a trace, the same way a background git sync result does.
+        If nothing answers (no daemon running, or it answered "disabled"), the command falls
+        straight through to writing the file directly to disk — the exact same underlying
+        note-creation code path <code>shiki new</code> uses, so the two are never out of sync with
+        each other. The command's own output always tells you which path it actually took:
       </p>
       <pre class="code">$ shiki capture "buy milk"
 captured (daemon): /home/you/notes/personal/capture-2026-08-10-15-35.md   # a running TUI picked it up live
@@ -650,46 +677,105 @@ captured: /home/you/notes/personal/capture-2026-08-10-15-35.md            # writ
         already-open TUI finds out immediately. Toggling it back on later reuses the same listener
         thread rather than restarting anything — the daemon, once started this session, never
         actually shuts down; off just means it answers "disabled" to new connections instead of
-        processing them.
+        processing them, with no rebind/reconnect step needed to turn it back on.
       </p>
       <p style="max-width:70ch;">
-        <code>shiki capture --check</code> reports whether a daemon is reachable right now without
-        capturing anything (and without touching stdin) — meant for a status-bar module or launcher
-        script that wants to show "capture: on"/"capture: off" before committing to a real capture.
-        It exits <code>0</code> when a daemon answered (reachable at all means a TUI process
-        exists, regardless of whether it said enabled or disabled) and non-zero otherwise, so
-        <code>shiki capture --check &amp;&amp; ...</code> composes naturally in a script;
-        <code>--json</code> emits <code>{"reachable": true|false, "enabled": true|false}</code>.
-        Every capture handled by the daemon is also recorded in the TUI's own log history
-        (<code>leader</code> then <code>l</code>), so a capture that happened while nobody was
-        watching the screen still leaves a trace, the same way a background git sync result does.
+        <code>shiki capture --check</code> exists specifically for the "is anything even listening"
+        question — a status-bar module can poll it every so often and show a different icon for
+        "no TUI running" vs. "TUI running, daemon toggled off" vs. "live," without ever performing
+        an actual capture just to find that out.
       </p>
+
+      <h3 id="capture-undo">Undo</h3>
       <p style="max-width:70ch;">
         <code>shiki capture --undo</code> reverses the single most recent capture — a plain note is
-        moved to trash (restorable exactly like any other deleted note); a <code>--daily</code>
-        append instead strips exactly the bullet that was added off the end of the daily note's
-        body, and only if the body still ends with it verbatim — if the daily note was edited in
-        between, undo refuses rather than risk removing content you actually meant to keep. This is
-        a <em>one-slot</em> undo, not a stack, same simplicity level as <code>leader+u</code> (undo
-        delete): a second <code>--undo</code> in a row reports "nothing to undo" rather than
-        reaching further back. The record backing it
-        (<code>~/.config/shiki/last-capture.toml</code>) is shared between the daemon and the
-        standalone fallback, so undo works the same regardless of which one made the original
-        capture — it tries the daemon first (for a live TUI refresh if the reverted item was on
-        screen), then falls back to reversing it directly.
+        moved to trash (restorable exactly like any other deleted note, via the same trash
+        mechanism <code>d</code> in NOTES already uses); a <code>--daily</code> append instead
+        strips exactly the bullet that was added off the end of the daily note's body, and only if
+        the body still ends with it verbatim — if the daily note was edited in between, undo
+        refuses with a clear error rather than risk removing content you actually meant to keep.
+        This is a <em>one-slot</em> undo, not a stack, same simplicity level as
+        <code>leader+u</code> (undo delete) in the TUI itself: a second <code>--undo</code> in a
+        row reports "nothing to undo" rather than reaching further back into history.
       </p>
+      <p style="max-width:70ch;">
+        The record backing it (<code>~/.config/shiki/last-capture.toml</code>) is shared between
+        the daemon and the standalone fallback — whichever one performed the original capture
+        writes to the exact same file, so <code>--undo</code> works identically no matter which
+        path made it. It tries the daemon first, the same way a capture itself does (so a live TUI
+        refreshes immediately if the reverted item was on screen), then falls back to reversing it
+        directly through that shared file if nothing answers.
+      </p>
+
       <div class="doc-callout">
         <strong>Encrypted notebooks need to already be unlocked in the TUI.</strong>
         <p>
-          Capturing into an encrypted notebook only works through the daemon if that notebook is
-          already unlocked in the running TUI this session — the background listener thread can't
-          itself pop up a passphrase prompt, so it replies with a clear "locked" error instead of
-          hanging or writing plaintext, and <code>shiki capture</code> reports that error rather
-          than silently falling back. Run <code>shiki capture</code> from a plain terminal (no
-          daemon involved) against an encrypted, locked notebook and it prompts for the passphrase
-          interactively instead, same as <code>shiki new</code>.
+          Capturing into (or undoing a capture in) an encrypted notebook only works through the
+          daemon if that notebook is already unlocked in the running TUI this session — the
+          background listener thread can't itself pop up a passphrase prompt, so it replies with a
+          clear "locked" error instead of hanging or writing plaintext, and <code>shiki capture</code>
+          reports that error rather than silently falling back to a plaintext write. Run
+          <code>shiki capture</code> from a plain terminal (no daemon involved) against an
+          encrypted, locked notebook and it prompts for the passphrase interactively instead, same
+          as <code>shiki new</code>.
         </p>
       </div>
+
+      <h3 id="capture-recipes">Wiring it into external launchers</h3>
+      <p style="max-width:70ch;">
+        These are starting points, not the only way to do it — anything that can run a shell
+        command can drive <code>shiki capture</code>.
+      </p>
+      <p class="muted" style="font-size:0.9rem;"><strong>Linux — rofi/wofi bound to a window-manager hotkey</strong></p>
+      <pre class="code">#!/usr/bin/env bash
+# ~/.local/bin/shiki-capture-rofi.sh — bind this to a hotkey in your WM config
+text=$(rofi -dmenu -p "capture")   # swap for `wofi --dmenu` on Wayland
+[ -n "$text" ] && shiki capture "$text"</pre>
+      <pre class="code"># i3/sway config
+bindsym $mod+c exec ~/.local/bin/shiki-capture-rofi.sh</pre>
+      <p class="muted" style="font-size:0.9rem;"><strong>Linux — a waybar module with a live status indicator</strong></p>
+      <pre class="code">// ~/.config/waybar/config
+"custom/capture": {
+  "exec": "shiki capture --check --json | jq -r 'if .reachable then (if .enabled then \"captured\" else \"idle\" end) else \"off\" end'",
+  "interval": 30,
+  "on-click": "rofi -dmenu -p capture | xargs -r shiki capture"
+}</pre>
+      <p class="muted" style="font-size:0.9rem;"><strong>macOS — a Raycast script command</strong></p>
+      <pre class="code">#!/bin/bash
+# @raycast.title Quick Capture
+# @raycast.mode fullOutput
+# @raycast.icon 📝
+# @raycast.argument1 { "type": "text", "placeholder": "capture text" }
+shiki capture "$1"</pre>
+      <p class="muted" style="font-size:0.9rem;"><strong>Windows — an AutoHotkey global hotkey</strong></p>
+      <pre class="code">; Ctrl+Shift+C anywhere in Windows
+^+c::
+InputBox, text, shiki capture, Quick note:
+if (text != "")
+    RunWait, shiki.exe capture "%text%",, Hide
+return</pre>
+      <p style="max-width:70ch;">
+        Alfred (macOS) and PowerToys Run (Windows) both support the same idea via their own
+        "script filter"/"custom action" mechanisms — point either one at the same one-line
+        <code>shiki capture "{query}"</code> command. A browser extension is the one integration
+        that needs more than a shell one-liner (extensions can't spawn arbitrary processes
+        directly); it would use
+        <a href="https://developer.chrome.com/docs/extensions/develop/concepts/native-messaging" target="_blank" rel="noopener">Native Messaging</a>
+        to launch a small native host process that in turn runs <code>shiki capture</code> — not
+        something shiki ships today, but the exact same command underneath either way.
+      </p>
+
+      <h3>Troubleshooting</h3>
+      <table class="ref-table">
+        <thead><tr><th>Symptom</th><th>What's going on / what to do</th></tr></thead>
+        <tbody>
+          <tr><td>Always prints <code>captured:</code>, never <code>captured (daemon):</code></td><td>No TUI has the daemon enabled right now. Run <code>shiki capture --check</code> to confirm — if it says "not reachable," open the TUI and toggle <code>enable_capture_daemon</code> on in Settings (GENERAL tab).</td></tr>
+          <tr><td><code>shiki capture --undo</code> says "nothing to undo"</td><td>Either nothing has been captured yet this "session" (the record is a single slot, not a history — see <a href="#capture-undo">Undo</a>), or a previous <code>--undo</code> already consumed it.</td></tr>
+          <tr><td><code>shiki capture --undo</code> says the daily note "has changed since that capture"</td><td>The daily note was edited (by hand, or by another capture) after the one you're trying to undo — undo refuses on purpose rather than risk stripping content you meant to keep. Edit the file directly if you need to remove that specific line.</td></tr>
+          <tr><td>Capture landed in the wrong notebook</td><td>Check for accidental content-prefix routing — if your text happens to start with <code>"something: "</code> and a notebook named <code>something</code> exists, it routes there automatically. Pass <code>-n &lt;notebook&gt;</code> explicitly to override it.</td></tr>
+          <tr><td>Encrypted notebook: "locked" error via the daemon</td><td>Expected — a background thread can't prompt for a passphrase. Unlock that notebook in the TUI first, or run <code>shiki capture</code> from a plain terminal instead (it prompts interactively there).</td></tr>
+        </tbody>
+      </table>
     </div>
   </section>
 

--- a/docs/documentation.html
+++ b/docs/documentation.html
@@ -94,6 +94,7 @@
       <a href="#modes">Modes</a>
       <a href="#keybindings">Keybindings</a>
       <a href="#cli">CLI</a>
+      <a href="#capture">Quick capture</a>
       <a href="#encryption">Encryption</a>
       <a href="#filesystem">Filesystem</a>
       <a href="#note-format">Note format</a>
@@ -497,6 +498,8 @@ shiki list --json         # list/search/show all take --json for scripting (list
 shiki show &lt;note&gt;         # show rendered content (ANSI)
 shiki edit &lt;note&gt;         # edit with $EDITOR
 shiki search &lt;query&gt;      # search and show results
+shiki capture "quick idea"       # near-instant note capture, no $EDITOR, no TUI drawn
+shiki capture "text" -n work     # capture into a specific notebook instead of default_notebook
 shiki tasks               # every pending checkbox task across notebooks, urgency-sorted
 shiki tasks --overdue --count  # just the number — made for waybar/polybar/tmux status modules
 shiki tasks --today --json     # machine-readable, with due/overdue/location per task
@@ -557,6 +560,66 @@ shiki doctor              # environment check: config, data dir, git, editor, te
           resolving to the same path on disk; <code>git.remote_template</code> containing its
           <code>{notebook}</code> placeholder; and <code>git.sign_commits</code> having an actual
           signing key configured.
+        </p>
+      </div>
+    </div>
+  </section>
+
+  <section id="capture">
+    <div class="container">
+      <h2>Quick capture (<code>shiki capture</code> + optional daemon)</h2>
+      <p style="max-width:70ch;">
+        <code>shiki capture "some text"</code> creates a note with no ceremony — no
+        <code>$EDITOR</code> spawned, no TUI drawn, just a single line of output. It's meant to be
+        wired into things <em>outside</em> shiki entirely: a rofi/wofi prompt bound to an OS
+        hotkey, a waybar/polybar click action, a Raycast/Alfred script command, an AutoHotkey
+        shortcut on Windows — anything that can shell out. Shiki can't register a global OS hotkey
+        itself from a terminal app; <code>shiki capture</code> is the one command every one of
+        those launchers just needs to call.
+      </p>
+      <p style="max-width:70ch;">
+        By default it targets <code>general.default_notebook</code> (auto-created if it doesn't
+        exist yet, same as <code>shiki new</code>), with an auto-generated title
+        (<code>Capture 2026-08-10 15:35</code>, no title prompt) so there's nothing to type but the
+        note's actual content. <code>-n &lt;notebook&gt;</code> overrides the target, same flag as
+        <code>shiki new</code>/<code>shiki daily</code>.
+      </p>
+      <pre class="code">shiki capture "buy milk"          # -> personal/capture-2026-08-10-15-35.md
+shiki capture "call Ana" -n work  # -> work/capture-....md instead</pre>
+      <p style="max-width:70ch;">
+        <strong>The optional daemon</strong> (<code>general.enable_capture_daemon</code>, off by
+        default — toggle it from <code>leader+s</code> → GENERAL →
+        <code>enable_capture_daemon</code>) makes a <em>running</em> TUI aware of captures the
+        instant they happen, instead of only writing to disk unnoticed until the next manual
+        reload. With it on, the TUI listens on a local TCP loopback port
+        (<code>127.0.0.1</code>, OS-assigned, recorded in
+        <code>~/.config/shiki/capture.port</code>); <code>shiki capture</code> tries that socket
+        first, and if a TUI answers, the new note appears live in NOTES (when you're already
+        looking at that notebook's root) with no keypress needed. The command's own output tells
+        you which path it took:
+      </p>
+      <pre class="code">$ shiki capture "buy milk"
+captured (daemon): /home/you/notes/personal/capture-2026-08-10-15-35.md   # a running TUI picked it up live
+$ shiki capture "buy milk"
+captured: /home/you/notes/personal/capture-2026-08-10-15-35.md            # written straight to disk, no TUI (or daemon off) noticed</pre>
+      <p style="max-width:70ch;">
+        Turning the daemon off doesn't turn <em>capture</em> off — <code>shiki capture</code>
+        always works, with or without a TUI running; the toggle only controls whether an
+        already-open TUI finds out immediately. Toggling it back on later reuses the same listener
+        thread rather than restarting anything — the daemon, once started this session, never
+        actually shuts down; off just means it answers "disabled" to new connections instead of
+        processing them.
+      </p>
+      <div class="doc-callout">
+        <strong>Encrypted notebooks need to already be unlocked in the TUI.</strong>
+        <p>
+          Capturing into an encrypted notebook only works through the daemon if that notebook is
+          already unlocked in the running TUI this session — the background listener thread can't
+          itself pop up a passphrase prompt, so it replies with a clear "locked" error instead of
+          hanging or writing plaintext, and <code>shiki capture</code> reports that error rather
+          than silently falling back. Run <code>shiki capture</code> from a plain terminal (no
+          daemon involved) against an encrypted, locked notebook and it prompts for the passphrase
+          interactively instead, same as <code>shiki new</code>.
         </p>
       </div>
     </div>
@@ -681,6 +744,7 @@ shiki doctor              # environment check: config, data dir, git, editor, te
 ├── keybindings.toml       # custom shortcuts (optional)
 ├── theme.toml             # custom theme (optional)
 ├── shiki.log              # persistent status/log history (leader+l to view, x to clear)
+├── capture.port           # port the capture daemon is listening on (only while a TUI has it enabled)
 ├── trash/                 # deleted notes/folders, restorable with leader+u (see below)
 │   └── &lt;notebook&gt;/
 └── templates/             # templates
@@ -805,6 +869,7 @@ Content in **markdown**.
           <tr><td><code>editor</code></td><td><code>$EDITOR</code>, then <code>"nvim"</code></td><td>The external editor <code>E</code> opens. Any shell command works, including one with flags, e.g. <code>"code --wait"</code></td></tr>
           <tr><td><code>daily_template</code></td><td><code>"daily"</code></td><td>Which template (by filename, without <code>.md</code>) <code>t</code>/<code>shiki daily</code> uses for a new daily note</td></tr>
           <tr><td><code>use_favorite_editor</code></td><td><code>false</code></td><td>When true, <code>i</code> opens your OS's detected default text editor (from <code>$VISUAL</code>/<code>$EDITOR</code>, or the desktop's own file-type default) instead of the built-in inline editor — same effect as pressing <code>E</code>, just on the more convenient key. Toggle on the fly with <code>leader</code> then <code>e</code>, no editing required</td></tr>
+          <tr><td><code>enable_capture_daemon</code></td><td><code>false</code></td><td>When true, the TUI listens on a local loopback port so external <code>shiki capture "text"</code> invocations land here live instead of only writing to disk unnoticed — <code>shiki capture</code> itself always works either way, this only controls whether an already-open TUI finds out immediately. Toggle from Settings → GENERAL, see <a href="#capture">Quick capture</a> above</td></tr>
           <tr><td><code>mouse_drag_selection</code></td><td><code>true</code></td><td>A plain click on a note's body in PREVIEW jumps into edit mode with the cursor on that line; click-and-drag instead selects text and copies it to the clipboard as soon as you release the mouse button — the same clipboard mechanism the logs modal's <code>y</code>/<code>c</code> uses</td></tr>
           <tr><td><code>data_dir</code></td><td>unset (platform default)</td><td>Point the <em>entire</em> notebooks root somewhere else — an absolute path to an existing folder of markdown notes (an Obsidian vault, for instance) instead of <code>~/.local/share/shiki/</code>. Every notebook without its own <code>path</code> (below) lives as a subdirectory of this</td></tr>
           <tr><td><code>show_hints</code></td><td><code>true</code></td><td>Shows a small muted hint line under the input box for text prompts whose behavior isn't obvious from the title alone — currently just new-notebook, explaining that a git URL clones and a filesystem path adopts an existing directory</td></tr>
@@ -1093,6 +1158,12 @@ daily_template = "daily"
 # When true, `i` opens the OS's detected favorite editor (env $VISUAL/$EDITOR,
 # then the desktop's default text/plain handler) instead of the inline editor.
 use_favorite_editor = false
+# When true, the TUI listens on a local loopback port so external
+# `shiki capture "text"` invocations land here live instead of only
+# writing to disk unnoticed. `shiki capture` itself always works either
+# way — this only controls whether an already-open TUI finds out
+# immediately. Off by default; toggle from leader+s -> GENERAL.
+enable_capture_daemon = false
 # When true, click-and-drag over a note's body in PREVIEW selects text and
 # copies it to the clipboard (OSC 52, same mechanism as the logs modal's
 # `y`/`c`) as soon as the mouse button is released.

--- a/docs/documentation.html
+++ b/docs/documentation.html
@@ -500,6 +500,14 @@ shiki edit &lt;note&gt;         # edit with $EDITOR
 shiki search &lt;query&gt;      # search and show results
 shiki capture "quick idea"       # near-instant note capture, no $EDITOR, no TUI drawn
 shiki capture "text" -n work     # capture into a specific notebook instead of default_notebook
+echo "piped idea" | shiki capture      # reads the text from stdin when no argument is given
+shiki capture "call Ana" --tags work,idea   # comma-separated tags, same flag as `shiki new`
+shiki capture "call Ana" --daily      # appends as a bullet to today's daily note instead of a new note
+shiki capture "call Ana" --json       # emits {"path":..,"daemon":..,"daily":..} for scripts
+shiki capture --check                 # is a capture daemon reachable right now? exits non-zero if not
+shiki capture "meeting notes" --folder work/meetings -n work   # into a subfolder, not the notebook root
+shiki capture "work: call Ana"        # no -n given -> routed into the "work" notebook automatically
+shiki capture --undo                  # reverses the single most recent capture (any kind)
 shiki tasks               # every pending checkbox task across notebooks, urgency-sorted
 shiki tasks --overdue --count  # just the number — made for waybar/polybar/tmux status modules
 shiki tasks --today --json     # machine-readable, with due/overdue/location per task
@@ -582,10 +590,44 @@ shiki doctor              # environment check: config, data dir, git, editor, te
         exist yet, same as <code>shiki new</code>), with an auto-generated title
         (<code>Capture 2026-08-10 15:35</code>, no title prompt) so there's nothing to type but the
         note's actual content. <code>-n &lt;notebook&gt;</code> overrides the target, same flag as
-        <code>shiki new</code>/<code>shiki daily</code>.
+        <code>shiki new</code>/<code>shiki daily</code>. The text itself is a plain positional
+        argument; omit it entirely and shiki reads it from stdin instead
+        (<code>echo "idea" | shiki capture</code>), for wiring into another program's own output
+        rather than typing a literal string.
       </p>
       <pre class="code">shiki capture "buy milk"          # -> personal/capture-2026-08-10-15-35.md
 shiki capture "call Ana" -n work  # -> work/capture-....md instead</pre>
+      <p style="max-width:70ch;">
+        <code>--tags work,idea</code> sets tags on the created note, same flag/format as
+        <code>shiki new --tags</code>. <code>--daily</code> changes the target entirely: instead of
+        a new note, the text is appended as a <code>- </code> bullet under today's daily note
+        (created via the same machinery the <code>t</code> keybinding/<code>shiki daily</code>
+        already use — template + agenda section included on first creation, an already-existing
+        daily is just opened and appended to) — for treating the daily note as a running inbox for
+        the whole day rather than one note per capture. <code>--tags</code> is ignored when
+        <code>--daily</code> is also given, since an appended bullet has no frontmatter of its own
+        to carry tags on. <code>--json</code> emits
+        <code>{"path": "...", "daemon": true|false, "daily": true|false}</code> instead of the
+        plain sentence, for a script or browser extension that wants to act on the result without
+        string-matching <code>"captured (daemon): "</code>. <code>--folder work/meetings</code>
+        creates the note inside that subfolder of the notebook instead of its root (each path
+        segment validated the same way a notebook/folder name is — no <code>..</code>/empty
+        segments); ignored when <code>--daily</code> is given, since a daily note's path is
+        always fixed.
+      </p>
+      <div class="doc-callout">
+        <strong>Content-prefix routing</strong>
+        <p>
+          If no <code>-n</code> was given and the text itself looks like
+          <code>"&lt;notebook&gt;: &lt;rest&gt;"</code> where <code>&lt;notebook&gt;</code>
+          case-insensitively matches a real, existing notebook, that notebook is used
+          automatically and the prefix is stripped from the saved text —
+          <code>shiki capture "work: call Ana"</code> needs no <code>-n work</code> at all. An
+          explicit <code>-n</code> always wins outright and skips this check entirely, so a
+          genuine note that happens to start with <code>"word: "</code> is never mis-routed as
+          long as a target was actually given.
+        </p>
+      </div>
       <p style="max-width:70ch;">
         <strong>The optional daemon</strong> (<code>general.enable_capture_daemon</code>, off by
         default — toggle it from <code>leader+s</code> → GENERAL →
@@ -609,6 +651,32 @@ captured: /home/you/notes/personal/capture-2026-08-10-15-35.md            # writ
         thread rather than restarting anything — the daemon, once started this session, never
         actually shuts down; off just means it answers "disabled" to new connections instead of
         processing them.
+      </p>
+      <p style="max-width:70ch;">
+        <code>shiki capture --check</code> reports whether a daemon is reachable right now without
+        capturing anything (and without touching stdin) — meant for a status-bar module or launcher
+        script that wants to show "capture: on"/"capture: off" before committing to a real capture.
+        It exits <code>0</code> when a daemon answered (reachable at all means a TUI process
+        exists, regardless of whether it said enabled or disabled) and non-zero otherwise, so
+        <code>shiki capture --check &amp;&amp; ...</code> composes naturally in a script;
+        <code>--json</code> emits <code>{"reachable": true|false, "enabled": true|false}</code>.
+        Every capture handled by the daemon is also recorded in the TUI's own log history
+        (<code>leader</code> then <code>l</code>), so a capture that happened while nobody was
+        watching the screen still leaves a trace, the same way a background git sync result does.
+      </p>
+      <p style="max-width:70ch;">
+        <code>shiki capture --undo</code> reverses the single most recent capture — a plain note is
+        moved to trash (restorable exactly like any other deleted note); a <code>--daily</code>
+        append instead strips exactly the bullet that was added off the end of the daily note's
+        body, and only if the body still ends with it verbatim — if the daily note was edited in
+        between, undo refuses rather than risk removing content you actually meant to keep. This is
+        a <em>one-slot</em> undo, not a stack, same simplicity level as <code>leader+u</code> (undo
+        delete): a second <code>--undo</code> in a row reports "nothing to undo" rather than
+        reaching further back. The record backing it
+        (<code>~/.config/shiki/last-capture.toml</code>) is shared between the daemon and the
+        standalone fallback, so undo works the same regardless of which one made the original
+        capture — it tries the daemon first (for a live TUI refresh if the reverted item was on
+        screen), then falls back to reversing it directly.
       </p>
       <div class="doc-callout">
         <strong>Encrypted notebooks need to already be unlocked in the TUI.</strong>
@@ -745,6 +813,7 @@ captured: /home/you/notes/personal/capture-2026-08-10-15-35.md            # writ
 ├── theme.toml             # custom theme (optional)
 ├── shiki.log              # persistent status/log history (leader+l to view, x to clear)
 ├── capture.port           # port the capture daemon is listening on (only while a TUI has it enabled)
+├── last-capture.toml      # backs `shiki capture --undo` — removed once undone
 ├── trash/                 # deleted notes/folders, restorable with leader+u (see below)
 │   └── &lt;notebook&gt;/
 └── templates/             # templates

--- a/shiki-cli/src/commands/capture.rs
+++ b/shiki-cli/src/commands/capture.rs
@@ -1,0 +1,126 @@
+use std::io::{Read, Write};
+use std::net::TcpStream;
+use std::time::Duration;
+
+use anyhow::{Context, Result};
+use shiki_config::Config;
+use shiki_core::NotebookStore;
+
+use super::unlock_if_encrypted;
+
+/// A parsed one-line reply from the capture daemon (`shiki-tui/src/
+/// capture.rs`) — `OK <path>` or `ERR <message>`.
+enum DaemonResponse {
+    Ok(String),
+    Err(String),
+}
+
+fn parse_port_file(contents: &str) -> Option<u16> {
+    contents.trim().parse().ok()
+}
+
+fn parse_response_line(line: &str) -> Option<DaemonResponse> {
+    let line = line.trim_end_matches(['\r', '\n']);
+    if let Some(rest) = line.strip_prefix("OK ") {
+        return Some(DaemonResponse::Ok(rest.to_string()));
+    }
+    line.strip_prefix("ERR ")
+        .map(|rest| DaemonResponse::Err(rest.to_string()))
+}
+
+/// Captures a quick note. Tries a running TUI's capture daemon first — if
+/// one answers, its response is authoritative (an explicit `locked: ...`
+/// refusal is reported as an error rather than silently bypassed by
+/// falling back to a direct write, which could otherwise duplicate work or
+/// confuse the user about which passphrase prompt they're about to hit).
+/// Anything else (no daemon running, the daemon replying "disabled", a
+/// connection timeout) falls back to writing straight to disk — the same
+/// path `shiki new` already uses, including the interactive passphrase
+/// prompt for an encrypted notebook, since a human is sitting at this
+/// terminal in that case.
+pub fn run(store: &NotebookStore, config: &Config, notebook: &str, text: &str) -> Result<()> {
+    match try_daemon(text) {
+        Some(DaemonResponse::Ok(path)) => {
+            println!("captured (daemon): {path}");
+            return Ok(());
+        }
+        Some(DaemonResponse::Err(msg)) if msg.starts_with("locked:") => {
+            anyhow::bail!("{msg}");
+        }
+        Some(DaemonResponse::Err(_)) | None => {
+            // Daemon disabled/unreachable/refused for a non-lock reason —
+            // fall through to the direct-write path below.
+        }
+    }
+
+    let nb = match store.get(notebook) {
+        Ok(nb) => nb,
+        Err(_) => store
+            .create(notebook)
+            .with_context(|| format!("could not create notebook '{notebook}'"))?,
+    };
+    let nb = unlock_if_encrypted(config, nb)?;
+    let title = format!("Capture {}", chrono::Local::now().format("%Y-%m-%d %H:%M"));
+    let note = nb.create_note(&title, text)?;
+    println!("captured: {}", note.path.display());
+    Ok(())
+}
+
+/// `None` means "nothing to connect to" (no port file, unparsable
+/// content, connection refused/timed out) — the caller treats that
+/// identically to "daemon disabled". `Some` means the daemon actually
+/// answered and its response must be respected.
+fn try_daemon(text: &str) -> Option<DaemonResponse> {
+    let port_path = Config::default_capture_port_path().ok()?;
+    let contents = std::fs::read_to_string(port_path).ok()?;
+    let port = parse_port_file(&contents)?;
+
+    let mut stream =
+        TcpStream::connect_timeout(&([127, 0, 0, 1], port).into(), Duration::from_millis(300))
+            .ok()?;
+    let _ = stream.set_write_timeout(Some(Duration::from_secs(3)));
+    let _ = stream.set_read_timeout(Some(Duration::from_secs(3)));
+    stream.write_all(text.as_bytes()).ok()?;
+    let _ = stream.shutdown(std::net::Shutdown::Write);
+
+    let mut response = String::new();
+    stream.read_to_string(&mut response).ok()?;
+    parse_response_line(&response)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_port_file_accepts_valid_content() {
+        assert_eq!(parse_port_file("54321"), Some(54321));
+        assert_eq!(parse_port_file("54321\n"), Some(54321));
+        assert_eq!(parse_port_file("  54321  "), Some(54321));
+    }
+
+    #[test]
+    fn parse_port_file_rejects_malformed_content() {
+        assert_eq!(parse_port_file(""), None);
+        assert_eq!(parse_port_file("not-a-port"), None);
+        assert_eq!(parse_port_file("-1"), None);
+    }
+
+    #[test]
+    fn parse_response_line_recognizes_ok_and_err() {
+        match parse_response_line("OK /tmp/note.md\n") {
+            Some(DaemonResponse::Ok(path)) => assert_eq!(path, "/tmp/note.md"),
+            _ => panic!("expected Ok"),
+        }
+        match parse_response_line("ERR locked: notebook 'personal' is locked\n") {
+            Some(DaemonResponse::Err(msg)) => assert!(msg.starts_with("locked:")),
+            _ => panic!("expected Err"),
+        }
+    }
+
+    #[test]
+    fn parse_response_line_rejects_unrecognized_content() {
+        assert!(parse_response_line("garbage").is_none());
+        assert!(parse_response_line("").is_none());
+    }
+}

--- a/shiki-cli/src/commands/capture.rs
+++ b/shiki-cli/src/commands/capture.rs
@@ -3,13 +3,15 @@ use std::net::TcpStream;
 use std::time::Duration;
 
 use anyhow::{Context, Result};
-use shiki_config::Config;
+use shiki_config::{Config, LastCapture};
 use shiki_core::NotebookStore;
 
 use super::unlock_if_encrypted;
 
 /// A parsed one-line reply from the capture daemon (`shiki-tui/src/
-/// capture.rs`) — `OK <path>` or `ERR <message>`.
+/// capture.rs`) — `OK <payload>` or `ERR <message>`. What `<payload>`
+/// means depends on which request was sent: a note path for `CAPTURE`/
+/// `UNDO`, or `enabled`/`disabled` for `PING`.
 enum DaemonResponse {
     Ok(String),
     Err(String),
@@ -28,6 +30,37 @@ fn parse_response_line(line: &str) -> Option<DaemonResponse> {
         .map(|rest| DaemonResponse::Err(rest.to_string()))
 }
 
+/// Builds a `CAPTURE` request — see `shiki-tui/src/capture.rs`'s module doc
+/// comment for the exact wire format. Header lines are only emitted when
+/// actually needed, so the common case (plain capture, no flags) stays a
+/// minimal two-line request. `notebook` is only sent when the caller
+/// explicitly passed `-n` — omitting it lets the daemon apply its own
+/// content-prefix routing/`default_notebook` fallback instead.
+fn build_capture_request(
+    text: &str,
+    daily: bool,
+    tags: &[String],
+    notebook: Option<&str>,
+    folder: Option<&str>,
+) -> String {
+    let mut req = String::from("CAPTURE\n");
+    if daily {
+        req.push_str("daily=1\n");
+    }
+    if !tags.is_empty() {
+        req.push_str(&format!("tags={}\n", tags.join(",")));
+    }
+    if let Some(notebook) = notebook {
+        req.push_str(&format!("notebook={notebook}\n"));
+    }
+    if let Some(folder) = folder {
+        req.push_str(&format!("folder={folder}\n"));
+    }
+    req.push('\n');
+    req.push_str(text);
+    req
+}
+
 /// Captures a quick note. Tries a running TUI's capture daemon first — if
 /// one answers, its response is authoritative (an explicit `locked: ...`
 /// refusal is reported as an error rather than silently bypassed by
@@ -35,13 +68,44 @@ fn parse_response_line(line: &str) -> Option<DaemonResponse> {
 /// confuse the user about which passphrase prompt they're about to hit).
 /// Anything else (no daemon running, the daemon replying "disabled", a
 /// connection timeout) falls back to writing straight to disk — the same
-/// path `shiki new` already uses, including the interactive passphrase
-/// prompt for an encrypted notebook, since a human is sitting at this
-/// terminal in that case.
-pub fn run(store: &NotebookStore, config: &Config, notebook: &str, text: &str) -> Result<()> {
-    match try_daemon(text) {
+/// path `shiki new`/`shiki daily` already use, including the interactive
+/// passphrase prompt for an encrypted notebook, since a human is sitting
+/// at this terminal in that case.
+#[allow(clippy::too_many_arguments)]
+pub fn run(
+    store: &NotebookStore,
+    config: &Config,
+    notebook: Option<String>,
+    text: Option<String>,
+    tags: &[String],
+    daily: bool,
+    json: bool,
+    check: bool,
+    undo: bool,
+    folder: Option<String>,
+) -> Result<()> {
+    if check {
+        return run_check(json);
+    }
+    if undo {
+        return run_undo(json);
+    }
+
+    let text = match text {
+        Some(t) => t,
+        None => {
+            let mut buf = String::new();
+            std::io::stdin()
+                .read_to_string(&mut buf)
+                .context("failed to read capture text from stdin")?;
+            buf
+        }
+    };
+
+    let request = build_capture_request(&text, daily, tags, notebook.as_deref(), folder.as_deref());
+    match try_daemon(&request) {
         Some(DaemonResponse::Ok(path)) => {
-            println!("captured (daemon): {path}");
+            print_capture_result(&path, true, daily, json);
             return Ok(());
         }
         Some(DaemonResponse::Err(msg)) if msg.starts_with("locked:") => {
@@ -53,24 +117,245 @@ pub fn run(store: &NotebookStore, config: &Config, notebook: &str, text: &str) -
         }
     }
 
-    let nb = match store.get(notebook) {
+    let existing_notebooks: Vec<String> = store
+        .list()
+        .unwrap_or_default()
+        .into_iter()
+        .map(|nb| nb.name)
+        .collect();
+    let (target, text) = match notebook.as_deref() {
+        Some(name) => (name.to_string(), text.as_str()),
+        None => shiki_core::notebook::route_by_prefix(&text, &existing_notebooks)
+            .unwrap_or_else(|| (config.general.default_notebook.clone(), &text)),
+    };
+
+    let nb = match store.get(&target) {
         Ok(nb) => nb,
         Err(_) => store
-            .create(notebook)
-            .with_context(|| format!("could not create notebook '{notebook}'"))?,
+            .create(&target)
+            .with_context(|| format!("could not create notebook '{target}'"))?,
     };
     let nb = unlock_if_encrypted(config, nb)?;
-    let title = format!("Capture {}", chrono::Local::now().format("%Y-%m-%d %H:%M"));
-    let note = nb.create_note(&title, text)?;
-    println!("captured: {}", note.path.display());
+
+    let (path, record) = if daily {
+        capture_into_daily(store, config, &nb, text)?
+    } else {
+        capture_into_new_note(&nb, text, tags, folder.as_deref())?
+    };
+    if let Ok(record_path) = Config::default_last_capture_path() {
+        let _ = record.save(&record_path);
+    }
+    print_capture_result(&path.display().to_string(), false, daily, json);
     Ok(())
+}
+
+fn capture_into_new_note(
+    nb: &shiki_core::Notebook,
+    text: &str,
+    tags: &[String],
+    folder: Option<&str>,
+) -> Result<(std::path::PathBuf, LastCapture)> {
+    let title = format!("Capture {}", chrono::Local::now().format("%Y-%m-%d %H:%M"));
+    let mut note = match folder {
+        Some(folder) => {
+            let relative = shiki_core::notebook::validate_relative_path(folder)?;
+            nb.create_note_in(&relative, &title, text)?
+        }
+        None => nb.create_note(&title, text)?,
+    };
+    if !tags.is_empty() {
+        note.frontmatter.tags = tags.to_vec();
+        note.save_with_crypto(nb.crypto.as_ref())?;
+    }
+    let record = LastCapture::Note {
+        notebook: nb.name.clone(),
+        path: note.path.display().to_string(),
+    };
+    Ok((note.path, record))
+}
+
+fn capture_into_daily(
+    store: &NotebookStore,
+    config: &Config,
+    nb: &shiki_core::Notebook,
+    text: &str,
+) -> Result<(std::path::PathBuf, LastCapture)> {
+    let today = chrono::Local::now().date_naive();
+    let templates_dir = Config::default_templates_dir()?;
+    let agenda = config
+        .general
+        .daily_agenda
+        .then(|| {
+            store
+                .all_notes()
+                .ok()
+                .and_then(|pool| shiki_core::tasks::agenda_section(&pool, today))
+        })
+        .flatten();
+    let mut note = shiki_core::daily::create_or_open(
+        nb,
+        today,
+        &templates_dir,
+        &config.general.daily_template,
+        agenda.as_deref(),
+    )?;
+    if !note.body.ends_with('\n') {
+        note.body.push('\n');
+    }
+    let appended = format!("- {text}\n");
+    note.body.push_str(&appended);
+    note.save_with_crypto(nb.crypto.as_ref())?;
+    let record = LastCapture::DailyAppend {
+        notebook: nb.name.clone(),
+        path: note.path.display().to_string(),
+        appended,
+    };
+    Ok((note.path, record))
+}
+
+fn format_capture_result(path: &str, via_daemon: bool, daily: bool, json: bool) -> String {
+    if json {
+        format!(r#"{{"path": {path:?}, "daemon": {via_daemon}, "daily": {daily}}}"#)
+    } else if via_daemon {
+        format!("captured (daemon): {path}")
+    } else {
+        format!("captured: {path}")
+    }
+}
+
+fn print_capture_result(path: &str, via_daemon: bool, daily: bool, json: bool) {
+    println!("{}", format_capture_result(path, via_daemon, daily, json));
+}
+
+/// `shiki capture --undo`: reverses the single most recent capture,
+/// wherever it landed. Tries the daemon first (`UNDO`) so a live TUI
+/// refreshes immediately if the reverted note was on screen; falls back to
+/// a standalone undo (same `LastCapture` record, shared with the daemon)
+/// when nothing answers.
+fn run_undo(json: bool) -> Result<()> {
+    match try_daemon("UNDO\n\n") {
+        Some(DaemonResponse::Ok(path)) => {
+            print_undo_result(&path, true, json);
+            return Ok(());
+        }
+        Some(DaemonResponse::Err(msg)) if msg.starts_with("locked:") => {
+            anyhow::bail!("{msg}");
+        }
+        Some(DaemonResponse::Err(_)) | None => {
+            // Unreachable, disabled, or a non-lock error (e.g. "nothing to
+            // undo") — falls through to the standalone path, which reads
+            // the exact same shared record and reports the same outcome.
+        }
+    }
+    run_undo_standalone(json)
+}
+
+fn run_undo_standalone(json: bool) -> Result<()> {
+    let record_path = Config::default_last_capture_path()?;
+    let Some(record) = LastCapture::load(&record_path) else {
+        if json {
+            println!(r#"{{"undone": false, "error": "nothing to undo"}}"#);
+        } else {
+            println!("nothing to undo");
+        }
+        anyhow::bail!("nothing to undo");
+    };
+
+    let (notebook, path) = match &record {
+        LastCapture::Note { notebook, path } => (notebook.clone(), path.clone()),
+        LastCapture::DailyAppend { notebook, path, .. } => (notebook.clone(), path.clone()),
+    };
+
+    let config_path = Config::default_path()?;
+    let config = Config::load_or_init(&config_path)?;
+    let data_dir = match config.general.data_dir.as_ref() {
+        Some(dir) => std::path::PathBuf::from(dir),
+        None => Config::default_data_dir()?,
+    };
+    let store = NotebookStore::new_with_custom_paths(data_dir, config.notebook_custom_paths());
+    let nb = store
+        .get(&notebook)
+        .with_context(|| format!("notebook '{notebook}' not found"))?;
+
+    match &record {
+        LastCapture::Note { path, .. } => {
+            let trash_dir = Config::default_trash_dir()?.join(&notebook);
+            let suffix = chrono::Local::now().format("%Y%m%d%H%M%S%3f").to_string();
+            shiki_core::trash::move_to_trash(std::path::Path::new(path), &trash_dir, &suffix)
+                .with_context(|| format!("could not move '{path}' to trash"))?;
+        }
+        LastCapture::DailyAppend { path, appended, .. } => {
+            let nb = unlock_if_encrypted(&config, nb)?;
+            let mut note = shiki_core::Note::from_file_in_notebook_with_crypto(
+                std::path::Path::new(path),
+                &notebook,
+                nb.crypto.as_ref(),
+            )
+            .with_context(|| format!("could not read '{path}'"))?;
+            if !note.body.ends_with(appended.as_str()) {
+                anyhow::bail!("the daily note has changed since that capture — not undoing");
+            }
+            let new_len = note.body.len() - appended.len();
+            note.body.truncate(new_len);
+            note.save_with_crypto(nb.crypto.as_ref())?;
+        }
+    }
+
+    LastCapture::clear(&record_path);
+    print_undo_result(&path, false, json);
+    Ok(())
+}
+
+fn format_undo_result(path: &str, via_daemon: bool, json: bool) -> String {
+    if json {
+        format!(r#"{{"undone": true, "path": {path:?}, "daemon": {via_daemon}}}"#)
+    } else if via_daemon {
+        format!("undone (daemon): {path}")
+    } else {
+        format!("undone: {path}")
+    }
+}
+
+fn print_undo_result(path: &str, via_daemon: bool, json: bool) {
+    println!("{}", format_undo_result(path, via_daemon, json));
+}
+
+/// `shiki capture --check`: reports whether a capture daemon is reachable
+/// right now, without capturing anything or touching stdin — meant for a
+/// script/status-bar module to decide what to show (e.g. "capture: on" in
+/// waybar) before committing to an actual capture. Exits non-zero when
+/// unreachable, so `shiki capture --check && ...` composes naturally.
+fn run_check(json: bool) -> Result<()> {
+    let response = try_daemon("PING\n\n");
+    let (reachable, enabled) = match response {
+        Some(DaemonResponse::Ok(status)) => (true, status == "enabled"),
+        _ => (false, false),
+    };
+    println!("{}", format_check_result(reachable, enabled, json));
+    if !reachable {
+        anyhow::bail!("capture daemon not reachable");
+    }
+    Ok(())
+}
+
+fn format_check_result(reachable: bool, enabled: bool, json: bool) -> String {
+    if json {
+        format!(r#"{{"reachable": {reachable}, "enabled": {enabled}}}"#)
+    } else if reachable {
+        format!(
+            "daemon: reachable ({})",
+            if enabled { "enabled" } else { "disabled" }
+        )
+    } else {
+        "daemon: not reachable".to_string()
+    }
 }
 
 /// `None` means "nothing to connect to" (no port file, unparsable
 /// content, connection refused/timed out) — the caller treats that
 /// identically to "daemon disabled". `Some` means the daemon actually
 /// answered and its response must be respected.
-fn try_daemon(text: &str) -> Option<DaemonResponse> {
+fn try_daemon(request: &str) -> Option<DaemonResponse> {
     let port_path = Config::default_capture_port_path().ok()?;
     let contents = std::fs::read_to_string(port_path).ok()?;
     let port = parse_port_file(&contents)?;
@@ -80,7 +365,7 @@ fn try_daemon(text: &str) -> Option<DaemonResponse> {
             .ok()?;
     let _ = stream.set_write_timeout(Some(Duration::from_secs(3)));
     let _ = stream.set_read_timeout(Some(Duration::from_secs(3)));
-    stream.write_all(text.as_bytes()).ok()?;
+    stream.write_all(request.as_bytes()).ok()?;
     let _ = stream.shutdown(std::net::Shutdown::Write);
 
     let mut response = String::new();
@@ -122,5 +407,78 @@ mod tests {
     fn parse_response_line_rejects_unrecognized_content() {
         assert!(parse_response_line("garbage").is_none());
         assert!(parse_response_line("").is_none());
+    }
+
+    #[test]
+    fn build_capture_request_omits_absent_headers() {
+        assert_eq!(
+            build_capture_request("buy milk", false, &[], None, None),
+            "CAPTURE\n\nbuy milk"
+        );
+    }
+
+    #[test]
+    fn build_capture_request_includes_every_header_when_given() {
+        let tags = vec!["work".to_string(), "idea".to_string()];
+        assert_eq!(
+            build_capture_request("buy milk", true, &tags, Some("work"), Some("work/meetings")),
+            "CAPTURE\ndaily=1\ntags=work,idea\nnotebook=work\nfolder=work/meetings\n\nbuy milk"
+        );
+    }
+
+    #[test]
+    fn format_capture_result_plain_text_distinguishes_daemon_from_fallback() {
+        assert_eq!(
+            format_capture_result("/tmp/note.md", true, false, false),
+            "captured (daemon): /tmp/note.md"
+        );
+        assert_eq!(
+            format_capture_result("/tmp/note.md", false, false, false),
+            "captured: /tmp/note.md"
+        );
+    }
+
+    #[test]
+    fn format_capture_result_json_shape_is_stable() {
+        assert_eq!(
+            format_capture_result("/tmp/note.md", true, true, true),
+            r#"{"path": "/tmp/note.md", "daemon": true, "daily": true}"#
+        );
+    }
+
+    #[test]
+    fn format_undo_result_distinguishes_daemon_from_standalone_and_json() {
+        assert_eq!(
+            format_undo_result("/tmp/note.md", true, false),
+            "undone (daemon): /tmp/note.md"
+        );
+        assert_eq!(
+            format_undo_result("/tmp/note.md", false, false),
+            "undone: /tmp/note.md"
+        );
+        assert_eq!(
+            format_undo_result("/tmp/note.md", false, true),
+            r#"{"undone": true, "path": "/tmp/note.md", "daemon": false}"#
+        );
+    }
+
+    #[test]
+    fn format_check_result_matches_reachability_and_enabled_state() {
+        assert_eq!(
+            format_check_result(true, true, false),
+            "daemon: reachable (enabled)"
+        );
+        assert_eq!(
+            format_check_result(true, false, false),
+            "daemon: reachable (disabled)"
+        );
+        assert_eq!(
+            format_check_result(false, false, false),
+            "daemon: not reachable"
+        );
+        assert_eq!(
+            format_check_result(true, false, true),
+            r#"{"reachable": true, "enabled": false}"#
+        );
     }
 }

--- a/shiki-cli/src/commands/mod.rs
+++ b/shiki-cli/src/commands/mod.rs
@@ -1,3 +1,4 @@
+pub mod capture;
 pub mod config;
 pub mod daily;
 pub mod doctor;

--- a/shiki-cli/src/main.rs
+++ b/shiki-cli/src/main.rs
@@ -38,6 +38,17 @@ enum Commands {
         #[arg(long, value_delimiter = ',')]
         tags: Vec<String>,
     },
+    /// Captures a quick note with no editor and (almost) no ceremony —
+    /// tries a running TUI's capture daemon first (if it's enabled and
+    /// listening) so the note shows up there live, then falls back to
+    /// writing straight to disk if no daemon is reachable. Meant for
+    /// scripts/launchers (rofi, waybar, Raycast, hotkeys, etc.), not
+    /// interactive use.
+    Capture {
+        text: String,
+        #[arg(short, long)]
+        notebook: Option<String>,
+    },
     /// Lists the notes in a notebook
     List {
         #[arg(short = 'n', long)]
@@ -296,6 +307,10 @@ fn main() -> Result<()> {
 
     match cli.command {
         None => tui::launch(ctx.config, ctx.store),
+        Some(Commands::Capture { text, notebook }) => {
+            let notebook = ctx.notebook_name(notebook);
+            commands::capture::run(&ctx.store, &ctx.config, &notebook, &text)
+        }
         Some(Commands::New {
             title,
             notebook,

--- a/shiki-cli/src/main.rs
+++ b/shiki-cli/src/main.rs
@@ -45,9 +45,48 @@ enum Commands {
     /// scripts/launchers (rofi, waybar, Raycast, hotkeys, etc.), not
     /// interactive use.
     Capture {
-        text: String,
+        /// Text to capture. Omit it to read from stdin instead, e.g.
+        /// `echo "idea" | shiki capture`. Ignored (and not read) when
+        /// `--check`/`--undo` is given. If it starts with `"<notebook>:
+        /// "` and no `-n` was given, and `<notebook>` names a real
+        /// notebook, that notebook is used automatically (the prefix is
+        /// stripped from the saved text) — e.g. `shiki capture "work:
+        /// call Ana"`.
+        text: Option<String>,
+        /// Overrides both `general.default_notebook` and content-prefix
+        /// routing — always wins outright when given.
         #[arg(short, long)]
         notebook: Option<String>,
+        /// Comma-separated tags, e.g. `--tags work,idea`. Ignored when
+        /// `--daily` is given — an appended bullet has no frontmatter of
+        /// its own to tag.
+        #[arg(long, value_delimiter = ',')]
+        tags: Vec<String>,
+        /// Creates the note inside this subfolder of the notebook instead
+        /// of its root, e.g. `--folder work/meetings`. Ignored when
+        /// `--daily` is given — a daily note's path is always fixed.
+        #[arg(long)]
+        folder: Option<String>,
+        /// Appends the text as a bullet to today's daily note instead of
+        /// creating a new note — for using the daily note as a running
+        /// inbox rather than one note per capture.
+        #[arg(long)]
+        daily: bool,
+        /// Emits `{"path": ..., "daemon": ..., "daily": ...}` instead of a
+        /// plain sentence — for scripts/browser extensions.
+        #[arg(long)]
+        json: bool,
+        /// Reports whether a capture daemon is reachable right now and
+        /// exits — doesn't capture anything or read stdin. Exits non-zero
+        /// when unreachable, so `shiki capture --check && ...` composes.
+        #[arg(long, conflicts_with = "undo")]
+        check: bool,
+        /// Reverses the single most recent capture (whichever kind, from
+        /// either this machine's daemon or the standalone fallback) —
+        /// moves a plain note to trash, or strips the bullet back off a
+        /// `--daily` append. Doesn't touch stdin/text.
+        #[arg(long)]
+        undo: bool,
     },
     /// Lists the notes in a notebook
     List {
@@ -307,9 +346,35 @@ fn main() -> Result<()> {
 
     match cli.command {
         None => tui::launch(ctx.config, ctx.store),
-        Some(Commands::Capture { text, notebook }) => {
-            let notebook = ctx.notebook_name(notebook);
-            commands::capture::run(&ctx.store, &ctx.config, &notebook, &text)
+        Some(Commands::Capture {
+            text,
+            notebook,
+            tags,
+            folder,
+            daily,
+            json,
+            check,
+            undo,
+        }) => {
+            // Deliberately NOT resolved via `ctx.notebook_name` here, unlike
+            // every other command — `commands::capture::run` needs to know
+            // whether `-n` was actually given at all, since an explicit
+            // override always wins over content-prefix routing, which in
+            // turn wins over `default_notebook`. Collapsing that into an
+            // already-resolved `String` up front would make it
+            // indistinguishable from "the user typed `-n personal`".
+            commands::capture::run(
+                &ctx.store,
+                &ctx.config,
+                notebook,
+                text,
+                &tags,
+                daily,
+                json,
+                check,
+                undo,
+                folder,
+            )
         }
         Some(Commands::New {
             title,

--- a/shiki-config/src/config.rs
+++ b/shiki-config/src/config.rs
@@ -36,6 +36,15 @@ pub struct General {
     /// instead of using a fixed `editor` command.
     #[serde(default)]
     pub use_favorite_editor: bool,
+    /// When true, the TUI listens on a local TCP loopback port
+    /// (`Config::default_capture_port_path` records which one) so external
+    /// `shiki capture "text"` invocations land in this running instance
+    /// live instead of only writing to disk unnoticed. Off by default —
+    /// `shiki capture` itself always works regardless of this setting; it
+    /// only controls whether an already-open TUI finds out about it
+    /// immediately.
+    #[serde(default)]
+    pub enable_capture_daemon: bool,
     /// When true, click-and-drag over a note's body in PREVIEW selects text
     /// and copies it to the clipboard (OSC 52) on release. Defaults to
     /// `true`, so this needs the named-default-fn form rather than bare
@@ -163,6 +172,7 @@ impl Default for General {
             editor: default_editor(),
             daily_template: default_daily_template(),
             use_favorite_editor: false,
+            enable_capture_daemon: false,
             mouse_drag_selection: true,
             data_dir: None,
             show_hints: true,
@@ -1397,6 +1407,20 @@ impl Config {
             .parent()
             .expect("config path always has a parent")
             .join("session.toml"))
+    }
+
+    /// Where the capture daemon (`general.enable_capture_daemon`) records
+    /// which ephemeral TCP port it bound — the config dir, for the exact
+    /// same collision reason as `default_log_path`/`default_trash_dir`/
+    /// `default_session_path`: the data dir's top level is user-named
+    /// notebooks, so a fixed filename placed there could collide with one.
+    /// Rewritten on every daemon start, so a dead process never leaves a
+    /// port number here that anything would mistakenly try to connect to.
+    pub fn default_capture_port_path() -> Result<PathBuf> {
+        Ok(Self::default_path()?
+            .parent()
+            .expect("config path always has a parent")
+            .join("capture.port"))
     }
 
     /// Loads the config from `path`, or creates and saves a default config if it doesn't exist.

--- a/shiki-config/src/config.rs
+++ b/shiki-config/src/config.rs
@@ -1423,6 +1423,18 @@ impl Config {
             .join("capture.port"))
     }
 
+    /// Where `shiki capture --undo`'s backing record (`LastCapture`) lives —
+    /// same collision reasoning as every other fixed file in this list.
+    /// Shared between the in-TUI daemon and the CLI's standalone fallback,
+    /// so `--undo` works the same regardless of which path performed the
+    /// capture being undone.
+    pub fn default_last_capture_path() -> Result<PathBuf> {
+        Ok(Self::default_path()?
+            .parent()
+            .expect("config path always has a parent")
+            .join("last-capture.toml"))
+    }
+
     /// Loads the config from `path`, or creates and saves a default config if it doesn't exist.
     pub fn load_or_init(path: &Path) -> Result<Self> {
         if path.exists() {

--- a/shiki-config/src/last_capture.rs
+++ b/shiki-config/src/last_capture.rs
@@ -1,0 +1,129 @@
+use std::path::Path;
+
+use serde::{Deserialize, Serialize};
+
+use crate::config::Result;
+
+/// Persisted record of the most recent `shiki capture` (either kind — a
+/// new note, or a `--daily` bullet append), backing `shiki capture --undo`.
+/// Written by whichever path actually performed the capture (the in-TUI
+/// daemon, or the CLI's standalone direct-write fallback — see
+/// CLAUDE.md's Quick capture section) to the *same* file
+/// (`Config::default_last_capture_path`), so `--undo` works identically
+/// regardless of which path did the original capture: it just reads
+/// whatever's here. A single slot, not a stack — undoing only ever
+/// reverses the single most recent capture, same simplicity level as the
+/// TUI's own `leader+u` (undo delete), which is also one level deep.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum LastCapture {
+    /// A whole new note was created — undoing moves it to trash (same
+    /// mechanism as a normal note delete, so it's still recoverable by
+    /// hand even after undoing).
+    Note { notebook: String, path: String },
+    /// Text was appended as a bullet to an existing/just-created daily
+    /// note — undoing strips exactly `appended` off the end of the body,
+    /// and only if the body still ends with it verbatim (an edit made to
+    /// the daily note in between means undo refuses rather than risking
+    /// removing content the user actually meant to keep).
+    DailyAppend {
+        notebook: String,
+        path: String,
+        appended: String,
+    },
+}
+
+impl LastCapture {
+    /// Reads the last-capture record, if any. Any failure (missing file,
+    /// unreadable, malformed TOML) is treated as "nothing to undo" rather
+    /// than a real error — a corrupt/missing record just means undo has
+    /// nothing to do, not that something is broken.
+    pub fn load(path: &Path) -> Option<Self> {
+        let contents = std::fs::read_to_string(path).ok()?;
+        toml::from_str(&contents).ok()
+    }
+
+    pub fn save(&self, path: &Path) -> Result<()> {
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+        let contents = toml::to_string_pretty(self)?;
+        std::fs::write(path, contents)?;
+        Ok(())
+    }
+
+    /// Removes the record after a successful undo, so a second `--undo`
+    /// reports "nothing to undo" instead of reapplying the same undo (which
+    /// would be a no-op for `Note` — the file's already gone — but would
+    /// otherwise re-attempt stripping `appended` a second time for
+    /// `DailyAppend`, harmlessly failing the "body still ends with it"
+    /// check, but with a confusing error rather than a clean "nothing to
+    /// undo"). Best-effort: a failed removal doesn't fail the undo that
+    /// already succeeded.
+    pub fn clear(path: &Path) {
+        let _ = std::fs::remove_file(path);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn temp_path(label: &str) -> std::path::PathBuf {
+        std::env::temp_dir().join(format!(
+            "shiki-last-capture-test-{label}-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ))
+    }
+
+    #[test]
+    fn save_then_load_round_trips_note_kind() {
+        let dir = temp_path("note");
+        let path = dir.join("last-capture.toml");
+        let record = LastCapture::Note {
+            notebook: "personal".into(),
+            path: "/tmp/capture-1.md".into(),
+        };
+        record.save(&path).expect("save must succeed");
+        assert_eq!(LastCapture::load(&path), Some(record));
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn save_then_load_round_trips_daily_append_kind() {
+        let dir = temp_path("daily");
+        let path = dir.join("last-capture.toml");
+        let record = LastCapture::DailyAppend {
+            notebook: "personal".into(),
+            path: "/tmp/2026-08-10-daily.md".into(),
+            appended: "- buy milk\n".into(),
+        };
+        record.save(&path).expect("save must succeed");
+        assert_eq!(LastCapture::load(&path), Some(record));
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn load_returns_none_for_a_missing_file() {
+        assert!(LastCapture::load(Path::new("/nonexistent/shiki-last-capture.toml")).is_none());
+    }
+
+    #[test]
+    fn clear_removes_the_record() {
+        let dir = temp_path("clear");
+        let path = dir.join("last-capture.toml");
+        LastCapture::Note {
+            notebook: "personal".into(),
+            path: "/tmp/x.md".into(),
+        }
+        .save(&path)
+        .unwrap();
+        LastCapture::clear(&path);
+        assert!(LastCapture::load(&path).is_none());
+        std::fs::remove_dir_all(&dir).ok();
+    }
+}

--- a/shiki-config/src/lib.rs
+++ b/shiki-config/src/lib.rs
@@ -1,8 +1,10 @@
 pub mod config;
+pub mod last_capture;
 pub mod session;
 pub mod theme;
 pub mod themes;
 
 pub use config::Config;
+pub use last_capture::LastCapture;
 pub use session::SessionState;
 pub use theme::Theme;

--- a/shiki-core/src/notebook.rs
+++ b/shiki-core/src/notebook.rs
@@ -441,6 +441,84 @@ fn validate_name(name: &str) -> Result<()> {
     Ok(())
 }
 
+/// Validates a `/`-separated relative path for use with `create_note_in`/
+/// `create_folder_in` — e.g. `shiki capture --folder`. Each component is
+/// checked with the same rule as a single notebook/folder name
+/// (`validate_name`): non-empty, not `.`/`..`, no embedded separator.
+/// Rejects the whole path on the first bad component rather than silently
+/// dropping it, so a typo'd `--folder ../../etc` fails loudly instead of
+/// writing somewhere unintended.
+pub fn validate_relative_path(relative: &str) -> Result<PathBuf> {
+    let mut path = PathBuf::new();
+    for component in relative.split('/') {
+        validate_name(component)?;
+        path.push(component);
+    }
+    Ok(path)
+}
+
+/// If `text` looks like `"<name>: <rest>"` where `<name>` case-insensitively
+/// matches one of `existing_notebooks`, returns that notebook's exact
+/// stored name plus the remaining text (leading whitespace trimmed) — used
+/// by `shiki capture` to route `"work: call Ana"` into the `work` notebook
+/// automatically. Returns `None` for anything else (no colon, an empty
+/// prefix, or a prefix that isn't a real notebook), meaning the caller
+/// should fall back to whatever notebook it would otherwise use. Only ever
+/// consulted when the caller has no *explicit* notebook override of its
+/// own — an explicit `-n <notebook>` always wins without this being
+/// consulted at all, so a real note whose text happens to start with
+/// `"word: "` is never mis-routed as long as a target was actually given.
+pub fn route_by_prefix<'a>(
+    text: &'a str,
+    existing_notebooks: &[String],
+) -> Option<(String, &'a str)> {
+    let (prefix, rest) = text.split_once(':')?;
+    let prefix = prefix.trim();
+    if prefix.is_empty() {
+        return None;
+    }
+    let matched = existing_notebooks
+        .iter()
+        .find(|n| n.eq_ignore_ascii_case(prefix))?;
+    Some((matched.clone(), rest.trim_start()))
+}
+
+#[cfg(test)]
+mod routing_tests {
+    use super::*;
+
+    #[test]
+    fn validate_relative_path_accepts_multi_segment_paths() {
+        assert_eq!(
+            validate_relative_path("work/meetings").unwrap(),
+            PathBuf::from("work").join("meetings")
+        );
+    }
+
+    #[test]
+    fn validate_relative_path_rejects_traversal_in_any_segment() {
+        assert!(validate_relative_path("work/..").is_err());
+        assert!(validate_relative_path("../etc").is_err());
+        assert!(validate_relative_path("").is_err());
+    }
+
+    #[test]
+    fn route_by_prefix_matches_case_insensitively_and_trims_rest() {
+        let notebooks = vec!["Work".to_string(), "personal".to_string()];
+        let (name, rest) = route_by_prefix("work:   call Ana", &notebooks).unwrap();
+        assert_eq!(name, "Work");
+        assert_eq!(rest, "call Ana");
+    }
+
+    #[test]
+    fn route_by_prefix_returns_none_for_no_colon_or_unknown_prefix() {
+        let notebooks = vec!["work".to_string()];
+        assert!(route_by_prefix("just some text", &notebooks).is_none());
+        assert!(route_by_prefix("unknown: text", &notebooks).is_none());
+        assert!(route_by_prefix(": text", &notebooks).is_none());
+    }
+}
+
 impl NotebookStore {
     pub fn new(root: PathBuf) -> Self {
         Self {

--- a/shiki-tui/src/app.rs
+++ b/shiki-tui/src/app.rs
@@ -1085,6 +1085,21 @@ pub struct App {
     /// gating in `run()` (`if app.sync_in_flight.is_some() { ... }`) to
     /// cover that case too rather than assuming this field already does.
     pub spinner_frame: usize,
+    /// `Some` once `general.enable_capture_daemon` has been turned on at
+    /// least once this session — the listener thread, once spawned, is
+    /// never torn down; toggling the setting off just flips
+    /// `CaptureDaemonHandle::enabled` so future connections get a clear
+    /// "daemon disabled" refusal instead of being processed. `None` means
+    /// no thread/port exists at all (the true off state, not just ignored).
+    pub(crate) capture_daemon: Option<crate::capture::CaptureDaemonHandle>,
+    /// Always present regardless of whether the daemon has ever been
+    /// enabled — cheap to create up front, and avoids `Option` juggling in
+    /// `poll_capture_channel` for a channel that's empty 99% of the time
+    /// anyway.
+    pub(crate) capture_rx: std::sync::mpsc::Receiver<crate::capture::CaptureRequest>,
+    /// The sender half handed to the listener thread's clone the moment the
+    /// daemon is actually spawned (see `set_capture_daemon_enabled`).
+    pub(crate) capture_tx: std::sync::mpsc::Sender<crate::capture::CaptureRequest>,
 }
 
 /// State of the update modal (leader+`U`), across its whole lifecycle: a
@@ -1208,6 +1223,7 @@ impl App {
             .iter()
             .position(|t| t.name == theme.name)
             .unwrap_or(0);
+        let (capture_tx, capture_rx) = std::sync::mpsc::channel();
 
         let mut app = Self {
             config,
@@ -1369,7 +1385,14 @@ impl App {
             sync_in_flight: None,
             sync_rx: None,
             spinner_frame: 0,
+            capture_daemon: None,
+            capture_rx,
+            capture_tx,
         };
+
+        if app.config.general.enable_capture_daemon {
+            app.ensure_capture_daemon_spawned();
+        }
 
         if app.config.general.remember_last_session {
             if let Some(session) = Config::default_session_path()
@@ -1391,6 +1414,58 @@ impl App {
         }
 
         Ok(app)
+    }
+
+    /// Spawns the capture-daemon listener thread if it isn't already
+    /// running — a no-op if `capture_daemon` is already `Some`, so this is
+    /// safe to call both from `new` (config says start enabled) and from
+    /// `set_capture_daemon_enabled` (the Settings toggle) without double-
+    /// spawning. A bind/IO failure (port exhaustion, no loopback interface,
+    /// etc.) reverts `general.enable_capture_daemon` back to `false` and
+    /// reports it via `set_status` rather than silently pretending the
+    /// daemon is running.
+    pub(crate) fn ensure_capture_daemon_spawned(&mut self) {
+        if self.capture_daemon.is_some() {
+            return;
+        }
+        match crate::capture::spawn_capture_daemon(self.capture_tx.clone()) {
+            Ok(handle) => self.capture_daemon = Some(handle),
+            Err(e) => {
+                self.set_status(format!("could not start capture daemon: {e}"));
+                self.config.general.enable_capture_daemon = false;
+                self.save_config();
+            }
+        }
+    }
+
+    /// Backs the GENERAL settings toggle (`GeneralField::EnableCaptureDaemon`).
+    /// The listener thread, once spawned, is never torn down — turning the
+    /// setting back off just flips `CaptureDaemonHandle::enabled` to `false`
+    /// so the still-running thread replies "daemon disabled" to any new
+    /// connection instead of processing it; turning it back on flips the
+    /// same flag back rather than rebinding a new port. This is deliberate:
+    /// no other background thread in this codebase (self-update, git sync)
+    /// has ever needed a shutdown/rejoin mechanism, and inventing one here
+    /// for a boolean flip isn't worth the complexity.
+    pub(crate) fn set_capture_daemon_enabled(&mut self, enabled: bool) {
+        if enabled {
+            self.ensure_capture_daemon_spawned();
+            match &self.capture_daemon {
+                Some(handle) => handle
+                    .enabled
+                    .store(true, std::sync::atomic::Ordering::Relaxed),
+                // Spawn failed — `ensure_capture_daemon_spawned` already
+                // reverted the config and reported why.
+                None => return,
+            }
+        } else if let Some(handle) = &self.capture_daemon {
+            handle
+                .enabled
+                .store(false, std::sync::atomic::Ordering::Relaxed);
+        }
+        self.config.general.enable_capture_daemon = enabled;
+        self.save_config();
+        self.set_status(format!("enable_capture_daemon -> {enabled}"));
     }
 
     /// Applies a previously saved `SessionState` (`general.remember_last_session`)
@@ -2444,6 +2519,7 @@ pub fn run<B: Backend<Error = io::Error>>(
         app.expire_status_message();
         app.poll_update_channel();
         app.poll_sync_channel();
+        app.poll_capture_channel();
         if app.sync_in_flight.is_some() {
             app.spinner_frame = app.spinner_frame.wrapping_add(1);
         }

--- a/shiki-tui/src/capture.rs
+++ b/shiki-tui/src/capture.rs
@@ -15,11 +15,25 @@
 //! start, so a dead process never leaves a stale port number for the next
 //! `shiki capture` invocation to hang against.
 //!
-//! Wire protocol is deliberately the simplest thing that works: one TCP
-//! connection per capture, client writes the raw capture text (not line-
-//! delimited — the text itself may contain newlines) then shuts down its
-//! write half, server reads to EOF, replies with exactly one line (`OK
-//! <path>` or `ERR <message>`), and closes.
+//! Wire protocol: one TCP connection per request, client writes the whole
+//! request then shuts down its write half, server reads to EOF, replies
+//! with exactly one line, closes. Three request kinds, all plain text (no
+//! JSON — the payload shapes are too simple to justify it):
+//! - `PING\n\n` — a reachability/health check (`shiki capture --check`);
+//!   answered directly by the accept-loop thread from the `enabled` flag
+//!   it already holds, without touching `App` at all. Reply is always
+//!   `OK enabled`/`OK disabled`, never `ERR` — being asked "are you there"
+//!   isn't itself an error state.
+//! - `UNDO\n\n` — reverses the single most recent capture (`shiki capture
+//!   --undo`), whichever kind it was and however it was made (daemon or
+//!   the CLI's own standalone fallback both write to the same
+//!   `LastCapture` record).
+//! - `CAPTURE\n<headers>\n\n<body>` — `<headers>` is zero or more
+//!   `key=value` lines (`daily=1`, `tags=a,b,c`, `notebook=work`,
+//!   `folder=work/meetings`), ending at the first blank line; `<body>` is
+//!   the raw capture text, not line-delimited (it may itself contain blank
+//!   lines/newlines) since it's simply "everything after the header
+//!   block's terminating blank line."
 
 use std::io::{Read, Write};
 use std::net::TcpListener;
@@ -29,23 +43,34 @@ use std::sync::mpsc::Sender;
 use std::sync::Arc;
 use std::time::Duration;
 
-use shiki_config::Config;
+use shiki_config::{Config, LastCapture};
 
 use crate::app::App;
 
-/// Sent from the listener thread to the main thread over `App::capture_tx`/
-/// `capture_rx` — the listener thread never touches `App`/`NotebookStore`
-/// itself, it's a dumb pipe; all real work happens on the main thread
-/// inside `perform_capture`, reusing the exact same note-creation/refresh
-/// path every other capture route already uses.
+/// What the listener thread asks the main thread to do — bundled with a
+/// one-shot reply channel, since the listener thread is still holding the
+/// client connection open, waiting to write the result back, and the
+/// existing git-sync/self-update background-thread channels are fire-and-
+/// forget with no "reply to this specific caller" concept.
 pub(crate) struct CaptureRequest {
-    pub text: String,
-    /// One-shot reply channel bundled per-request, since the existing
-    /// git-sync/self-update background-thread channels are fire-and-forget
-    /// with no "reply to this specific caller" concept — a capture needs
-    /// one, since the listener thread is still holding the client
-    /// connection open, waiting to write the result back.
+    pub kind: RequestKind,
     pub reply_tx: Sender<CaptureReply>,
+}
+
+pub(crate) enum RequestKind {
+    Capture {
+        text: String,
+        daily: bool,
+        tags: Vec<String>,
+        /// Explicit `-n <notebook>` from the client, if any — takes
+        /// priority over content-prefix routing and `default_notebook`.
+        notebook: Option<String>,
+        /// `--folder <path>` from the client, if any — a note is created
+        /// inside this subfolder instead of the notebook's root. Ignored
+        /// when `daily` is set (a daily note's path is always fixed).
+        folder: Option<String>,
+    },
+    Undo,
 }
 
 pub(crate) enum CaptureReply {
@@ -59,6 +84,66 @@ pub(crate) enum CaptureReply {
 /// the flag instead.
 pub(crate) struct CaptureDaemonHandle {
     pub enabled: Arc<AtomicBool>,
+}
+
+/// A parsed request off the wire — see the module doc comment for the
+/// exact text format. Pure/testable independent of any real socket.
+enum ParsedRequest {
+    Ping,
+    Undo,
+    Capture {
+        daily: bool,
+        tags: Vec<String>,
+        notebook: Option<String>,
+        folder: Option<String>,
+        text: String,
+    },
+    /// Anything not starting with a recognized command word.
+    Invalid,
+}
+
+/// Headers end at the first blank line; everything after it is the body
+/// verbatim (including any further blank lines inside it) — so this can't
+/// just be `raw.lines()`, which would also split the body on its own
+/// internal newlines.
+fn parse_request(raw: &str) -> ParsedRequest {
+    let (header_block, body) = raw
+        .split_once("\n\n")
+        .unwrap_or((raw.trim_end_matches('\n'), ""));
+    let mut lines = header_block.lines();
+    match lines.next().unwrap_or("").trim() {
+        "PING" => ParsedRequest::Ping,
+        "UNDO" => ParsedRequest::Undo,
+        "CAPTURE" => {
+            let mut daily = false;
+            let mut tags = Vec::new();
+            let mut notebook = None;
+            let mut folder = None;
+            for line in lines {
+                if let Some(v) = line.strip_prefix("daily=") {
+                    daily = matches!(v.trim(), "1" | "true");
+                } else if let Some(v) = line.strip_prefix("tags=") {
+                    tags = v
+                        .split(',')
+                        .map(|s| s.trim().to_string())
+                        .filter(|s| !s.is_empty())
+                        .collect();
+                } else if let Some(v) = line.strip_prefix("notebook=") {
+                    notebook = Some(v.trim().to_string()).filter(|s| !s.is_empty());
+                } else if let Some(v) = line.strip_prefix("folder=") {
+                    folder = Some(v.trim().to_string()).filter(|s| !s.is_empty());
+                }
+            }
+            ParsedRequest::Capture {
+                daily,
+                tags,
+                notebook,
+                folder,
+                text: body.to_string(),
+            }
+        }
+        _ => ParsedRequest::Invalid,
+    }
 }
 
 /// Binds an ephemeral loopback port, records it, and spawns the accept-loop
@@ -99,29 +184,82 @@ fn accept_loop(
 ) {
     for stream in listener.incoming() {
         let Ok(mut stream) = stream else { continue };
-        if !enabled.load(Ordering::Relaxed) {
-            let _ = stream.write_all(disabled_response().as_bytes());
-            continue;
-        }
-        let mut text = String::new();
-        if stream.read_to_string(&mut text).is_err() {
+        let mut raw = String::new();
+        if stream.read_to_string(&mut raw).is_err() {
             let _ = stream.write_all(b"ERR could not read request\n");
             continue;
         }
 
-        let (reply_tx, reply_rx) = std::sync::mpsc::channel();
-        if capture_tx.send(CaptureRequest { text, reply_tx }).is_err() {
-            // Main thread is gone (process shutting down) — nothing left
-            // to reply to correctly, but still close the connection cleanly.
-            let _ = stream.write_all(b"ERR shiki is shutting down\n");
-            continue;
+        match parse_request(&raw) {
+            ParsedRequest::Ping => {
+                // Answered directly, no round trip through `App` — a health
+                // check should be as fast as the connection itself, and
+                // doesn't need anything `App` holds beyond this flag, which
+                // the accept-loop thread already has its own clone of.
+                let status = if enabled.load(Ordering::Relaxed) {
+                    "enabled"
+                } else {
+                    "disabled"
+                };
+                let _ = stream.write_all(format!("OK {status}\n").as_bytes());
+            }
+            ParsedRequest::Undo => {
+                if !enabled.load(Ordering::Relaxed) {
+                    let _ = stream.write_all(disabled_response().as_bytes());
+                    continue;
+                }
+                dispatch(&mut stream, &capture_tx, RequestKind::Undo);
+            }
+            ParsedRequest::Capture {
+                daily,
+                tags,
+                notebook,
+                folder,
+                text,
+            } => {
+                if !enabled.load(Ordering::Relaxed) {
+                    let _ = stream.write_all(disabled_response().as_bytes());
+                    continue;
+                }
+                dispatch(
+                    &mut stream,
+                    &capture_tx,
+                    RequestKind::Capture {
+                        text,
+                        daily,
+                        tags,
+                        notebook,
+                        folder,
+                    },
+                );
+            }
+            ParsedRequest::Invalid => {
+                let _ = stream.write_all(b"ERR unrecognized request\n");
+            }
         }
-        let response = match reply_rx.recv_timeout(Duration::from_secs(5)) {
-            Ok(reply) => response_line(&reply),
-            Err(_) => "ERR timed out waiting for shiki to respond\n".to_string(),
-        };
-        let _ = stream.write_all(response.as_bytes());
     }
+}
+
+/// Sends `kind` to the main thread and writes its reply back to `stream` —
+/// shared by the `CAPTURE`/`UNDO` branches of `accept_loop`, which differ
+/// only in what they send, not in how the round trip works.
+fn dispatch(
+    stream: &mut std::net::TcpStream,
+    capture_tx: &Sender<CaptureRequest>,
+    kind: RequestKind,
+) {
+    let (reply_tx, reply_rx) = std::sync::mpsc::channel();
+    if capture_tx.send(CaptureRequest { kind, reply_tx }).is_err() {
+        // Main thread is gone (process shutting down) — nothing left to
+        // reply to correctly, but still close the connection cleanly.
+        let _ = stream.write_all(b"ERR shiki is shutting down\n");
+        return;
+    }
+    let response = match reply_rx.recv_timeout(Duration::from_secs(5)) {
+        Ok(reply) => response_line(&reply),
+        Err(_) => "ERR timed out waiting for shiki to respond\n".to_string(),
+    };
+    let _ = stream.write_all(response.as_bytes());
 }
 
 fn disabled_response() -> String {
@@ -135,53 +273,273 @@ fn response_line(reply: &CaptureReply) -> String {
     }
 }
 
-/// Runs on the main thread (`App::poll_capture_channel`), reusing the exact
-/// note-creation path every other capture route in this codebase already
-/// uses — this is what makes cache/panel refresh and auto-sync counting
-/// "just work" for a capture that arrived from an external process.
-pub(crate) fn perform_capture(app: &mut App, text: &str) -> CaptureReply {
+/// Runs on the main thread (`App::poll_capture_channel`) — dispatches to
+/// `perform_capture`/`perform_undo` depending on what the listener thread
+/// asked for.
+pub(crate) fn handle_request(app: &mut App, request: &RequestKind) -> CaptureReply {
+    match request {
+        RequestKind::Capture {
+            text,
+            daily,
+            tags,
+            notebook,
+            folder,
+        } => perform_capture(
+            app,
+            text,
+            *daily,
+            tags,
+            notebook.as_deref(),
+            folder.as_deref(),
+        ),
+        RequestKind::Undo => perform_undo(app),
+    }
+}
+
+/// Resolves which notebook a capture with no explicit `-n` targets:
+/// content-prefix routing (`"work: call Ana"`) first, then
+/// `general.default_notebook`. An explicit override always wins outright
+/// and never reaches this function at all — see the call site.
+fn resolve_notebook_and_text<'a>(
+    text: &'a str,
+    explicit: Option<&str>,
+    default_notebook: &str,
+    existing_notebooks: &[String],
+) -> (String, &'a str) {
+    if let Some(name) = explicit {
+        return (name.to_string(), text);
+    }
+    shiki_core::notebook::route_by_prefix(text, existing_notebooks)
+        .unwrap_or_else(|| (default_notebook.to_string(), text))
+}
+
+/// Reuses the exact note-creation/daily-note path every other capture
+/// route in this codebase already uses — this is what makes cache/panel
+/// refresh and auto-sync counting "just work" for a capture that arrived
+/// from an external process. Every outcome is also funneled through
+/// `App::set_status`, so a capture that happened while the TUI was
+/// unattended still leaves a trace in the logs modal (`leader` then `l`),
+/// not just a footer message nobody was there to read.
+fn perform_capture(
+    app: &mut App,
+    text: &str,
+    daily: bool,
+    tags: &[String],
+    explicit_notebook: Option<&str>,
+    folder: Option<&str>,
+) -> CaptureReply {
     let text = text.trim();
     if text.is_empty() {
-        return CaptureReply::Err("empty capture text".into());
+        let reply = CaptureReply::Err("empty capture text".into());
+        app.set_status("capture failed: empty text".into());
+        return reply;
     }
 
-    let name = app.config.general.default_notebook.clone();
+    let existing_notebooks: Vec<String> = app.notebooks.iter().map(|nb| nb.name.clone()).collect();
+    let (name, text) = resolve_notebook_and_text(
+        text,
+        explicit_notebook,
+        &app.config.general.default_notebook.clone(),
+        &existing_notebooks,
+    );
+
     let nb = match app.store.get(&name) {
         Ok(nb) => nb,
         Err(_) => match app.store.create(&name) {
             Ok(nb) => nb,
-            Err(e) => return CaptureReply::Err(format!("could not create notebook '{name}': {e}")),
+            Err(e) => {
+                let msg = format!("could not create notebook '{name}': {e}");
+                app.set_status(format!("capture failed: {msg}"));
+                return CaptureReply::Err(msg);
+            }
         },
     };
 
     let encrypted = app.config.encrypt_for(&name);
     let crypto = app.resolved_notebook_crypto(&name);
     if encrypted && crypto.is_none() {
-        return CaptureReply::Err(format!(
+        let msg = format!(
             "locked: notebook '{name}' is encrypted and locked in this session — \
              unlock it in the TUI or run `shiki capture` from a terminal instead"
-        ));
+        );
+        app.set_status(format!("capture failed: notebook '{name}' is locked"));
+        return CaptureReply::Err(msg);
     }
     let nb = nb.with_crypto(crypto);
 
-    let title = format!("Capture {}", chrono::Local::now().format("%Y-%m-%d %H:%M"));
-    let note = match nb.create_note(&title, text) {
-        Ok(note) => note,
-        Err(e) => return CaptureReply::Err(format!("could not create note: {e}")),
+    let result = if daily {
+        capture_into_daily(app, &nb, text)
+    } else {
+        capture_into_new_note(&nb, text, tags, folder)
     };
 
-    // Captures always land at the notebook's root — only refresh the live
-    // panel when that's genuinely what's on screen, so a capture into a
-    // different notebook (or the same notebook but a different folder)
-    // doesn't stomp on whatever the user's currently browsing.
-    let viewing_target_root =
-        app.selected_notebook().is_some_and(|sel| sel.name == name) && app.notes_path.is_empty();
-    if viewing_target_root {
+    let (path, record) = match result {
+        Ok(outcome) => outcome,
+        Err(e) => {
+            let msg = format!("could not save capture: {e}");
+            app.set_status(format!("capture failed: {msg}"));
+            return CaptureReply::Err(msg);
+        }
+    };
+    if let Ok(record_path) = Config::default_last_capture_path() {
+        let _ = record.save(&record_path);
+    }
+
+    // A daily-note append always lands at the notebook's root, regardless
+    // of `folder` (which only applies to a brand-new note); only refresh
+    // the live panel when that's genuinely what's on screen, so a capture
+    // elsewhere doesn't stomp on whatever the user's currently browsing.
+    let target_relative = if daily { "" } else { folder.unwrap_or("") };
+    let viewing_target = app.selected_notebook().is_some_and(|sel| sel.name == name)
+        && app.notes_path.join("/") == target_relative;
+    if viewing_target {
         app.refresh_notes_preserve_selection();
     }
     app.note_changed(&name);
+    app.set_status(format!("captured: {}", path.display()));
 
-    CaptureReply::Ok(note.path)
+    CaptureReply::Ok(path)
+}
+
+fn capture_into_new_note(
+    nb: &shiki_core::Notebook,
+    text: &str,
+    tags: &[String],
+    folder: Option<&str>,
+) -> shiki_core::Result<(PathBuf, LastCapture)> {
+    let title = format!("Capture {}", chrono::Local::now().format("%Y-%m-%d %H:%M"));
+    let mut note = match folder {
+        Some(folder) => {
+            let relative = shiki_core::notebook::validate_relative_path(folder)?;
+            nb.create_note_in(&relative, &title, text)?
+        }
+        None => nb.create_note(&title, text)?,
+    };
+    if !tags.is_empty() {
+        note.frontmatter.tags = tags.to_vec();
+        note.save_with_crypto(nb.crypto.as_ref())?;
+    }
+    let record = LastCapture::Note {
+        notebook: nb.name.clone(),
+        path: note.path.display().to_string(),
+    };
+    Ok((note.path, record))
+}
+
+fn capture_into_daily(
+    app: &App,
+    nb: &shiki_core::Notebook,
+    text: &str,
+) -> shiki_core::Result<(PathBuf, LastCapture)> {
+    let today = chrono::Local::now().date_naive();
+    let templates_dir = Config::default_templates_dir().unwrap_or_default();
+    let agenda = if app.config.general.daily_agenda {
+        app.store
+            .all_notes()
+            .ok()
+            .and_then(|pool| shiki_core::tasks::agenda_section(&pool, today))
+    } else {
+        None
+    };
+    let mut note = shiki_core::daily::create_or_open(
+        nb,
+        today,
+        &templates_dir,
+        &app.config.general.daily_template,
+        agenda.as_deref(),
+    )?;
+    if !note.body.ends_with('\n') {
+        note.body.push('\n');
+    }
+    let appended = format!("- {text}\n");
+    note.body.push_str(&appended);
+    note.save_with_crypto(nb.crypto.as_ref())?;
+    let record = LastCapture::DailyAppend {
+        notebook: nb.name.clone(),
+        path: note.path.display().to_string(),
+        appended,
+    };
+    Ok((note.path, record))
+}
+
+/// Reverses the single most recent capture — see `LastCapture`'s own doc
+/// comment for why this is a one-slot record, not a stack.
+fn perform_undo(app: &mut App) -> CaptureReply {
+    let record_path = match Config::default_last_capture_path() {
+        Ok(p) => p,
+        Err(e) => return CaptureReply::Err(format!("could not resolve state path: {e}")),
+    };
+    let Some(record) = LastCapture::load(&record_path) else {
+        return CaptureReply::Err("nothing to undo".into());
+    };
+
+    let (notebook, path, outcome) = match &record {
+        LastCapture::Note { notebook, path } => {
+            let outcome = undo_note(app, notebook, path);
+            (notebook.clone(), path.clone(), outcome)
+        }
+        LastCapture::DailyAppend {
+            notebook,
+            path,
+            appended,
+        } => {
+            let outcome = undo_daily_append(app, notebook, path, appended);
+            (notebook.clone(), path.clone(), outcome)
+        }
+    };
+
+    let path = match outcome {
+        Ok(()) => path,
+        Err(e) => {
+            app.set_status(format!("undo failed: {e}"));
+            return CaptureReply::Err(e);
+        }
+    };
+
+    LastCapture::clear(&record_path);
+    let viewing_target = app
+        .selected_notebook()
+        .is_some_and(|sel| sel.name == notebook);
+    if viewing_target {
+        app.refresh_notes_preserve_selection();
+    }
+    app.note_changed(&notebook);
+    app.set_status(format!("undone: {path}"));
+    CaptureReply::Ok(PathBuf::from(path))
+}
+
+fn undo_note(app: &App, notebook: &str, path: &str) -> Result<(), String> {
+    let Some(trash_root) = app.trash_root.as_ref() else {
+        return Err("trash directory unavailable".into());
+    };
+    let trash_dir = trash_root.join(notebook);
+    let suffix = chrono::Local::now().format("%Y%m%d%H%M%S%3f").to_string();
+    shiki_core::trash::move_to_trash(std::path::Path::new(path), &trash_dir, &suffix)
+        .map(|_| ())
+        .map_err(|e| format!("could not move '{path}' to trash: {e}"))
+}
+
+fn undo_daily_append(app: &App, notebook: &str, path: &str, appended: &str) -> Result<(), String> {
+    let encrypted = app.config.encrypt_for(notebook);
+    let crypto = app.resolved_notebook_crypto(notebook);
+    if encrypted && crypto.is_none() {
+        return Err(format!(
+            "locked: notebook '{notebook}' is encrypted and locked in this session"
+        ));
+    }
+    let mut note = shiki_core::Note::from_file_in_notebook_with_crypto(
+        std::path::Path::new(path),
+        notebook,
+        crypto.as_ref(),
+    )
+    .map_err(|e| format!("could not read '{path}': {e}"))?;
+    if !note.body.ends_with(appended) {
+        return Err("the daily note has changed since that capture — not undoing".into());
+    }
+    let new_len = note.body.len() - appended.len();
+    note.body.truncate(new_len);
+    note.save_with_crypto(crypto.as_ref())
+        .map_err(|e| format!("could not save '{path}': {e}"))
 }
 
 #[cfg(test)]
@@ -203,5 +561,99 @@ mod tests {
     #[test]
     fn disabled_response_is_a_clear_err_line() {
         assert_eq!(disabled_response(), "ERR daemon disabled\n");
+    }
+
+    #[test]
+    fn parse_request_recognizes_ping_and_undo() {
+        assert!(matches!(parse_request("PING\n\n"), ParsedRequest::Ping));
+        assert!(matches!(parse_request("PING"), ParsedRequest::Ping));
+        assert!(matches!(parse_request("UNDO\n\n"), ParsedRequest::Undo));
+        assert!(matches!(parse_request("UNDO"), ParsedRequest::Undo));
+    }
+
+    #[test]
+    fn parse_request_parses_plain_capture_with_no_headers() {
+        match parse_request("CAPTURE\n\nbuy milk") {
+            ParsedRequest::Capture {
+                daily,
+                tags,
+                notebook,
+                folder,
+                text,
+            } => {
+                assert!(!daily);
+                assert!(tags.is_empty());
+                assert!(notebook.is_none());
+                assert!(folder.is_none());
+                assert_eq!(text, "buy milk");
+            }
+            _ => panic!("expected Capture"),
+        }
+    }
+
+    #[test]
+    fn parse_request_parses_all_headers() {
+        match parse_request(
+            "CAPTURE\ndaily=1\ntags=work,idea\nnotebook=work\nfolder=work/meetings\n\nbuy milk",
+        ) {
+            ParsedRequest::Capture {
+                daily,
+                tags,
+                notebook,
+                folder,
+                text,
+            } => {
+                assert!(daily);
+                assert_eq!(tags, vec!["work".to_string(), "idea".to_string()]);
+                assert_eq!(notebook.as_deref(), Some("work"));
+                assert_eq!(folder.as_deref(), Some("work/meetings"));
+                assert_eq!(text, "buy milk");
+            }
+            _ => panic!("expected Capture"),
+        }
+    }
+
+    #[test]
+    fn parse_request_body_may_contain_blank_lines() {
+        match parse_request("CAPTURE\n\nline one\n\nline two") {
+            ParsedRequest::Capture { text, .. } => {
+                assert_eq!(text, "line one\n\nline two");
+            }
+            _ => panic!("expected Capture"),
+        }
+    }
+
+    #[test]
+    fn parse_request_rejects_unrecognized_command() {
+        assert!(matches!(
+            parse_request("GARBAGE\n\nsomething"),
+            ParsedRequest::Invalid
+        ));
+        assert!(matches!(parse_request(""), ParsedRequest::Invalid));
+    }
+
+    #[test]
+    fn resolve_notebook_and_text_prefers_explicit_override() {
+        let existing = vec!["work".to_string()];
+        let (name, text) =
+            resolve_notebook_and_text("work: call Ana", Some("personal"), "personal", &existing);
+        assert_eq!(name, "personal");
+        assert_eq!(text, "work: call Ana");
+    }
+
+    #[test]
+    fn resolve_notebook_and_text_routes_by_prefix_when_no_override() {
+        let existing = vec!["work".to_string()];
+        let (name, text) = resolve_notebook_and_text("work: call Ana", None, "personal", &existing);
+        assert_eq!(name, "work");
+        assert_eq!(text, "call Ana");
+    }
+
+    #[test]
+    fn resolve_notebook_and_text_falls_back_to_default() {
+        let existing = vec!["work".to_string()];
+        let (name, text) = resolve_notebook_and_text("just an idea", None, "personal", &existing);
+        assert_eq!(name, "personal");
+        assert_eq!(text, "just an idea");
     }
 }

--- a/shiki-tui/src/capture.rs
+++ b/shiki-tui/src/capture.rs
@@ -1,0 +1,207 @@
+//! Quick-capture daemon (`general.enable_capture_daemon`) — lets an
+//! external `shiki capture "text"` invocation (`shiki-cli/src/commands/
+//! capture.rs`) land in an already-running TUI instance live, instead of
+//! only writing to disk unnoticed. Off by default; `shiki capture` itself
+//! always works with or without this running (see the CLI side's direct-
+//! write fallback) — this module only covers the "TUI is open and wants to
+//! know immediately" path.
+//!
+//! Transport is a plain TCP loopback socket (`127.0.0.1`, an OS-assigned
+//! ephemeral port), not a Unix domain socket, specifically so the exact
+//! same implementation works on Windows too — shiki ships real Windows
+//! binaries (see `release.yml`), and a Unix-socket-only daemon would leave
+//! that platform without the feature entirely. The bound port is recorded
+//! in `Config::default_capture_port_path()`, rewritten on every daemon
+//! start, so a dead process never leaves a stale port number for the next
+//! `shiki capture` invocation to hang against.
+//!
+//! Wire protocol is deliberately the simplest thing that works: one TCP
+//! connection per capture, client writes the raw capture text (not line-
+//! delimited — the text itself may contain newlines) then shuts down its
+//! write half, server reads to EOF, replies with exactly one line (`OK
+//! <path>` or `ERR <message>`), and closes.
+
+use std::io::{Read, Write};
+use std::net::TcpListener;
+use std::path::PathBuf;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::mpsc::Sender;
+use std::sync::Arc;
+use std::time::Duration;
+
+use shiki_config::Config;
+
+use crate::app::App;
+
+/// Sent from the listener thread to the main thread over `App::capture_tx`/
+/// `capture_rx` — the listener thread never touches `App`/`NotebookStore`
+/// itself, it's a dumb pipe; all real work happens on the main thread
+/// inside `perform_capture`, reusing the exact same note-creation/refresh
+/// path every other capture route already uses.
+pub(crate) struct CaptureRequest {
+    pub text: String,
+    /// One-shot reply channel bundled per-request, since the existing
+    /// git-sync/self-update background-thread channels are fire-and-forget
+    /// with no "reply to this specific caller" concept — a capture needs
+    /// one, since the listener thread is still holding the client
+    /// connection open, waiting to write the result back.
+    pub reply_tx: Sender<CaptureReply>,
+}
+
+pub(crate) enum CaptureReply {
+    Ok(PathBuf),
+    Err(String),
+}
+
+/// Held by `App` once the daemon has been spawned at least once this
+/// session. The listener thread is never torn down — see
+/// `App::set_capture_daemon_enabled` for why toggling this off just flips
+/// the flag instead.
+pub(crate) struct CaptureDaemonHandle {
+    pub enabled: Arc<AtomicBool>,
+}
+
+/// Binds an ephemeral loopback port, records it, and spawns the accept-loop
+/// thread. Returns as soon as the port is known and written to disk, so a
+/// capture issued moments later reliably finds it.
+pub(crate) fn spawn_capture_daemon(
+    capture_tx: Sender<CaptureRequest>,
+) -> anyhow::Result<CaptureDaemonHandle> {
+    let listener = TcpListener::bind(("127.0.0.1", 0))?;
+    let port = listener.local_addr()?.port();
+    write_port_file(port)?;
+
+    let enabled = Arc::new(AtomicBool::new(true));
+    let thread_enabled = Arc::clone(&enabled);
+    std::thread::spawn(move || accept_loop(listener, capture_tx, thread_enabled));
+
+    Ok(CaptureDaemonHandle { enabled })
+}
+
+fn write_port_file(port: u16) -> anyhow::Result<()> {
+    let path = Config::default_capture_port_path()?;
+    std::fs::write(&path, port.to_string())?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        // Best-effort: a stricter mode just means only this user's other
+        // processes can read the port number, not a functional requirement
+        // (the port itself has no auth beyond "connects from localhost").
+        let _ = std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o600));
+    }
+    Ok(())
+}
+
+fn accept_loop(
+    listener: TcpListener,
+    capture_tx: Sender<CaptureRequest>,
+    enabled: Arc<AtomicBool>,
+) {
+    for stream in listener.incoming() {
+        let Ok(mut stream) = stream else { continue };
+        if !enabled.load(Ordering::Relaxed) {
+            let _ = stream.write_all(disabled_response().as_bytes());
+            continue;
+        }
+        let mut text = String::new();
+        if stream.read_to_string(&mut text).is_err() {
+            let _ = stream.write_all(b"ERR could not read request\n");
+            continue;
+        }
+
+        let (reply_tx, reply_rx) = std::sync::mpsc::channel();
+        if capture_tx.send(CaptureRequest { text, reply_tx }).is_err() {
+            // Main thread is gone (process shutting down) — nothing left
+            // to reply to correctly, but still close the connection cleanly.
+            let _ = stream.write_all(b"ERR shiki is shutting down\n");
+            continue;
+        }
+        let response = match reply_rx.recv_timeout(Duration::from_secs(5)) {
+            Ok(reply) => response_line(&reply),
+            Err(_) => "ERR timed out waiting for shiki to respond\n".to_string(),
+        };
+        let _ = stream.write_all(response.as_bytes());
+    }
+}
+
+fn disabled_response() -> String {
+    "ERR daemon disabled\n".to_string()
+}
+
+fn response_line(reply: &CaptureReply) -> String {
+    match reply {
+        CaptureReply::Ok(path) => format!("OK {}\n", path.display()),
+        CaptureReply::Err(msg) => format!("ERR {msg}\n"),
+    }
+}
+
+/// Runs on the main thread (`App::poll_capture_channel`), reusing the exact
+/// note-creation path every other capture route in this codebase already
+/// uses — this is what makes cache/panel refresh and auto-sync counting
+/// "just work" for a capture that arrived from an external process.
+pub(crate) fn perform_capture(app: &mut App, text: &str) -> CaptureReply {
+    let text = text.trim();
+    if text.is_empty() {
+        return CaptureReply::Err("empty capture text".into());
+    }
+
+    let name = app.config.general.default_notebook.clone();
+    let nb = match app.store.get(&name) {
+        Ok(nb) => nb,
+        Err(_) => match app.store.create(&name) {
+            Ok(nb) => nb,
+            Err(e) => return CaptureReply::Err(format!("could not create notebook '{name}': {e}")),
+        },
+    };
+
+    let encrypted = app.config.encrypt_for(&name);
+    let crypto = app.resolved_notebook_crypto(&name);
+    if encrypted && crypto.is_none() {
+        return CaptureReply::Err(format!(
+            "locked: notebook '{name}' is encrypted and locked in this session — \
+             unlock it in the TUI or run `shiki capture` from a terminal instead"
+        ));
+    }
+    let nb = nb.with_crypto(crypto);
+
+    let title = format!("Capture {}", chrono::Local::now().format("%Y-%m-%d %H:%M"));
+    let note = match nb.create_note(&title, text) {
+        Ok(note) => note,
+        Err(e) => return CaptureReply::Err(format!("could not create note: {e}")),
+    };
+
+    // Captures always land at the notebook's root — only refresh the live
+    // panel when that's genuinely what's on screen, so a capture into a
+    // different notebook (or the same notebook but a different folder)
+    // doesn't stomp on whatever the user's currently browsing.
+    let viewing_target_root =
+        app.selected_notebook().is_some_and(|sel| sel.name == name) && app.notes_path.is_empty();
+    if viewing_target_root {
+        app.refresh_notes_preserve_selection();
+    }
+    app.note_changed(&name);
+
+    CaptureReply::Ok(note.path)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn response_line_formats_ok_and_err() {
+        assert_eq!(
+            response_line(&CaptureReply::Ok(PathBuf::from("/tmp/note.md"))),
+            "OK /tmp/note.md\n"
+        );
+        assert_eq!(
+            response_line(&CaptureReply::Err("oops".into())),
+            "ERR oops\n"
+        );
+    }
+
+    #[test]
+    fn disabled_response_is_a_clear_err_line() {
+        assert_eq!(disabled_response(), "ERR daemon disabled\n");
+    }
+}

--- a/shiki-tui/src/key_handlers.rs
+++ b/shiki-tui/src/key_handlers.rs
@@ -1309,7 +1309,7 @@ impl App {
     /// own one-shot reply channel before moving to the next.
     pub(crate) fn poll_capture_channel(&mut self) {
         while let Ok(request) = self.capture_rx.try_recv() {
-            let reply = crate::capture::perform_capture(self, &request.text);
+            let reply = crate::capture::handle_request(self, &request.kind);
             let _ = request.reply_tx.send(reply);
         }
     }

--- a/shiki-tui/src/key_handlers.rs
+++ b/shiki-tui/src/key_handlers.rs
@@ -310,6 +310,11 @@ impl App {
             ));
             return;
         }
+        if field == GeneralField::EnableCaptureDaemon {
+            let new_value = !self.config.general.enable_capture_daemon;
+            self.set_capture_daemon_enabled(new_value);
+            return;
+        }
         if field == GeneralField::MouseDragSelection {
             self.config.general.mouse_drag_selection = !self.config.general.mouse_drag_selection;
             self.save_config();
@@ -429,6 +434,7 @@ impl App {
             }
             GeneralField::PageStep => ("page_step", self.config.general.page_step.to_string()),
             GeneralField::UseFavoriteEditor
+            | GeneralField::EnableCaptureDaemon
             | GeneralField::MouseDragSelection
             | GeneralField::ShowHints
             | GeneralField::RememberLastSession
@@ -1293,6 +1299,18 @@ impl App {
                 ));
                 self.update_rx = None;
             }
+        }
+    }
+
+    /// Non-blocking: called once per `run()` loop iteration, same spot as
+    /// `poll_update_channel`/`poll_sync_channel`. Drains every pending
+    /// `CaptureRequest`, not just one — several `shiki capture` invocations
+    /// could queue up between two frames — and answers each one over its
+    /// own one-shot reply channel before moving to the next.
+    pub(crate) fn poll_capture_channel(&mut self) {
+        while let Ok(request) = self.capture_rx.try_recv() {
+            let reply = crate::capture::perform_capture(self, &request.text);
+            let _ = request.reply_tx.send(reply);
         }
     }
     fn handle_update_key(&mut self, key: KeyEvent) {
@@ -4880,6 +4898,7 @@ impl App {
                             "page_step"
                         }
                         GeneralField::UseFavoriteEditor => "use_favorite_editor",
+                        GeneralField::EnableCaptureDaemon => "enable_capture_daemon",
                         GeneralField::MouseDragSelection => "mouse_drag_selection",
                         GeneralField::ShowHints => "show_hints",
                         GeneralField::RememberLastSession => "remember_last_session",

--- a/shiki-tui/src/lib.rs
+++ b/shiki-tui/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod app;
+pub(crate) mod capture;
 pub mod clipboard;
 pub mod confirm;
 pub mod draw;

--- a/shiki-tui/src/panel_settings.rs
+++ b/shiki-tui/src/panel_settings.rs
@@ -68,6 +68,7 @@ pub enum GeneralField {
     Editor,
     DailyTemplate,
     UseFavoriteEditor,
+    EnableCaptureDaemon,
     MouseDragSelection,
     ShowHints,
     RememberLastSession,
@@ -88,11 +89,12 @@ pub enum GeneralField {
 }
 
 impl GeneralField {
-    pub const ALL: [GeneralField; 21] = [
+    pub const ALL: [GeneralField; 22] = [
         GeneralField::DefaultNotebook,
         GeneralField::Editor,
         GeneralField::DailyTemplate,
         GeneralField::UseFavoriteEditor,
+        GeneralField::EnableCaptureDaemon,
         GeneralField::MouseDragSelection,
         GeneralField::ShowHints,
         GeneralField::RememberLastSession,
@@ -329,6 +331,11 @@ fn general_rows(app: &App) -> Vec<Line<'static>> {
             app,
             "use_favorite_editor",
             cfg.general.use_favorite_editor.to_string(),
+        ),
+        row_line(
+            app,
+            "enable_capture_daemon",
+            cfg.general.enable_capture_daemon.to_string(),
         ),
         row_line(
             app,


### PR DESCRIPTION
## Summary
- `shiki capture "text"`: near-instant note capture with no `$EDITOR` and no TUI drawn — meant for scripts/launchers (rofi, waybar, Raycast, AutoHotkey, an OS hotkey). Always works standalone, falling back to a direct `Notebook::create_note` write (same path `shiki new` already uses) when nothing else answers.
- `general.enable_capture_daemon` (off by default, toggle from Settings → GENERAL): lets a *running* TUI pick up captures live over a local TCP loopback socket instead of only writing to disk unnoticed. TCP loopback (not a Unix socket) was chosen specifically so the same implementation works on the Windows binaries shiki also ships. The listener thread is never torn down — toggling off just flips a shared `Arc<AtomicBool>` so it starts refusing new connections instead of rebinding/rejoining anything.
- Capturing into an encrypted, locked notebook via the daemon fails with a clear `locked: ...` error instead of hanging or writing plaintext (a background thread can't prompt for a passphrase); the CLI's fallback path still prompts interactively, same as `shiki new`.
- Documented in `IDEA.md` ("Quick capture" section) and mirrored verbatim into `docs/documentation.html`, plus a `CHANGELOG.md [Unreleased]` entry and an architecture writeup in `CLAUDE.md`.

## Test plan
- [x] `cargo build/fmt/clippy/test --workspace` — clean, 234 tests passing (7 new: port-file parsing, response-line parsing, response formatting)
- [x] Verified live via tmux: toggled the daemon on in Settings, ran `shiki capture` from another shell, confirmed `captured (daemon): <path>` and the note appearing live in NOTES with no reload
- [x] Toggled the daemon off, confirmed `shiki capture` still works (`captured: <path>`, no live TUI update)
- [x] `kill -9`'d the TUI process, confirmed the next `shiki capture` falls back in single-digit ms instead of hanging on a stale port
- [ ] Encrypted+locked notebook via the daemon — not exercised live (needs a real TTY for the passphrase prompt in the fallback path, unavailable in the sandbox shell used for testing); reasoned correct via code review, reuses the already-tested `App::resolved_notebook_crypto`

🤖 Generated with [Claude Code](https://claude.com/claude-code)