### PR TITLE
Feature/adaptive syntax highlighting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3806,6 +3806,7 @@ dependencies = [
  "thiserror 2.0.19",
  "tokio",
  "tracing",
+ "two-face",
  "unicode-width",
 ]
 
@@ -4476,6 +4477,17 @@ name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
+name = "two-face"
+version = "0.5.2+bat-0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "915be7adc2ff6f4338acbf71f3eda0a146f46003b992a1669c674308610efdac"
+dependencies = [
+ "serde",
+ "serde_derive",
+ "syntect",
+]
 
 [[package]]
 name = "type-map"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,17 @@ tokio = { version = "1", features = ["full"] }
 git2 = { version = "0.21", features = ["ssh", "https", "vendored-libgit2", "vendored-openssl"] }
 comrak = "0.54"
 syntect = "5"
+# Bundles ~150 extra syntect syntax definitions (from bat's asset collection)
+# on top of syntect's own bundled defaults — notably TypeScript/TSX, which
+# syntect's `SyntaxSet::load_defaults_newlines` doesn't include at all, so a
+# ```tsx fence fell back to flat dimmed text with no per-token color before
+# this. `default-features = false` + `syntect-fancy` picks the same
+# fancy-regex backend `syntect` above already defaults to (not `syntect-onig`,
+# which needs a C regex engine) so the two crates share one syntect build
+# instead of pulling in both regex backends.
+two-face = { version = "0.5", default-features = false, features = [
+    "syntect-fancy",
+] }
 ratatui-textarea = "0.9"
 nucleo-matcher = "0.3"
 serde = { version = "1", features = ["derive"] }

--- a/shiki-tui/Cargo.toml
+++ b/shiki-tui/Cargo.toml
@@ -19,6 +19,7 @@ ratatui-textarea.workspace = true
 tokio.workspace = true
 comrak.workspace = true
 syntect.workspace = true
+two-face.workspace = true
 anyhow.workspace = true
 thiserror.workspace = true
 tracing.workspace = true

--- a/shiki-tui/src/app.rs
+++ b/shiki-tui/src/app.rs
@@ -457,21 +457,24 @@ pub(crate) enum DeleteTarget {
     Notebook,
 }
 
-/// `(note path, [fg, accent, muted, link, bg, tag], content width, formatted
-/// lines, source-line-per-row)` — see `App::note_preview_cache`'s own doc
-/// comment for what each element means. `bg`/`tag` ride along in the same
-/// array purely so they participate in the cache-key equality check (`bg`
-/// drives `render::is_dark_color`, which picks the syntect syntax-
-/// highlighting theme for code fences; `tag` colors the metadata header's
-/// `#tag` spans — see `panel_preview::metadata_lines`) without two more
-/// tuple fields. Named only to keep clippy's `type_complexity` lint quiet;
-/// still just a plain tuple everywhere it's used. Source-line-per-row is
-/// `None` for the metadata header's own rows (there's no corresponding
-/// `note.body` line to jump to on click) and `Some(line)` for every real
-/// body row, same as before.
+/// `(note path, [fg, accent, muted, link, bg, tag, success, warning], content
+/// width, formatted lines, source-line-per-row)` — see
+/// `App::note_preview_cache`'s own doc comment for what each element means.
+/// `bg`/`tag`/`success`/`warning` ride along in the same array purely so they
+/// participate in the cache-key equality check (`bg` drives
+/// `render::is_dark_color`, which decides the `dark` fallback
+/// `syntax::SyntaxPalette` uses for terminal-native colors with no fixed RGB;
+/// `tag` colors the metadata header's `#tag` spans, see
+/// `panel_preview::metadata_lines`; `success`/`warning` are two more of the
+/// colors `syntax::build_runtime_theme` maps code-fence tokens onto — see
+/// `render::markdown_to_lines_indexed`) without more tuple fields. Named only
+/// to keep clippy's `type_complexity` lint quiet; still just a plain tuple
+/// everywhere it's used. Source-line-per-row is `None` for the metadata
+/// header's own rows (there's no corresponding `note.body` line to jump to
+/// on click) and `Some(line)` for every real body row, same as before.
 type NotePreviewCache = (
     std::path::PathBuf,
-    [Color; 6],
+    [Color; 8],
     u16,
     Vec<Line<'static>>,
     Vec<Option<usize>>,
@@ -2179,6 +2182,8 @@ impl App {
             hex_to_color(&self.theme.link),
             hex_to_color(&self.theme.bg),
             hex_to_color(&self.theme.tag),
+            hex_to_color(&self.theme.success),
+            hex_to_color(&self.theme.warning),
         ];
         let width = layout::split(self.last_frame_area, self.focus, self.zen_mode)
             .preview
@@ -2194,7 +2199,8 @@ impl App {
         let body = note.body.clone();
         let dark = crate::render::is_dark_color(colors[4]);
         let indexed = crate::render::markdown_to_lines_indexed(
-            &body, colors[0], colors[1], colors[2], colors[3], dark,
+            &body, colors[0], colors[1], colors[2], colors[3], colors[5], colors[6], colors[7],
+            dark,
         );
         let (source_indices, plain_lines): (Vec<usize>, Vec<Line<'static>>) =
             indexed.into_iter().unzip();

--- a/shiki-tui/src/app.rs
+++ b/shiki-tui/src/app.rs
@@ -2198,10 +2198,17 @@ impl App {
         }
         let body = note.body.clone();
         let dark = crate::render::is_dark_color(colors[4]);
-        let indexed = crate::render::markdown_to_lines_indexed(
-            &body, colors[0], colors[1], colors[2], colors[3], colors[5], colors[6], colors[7],
+        let palette = crate::syntax::SyntaxPalette {
+            fg: colors[0],
+            accent: colors[1],
+            muted: colors[2],
+            link: colors[3],
+            tag: colors[5],
+            success: colors[6],
+            warning: colors[7],
             dark,
-        );
+        };
+        let indexed = crate::render::markdown_to_lines_indexed(&body, &palette);
         let (source_indices, plain_lines): (Vec<usize>, Vec<Line<'static>>) =
             indexed.into_iter().unzip();
         let grouped = crate::wrap::wrap_lines_grouped(&plain_lines, width);

--- a/shiki-tui/src/render.rs
+++ b/shiki-tui/src/render.rs
@@ -379,18 +379,16 @@ pub fn borrow_lines<'a>(lines: &'a [Line<'static>]) -> Vec<Line<'a>> {
         .collect()
 }
 
-pub fn markdown_to_lines(
-    body: &str,
-    fg: Color,
-    accent: Color,
-    muted: Color,
-    link: Color,
-    tag: Color,
-    success: Color,
-    warning: Color,
-    dark: bool,
-) -> Vec<Line<'static>> {
-    markdown_to_lines_indexed(body, fg, accent, muted, link, tag, success, warning, dark)
+// Only ever called by this module's own tests — `app.rs`'s real PREVIEW
+// render path always needs the source-line mapping, so it calls
+// `markdown_to_lines_indexed` directly instead. `#[cfg(test)]` (rather than
+// leaving it a plain `pub(crate) fn`) is what it takes to say that honestly:
+// this used to be `pub`, which hid the fact that it had no production
+// caller at all (rustc's dead-code lint skips `pub` items on the assumption
+// something outside the crate might use them).
+#[cfg(test)]
+fn markdown_to_lines(body: &str, colors: &crate::syntax::SyntaxPalette) -> Vec<Line<'static>> {
+    markdown_to_lines_indexed(body, colors)
         .into_iter()
         .map(|(_, line)| line)
         .collect()
@@ -406,17 +404,14 @@ pub fn markdown_to_lines(
 /// consumed but produces no rendered row of its own — its index is reused
 /// by the header-divider row rendered in its place instead, so clicking the
 /// divider still lands on a real source line.
-pub fn markdown_to_lines_indexed(
+pub(crate) fn markdown_to_lines_indexed(
     body: &str,
-    fg: Color,
-    accent: Color,
-    muted: Color,
-    link: Color,
-    tag: Color,
-    success: Color,
-    warning: Color,
-    dark: bool,
+    colors: &crate::syntax::SyntaxPalette,
 ) -> Vec<(usize, Line<'static>)> {
+    let fg = colors.fg;
+    let accent = colors.accent;
+    let muted = colors.muted;
+    let link = colors.link;
     let heading = Style::default().fg(accent).add_modifier(Modifier::BOLD);
     let text = Style::default().fg(fg);
     let dim = Style::default().fg(muted).add_modifier(Modifier::ITALIC);
@@ -426,20 +421,6 @@ pub fn markdown_to_lines_indexed(
     // needing a 20th configurable color just for this.
     let math = Style::default().fg(accent).add_modifier(Modifier::ITALIC);
     let link_style = Style::default().fg(link).add_modifier(Modifier::UNDERLINED);
-    // Built once per call (not per fence) and handed to every
-    // `CodeHighlighter::new` in this note — the whole point of adaptive code
-    // highlighting is that it comes straight from the *active* theme's own
-    // colors, not a syntect-bundled palette; see `syntax::build_runtime_theme`.
-    let syntax_palette = crate::syntax::SyntaxPalette {
-        fg,
-        accent,
-        muted,
-        link,
-        tag,
-        success,
-        warning,
-        dark,
-    };
 
     let mut in_code_block = false;
     let mut in_math_block = false;
@@ -460,7 +441,7 @@ pub fn markdown_to_lines_indexed(
                 code_highlighter = if lang.is_empty() || lang == "mermaid" {
                     None
                 } else {
-                    crate::syntax::CodeHighlighter::new(&lang, &syntax_palette)
+                    crate::syntax::CodeHighlighter::new(&lang, colors)
                 };
                 // The opening fence line itself gets a distinct style when
                 // the language is recognized (real highlighting follows) or
@@ -629,9 +610,16 @@ mod tests {
     const ACCENT: Color = Color::Blue;
     const MUTED: Color = Color::Gray;
     const LINK: Color = Color::Cyan;
-    const TAG: Color = Color::Magenta;
-    const SUCCESS: Color = Color::Green;
-    const WARNING: Color = Color::Yellow;
+    const PALETTE: crate::syntax::SyntaxPalette = crate::syntax::SyntaxPalette {
+        fg: FG,
+        accent: ACCENT,
+        muted: MUTED,
+        link: LINK,
+        tag: Color::Magenta,
+        success: Color::Green,
+        warning: Color::Yellow,
+        dark: true,
+    };
 
     fn line_text(line: &Line) -> String {
         line.spans.iter().map(|s| s.content.as_ref()).collect()
@@ -707,7 +695,7 @@ mod tests {
 
     #[test]
     fn bold_inside_a_blockquote_is_still_bold_not_literal_asterisks() {
-        let lines = markdown_to_lines("> **Warning:** be careful", FG, ACCENT, MUTED, LINK, TAG, SUCCESS, WARNING, true);
+        let lines = markdown_to_lines("> **Warning:** be careful", &PALETTE);
         assert_eq!(lines.len(), 1);
         let full = line_text(&lines[0]);
         assert!(!full.contains('*'), "asterisks must not survive: {full:?}");
@@ -739,14 +727,14 @@ mod tests {
 
     #[test]
     fn horizontal_rule_renders_as_a_visible_divider() {
-        let lines = markdown_to_lines("above\n---\nbelow", FG, ACCENT, MUTED, LINK, TAG, SUCCESS, WARNING, true);
+        let lines = markdown_to_lines("above\n---\nbelow", &PALETTE);
         assert_eq!(line_text(&lines[1]), "─".repeat(40));
     }
 
     #[test]
     fn table_renders_aligned_columns_with_a_header_rule() {
         let body = "| Name | Age |\n| --- | --- |\n| Alice | 30 |\n| Bo | 7 |";
-        let lines = markdown_to_lines(body, FG, ACCENT, MUTED, LINK, TAG, SUCCESS, WARNING, true);
+        let lines = markdown_to_lines(body, &PALETTE);
         // header row + divider row + 2 body rows = 4 lines, no leftover
         // raw `|---|` separator line rendered literally.
         assert_eq!(lines.len(), 4);
@@ -766,7 +754,7 @@ mod tests {
     fn table_like_prose_without_a_real_separator_is_left_alone() {
         // A single line with pipes (e.g. a shell example) but no valid
         // `---`-only separator row after it must not trigger table mode.
-        let lines = markdown_to_lines("ls | grep foo | wc -l", FG, ACCENT, MUTED, LINK, TAG, SUCCESS, WARNING, true);
+        let lines = markdown_to_lines("ls | grep foo | wc -l", &PALETTE);
         assert_eq!(lines.len(), 1);
         assert_eq!(line_text(&lines[0]), "ls | grep foo | wc -l");
     }
@@ -774,7 +762,7 @@ mod tests {
     #[test]
     fn details_summary_is_shown_expanded_with_tags_stripped() {
         let body = "<details>\n<summary>Click to expand</summary>\nhidden content\n</details>";
-        let lines = markdown_to_lines(body, FG, ACCENT, MUTED, LINK, TAG, SUCCESS, WARNING, true);
+        let lines = markdown_to_lines(body, &PALETTE);
         // <details>/</details> themselves produce no line; summary becomes
         // a styled header; the body content still renders normally.
         assert_eq!(lines.len(), 2);
@@ -785,7 +773,7 @@ mod tests {
     #[test]
     fn math_block_is_styled_distinctly_from_code_block() {
         let body = "$$\nx = y\n$$";
-        let lines = markdown_to_lines(body, FG, ACCENT, MUTED, LINK, TAG, SUCCESS, WARNING, true);
+        let lines = markdown_to_lines(body, &PALETTE);
         assert_eq!(lines.len(), 3);
         // Content line inside the math block uses `accent`, not `muted`
         // (which code fences use) — the whole point of the distinction.
@@ -795,7 +783,7 @@ mod tests {
     #[test]
     fn tsx_fence_gets_real_per_token_highlighting_not_flat_dim() {
         let body = "```tsx\nconst x = 1;\n```";
-        let lines = markdown_to_lines(body, FG, ACCENT, MUTED, LINK, TAG, SUCCESS, WARNING, true);
+        let lines = markdown_to_lines(body, &PALETTE);
         assert_eq!(lines.len(), 3);
         // Before real highlighting existed (and before `tsx` was a
         // recognized language at all — plain syntect's bundled defaults

--- a/shiki-tui/src/render.rs
+++ b/shiki-tui/src/render.rs
@@ -50,12 +50,13 @@ pub fn git_status_suffix(gs: &shiki_core::git::GitStatus) -> String {
 }
 
 /// Whether a resolved theme color reads as "dark" (perceptual luminance
-/// under half) — used to pick a syntect syntax-highlighting theme
-/// (`syntax::CodeHighlighter`) that won't clash with the active shiki theme
-/// (e.g. a light-on-light syntect theme under catppuccin-latte). `Reset`
-/// (the "default" theme's un-set background) defaults to `true` — most
-/// terminals default to a dark background, and a wrong guess here only
-/// affects code-fence coloring, not correctness.
+/// under half) — feeds `syntax::SyntaxPalette.dark`, which only matters for
+/// `Color::Reset`/`Color::Indexed` theme slots (the "default" theme's
+/// terminal-native colors, which have no fixed RGB `syntect` can use): a
+/// dark-background terminal gets a light fallback text color for code-fence
+/// tokens that inherit those slots, and vice versa. `Reset` itself defaults
+/// to `true` — most terminals default to a dark background, and a wrong
+/// guess here only affects code-fence coloring, not correctness.
 pub fn is_dark_color(color: Color) -> bool {
     match color {
         Color::Rgb(r, g, b) => {
@@ -384,9 +385,12 @@ pub fn markdown_to_lines(
     accent: Color,
     muted: Color,
     link: Color,
+    tag: Color,
+    success: Color,
+    warning: Color,
     dark: bool,
 ) -> Vec<Line<'static>> {
-    markdown_to_lines_indexed(body, fg, accent, muted, link, dark)
+    markdown_to_lines_indexed(body, fg, accent, muted, link, tag, success, warning, dark)
         .into_iter()
         .map(|(_, line)| line)
         .collect()
@@ -408,6 +412,9 @@ pub fn markdown_to_lines_indexed(
     accent: Color,
     muted: Color,
     link: Color,
+    tag: Color,
+    success: Color,
+    warning: Color,
     dark: bool,
 ) -> Vec<(usize, Line<'static>)> {
     let heading = Style::default().fg(accent).add_modifier(Modifier::BOLD);
@@ -419,6 +426,20 @@ pub fn markdown_to_lines_indexed(
     // needing a 20th configurable color just for this.
     let math = Style::default().fg(accent).add_modifier(Modifier::ITALIC);
     let link_style = Style::default().fg(link).add_modifier(Modifier::UNDERLINED);
+    // Built once per call (not per fence) and handed to every
+    // `CodeHighlighter::new` in this note — the whole point of adaptive code
+    // highlighting is that it comes straight from the *active* theme's own
+    // colors, not a syntect-bundled palette; see `syntax::build_runtime_theme`.
+    let syntax_palette = crate::syntax::SyntaxPalette {
+        fg,
+        accent,
+        muted,
+        link,
+        tag,
+        success,
+        warning,
+        dark,
+    };
 
     let mut in_code_block = false;
     let mut in_math_block = false;
@@ -439,7 +460,7 @@ pub fn markdown_to_lines_indexed(
                 code_highlighter = if lang.is_empty() || lang == "mermaid" {
                     None
                 } else {
-                    crate::syntax::CodeHighlighter::new(&lang, dark)
+                    crate::syntax::CodeHighlighter::new(&lang, &syntax_palette)
                 };
                 // The opening fence line itself gets a distinct style when
                 // the language is recognized (real highlighting follows) or
@@ -608,6 +629,9 @@ mod tests {
     const ACCENT: Color = Color::Blue;
     const MUTED: Color = Color::Gray;
     const LINK: Color = Color::Cyan;
+    const TAG: Color = Color::Magenta;
+    const SUCCESS: Color = Color::Green;
+    const WARNING: Color = Color::Yellow;
 
     fn line_text(line: &Line) -> String {
         line.spans.iter().map(|s| s.content.as_ref()).collect()
@@ -683,7 +707,7 @@ mod tests {
 
     #[test]
     fn bold_inside_a_blockquote_is_still_bold_not_literal_asterisks() {
-        let lines = markdown_to_lines("> **Warning:** be careful", FG, ACCENT, MUTED, LINK, true);
+        let lines = markdown_to_lines("> **Warning:** be careful", FG, ACCENT, MUTED, LINK, TAG, SUCCESS, WARNING, true);
         assert_eq!(lines.len(), 1);
         let full = line_text(&lines[0]);
         assert!(!full.contains('*'), "asterisks must not survive: {full:?}");
@@ -715,14 +739,14 @@ mod tests {
 
     #[test]
     fn horizontal_rule_renders_as_a_visible_divider() {
-        let lines = markdown_to_lines("above\n---\nbelow", FG, ACCENT, MUTED, LINK, true);
+        let lines = markdown_to_lines("above\n---\nbelow", FG, ACCENT, MUTED, LINK, TAG, SUCCESS, WARNING, true);
         assert_eq!(line_text(&lines[1]), "─".repeat(40));
     }
 
     #[test]
     fn table_renders_aligned_columns_with_a_header_rule() {
         let body = "| Name | Age |\n| --- | --- |\n| Alice | 30 |\n| Bo | 7 |";
-        let lines = markdown_to_lines(body, FG, ACCENT, MUTED, LINK, true);
+        let lines = markdown_to_lines(body, FG, ACCENT, MUTED, LINK, TAG, SUCCESS, WARNING, true);
         // header row + divider row + 2 body rows = 4 lines, no leftover
         // raw `|---|` separator line rendered literally.
         assert_eq!(lines.len(), 4);
@@ -742,7 +766,7 @@ mod tests {
     fn table_like_prose_without_a_real_separator_is_left_alone() {
         // A single line with pipes (e.g. a shell example) but no valid
         // `---`-only separator row after it must not trigger table mode.
-        let lines = markdown_to_lines("ls | grep foo | wc -l", FG, ACCENT, MUTED, LINK, true);
+        let lines = markdown_to_lines("ls | grep foo | wc -l", FG, ACCENT, MUTED, LINK, TAG, SUCCESS, WARNING, true);
         assert_eq!(lines.len(), 1);
         assert_eq!(line_text(&lines[0]), "ls | grep foo | wc -l");
     }
@@ -750,7 +774,7 @@ mod tests {
     #[test]
     fn details_summary_is_shown_expanded_with_tags_stripped() {
         let body = "<details>\n<summary>Click to expand</summary>\nhidden content\n</details>";
-        let lines = markdown_to_lines(body, FG, ACCENT, MUTED, LINK, true);
+        let lines = markdown_to_lines(body, FG, ACCENT, MUTED, LINK, TAG, SUCCESS, WARNING, true);
         // <details>/</details> themselves produce no line; summary becomes
         // a styled header; the body content still renders normally.
         assert_eq!(lines.len(), 2);
@@ -761,10 +785,34 @@ mod tests {
     #[test]
     fn math_block_is_styled_distinctly_from_code_block() {
         let body = "$$\nx = y\n$$";
-        let lines = markdown_to_lines(body, FG, ACCENT, MUTED, LINK, true);
+        let lines = markdown_to_lines(body, FG, ACCENT, MUTED, LINK, TAG, SUCCESS, WARNING, true);
         assert_eq!(lines.len(), 3);
         // Content line inside the math block uses `accent`, not `muted`
         // (which code fences use) — the whole point of the distinction.
         assert_eq!(lines[1].spans[0].style.fg, Some(ACCENT));
+    }
+
+    #[test]
+    fn tsx_fence_gets_real_per_token_highlighting_not_flat_dim() {
+        let body = "```tsx\nconst x = 1;\n```";
+        let lines = markdown_to_lines(body, FG, ACCENT, MUTED, LINK, TAG, SUCCESS, WARNING, true);
+        assert_eq!(lines.len(), 3);
+        // Before real highlighting existed (and before `tsx` was a
+        // recognized language at all — plain syntect's bundled defaults
+        // don't include TypeScript/TSX), every span on this row shared the
+        // exact same `dim`/`muted` style. Now the line must be tokenized
+        // into more than one span, with at least one span colored something
+        // other than plain `fg`/`muted`.
+        let code_line = &lines[1];
+        assert!(
+            code_line.spans.len() > 1,
+            "expected the code line to be tokenized into multiple spans, got {code_line:?}"
+        );
+        let distinct_colors: std::collections::HashSet<_> =
+            code_line.spans.iter().map(|s| s.style.fg).collect();
+        assert!(
+            distinct_colors.len() > 1,
+            "expected multiple distinct token colors, got {distinct_colors:?}"
+        );
     }
 }

--- a/shiki-tui/src/syntax.rs
+++ b/shiki-tui/src/syntax.rs
@@ -126,15 +126,21 @@ fn to_syntect_color(color: Color, dark: bool) -> SyntectColor {
 /// `ThemeItem` matching any scope beginning with `selector` (TextMate scope
 /// matching is prefix-based per path component, so `"keyword"` also matches
 /// `keyword.control.ts`, `keyword.operator.js`, etc.).
-fn scope_rule(selector: &str, color: SyntectColor, font_style: Option<FontStyle>) -> Option<ThemeItem> {
-    ScopeSelectors::from_str(selector).ok().map(|scope| ThemeItem {
-        scope,
-        style: StyleModifier {
-            foreground: Some(color),
-            background: None,
-            font_style,
-        },
-    })
+fn scope_rule(
+    selector: &str,
+    color: SyntectColor,
+    font_style: Option<FontStyle>,
+) -> Option<ThemeItem> {
+    ScopeSelectors::from_str(selector)
+        .ok()
+        .map(|scope| ThemeItem {
+            scope,
+            style: StyleModifier {
+                foreground: Some(color),
+                background: None,
+                font_style,
+            },
+        })
 }
 
 /// Builds a `syntect::highlighting::Theme` from `palette` in memory, rather
@@ -344,12 +350,20 @@ mod tests {
             .iter()
             .find(|s| s.content.as_ref() == "const")
             .expect("`const` is tokenized as its own span");
-        assert_eq!(const_span.style.fg, Some(accent), "storage keywords use `accent`");
+        assert_eq!(
+            const_span.style.fg,
+            Some(accent),
+            "storage keywords use `accent`"
+        );
         let string_span = spans
             .iter()
             .find(|s| s.content.as_ref().contains("hi"))
             .expect("the string literal is tokenized as its own span");
-        assert_eq!(string_span.style.fg, Some(success), "string literals use `success`");
+        assert_eq!(
+            string_span.style.fg,
+            Some(success),
+            "string literals use `success`"
+        );
     }
 
     #[test]

--- a/shiki-tui/src/syntax.rs
+++ b/shiki-tui/src/syntax.rs
@@ -4,39 +4,51 @@
 //! visual treatment as a blockquote, with no per-token color at all despite
 //! `syntect` already being a workspace dependency.
 //!
-//! `SyntaxSet`/`ThemeSet` are process-wide, loaded once behind `OnceLock`
-//! (both are non-trivial to build — they parse a bundle of `.sublime-syntax`/
-//! `.tmTheme` files) and never rebuilt, same "expensive walk once" discipline
-//! as `App`'s various `refresh_*_cache` methods.
+//! Two things layer on top of that first pass:
+//!
+//! - **Language coverage** comes from `two_face::syntax::extra_newlines`, not
+//!   `syntect::parsing::SyntaxSet::load_defaults_newlines`. Plain syntect's
+//!   bundled defaults don't include TypeScript or TSX at all (a long-standing
+//!   gap in syntect's own asset bundle) — a ```tsx fence rendered as flat
+//!   dimmed text even after highlighting existed. `two-face` bundles ~150
+//!   extra syntaxes (from `bat`'s asset collection, TypeScript/TSX included)
+//!   on top of syntect's own defaults, so it's a drop-in replacement rather
+//!   than something merged in alongside them.
+//! - **Colors adapt to whichever shiki theme is active**, rather than a
+//!   syntect theme bundled from `syntect::highlighting::ThemeSet` (the
+//!   original version picked between exactly two fixed themes,
+//!   `base16-ocean.dark`/`InspiredGitHub`, by dark/light only — every one of
+//!   shiki's 12+ themes rendered code fences in the same two palettes
+//!   regardless of the theme's own accent/hue, e.g. gruvbox's code blocks
+//!   never looked gruvbox-yellow). `build_runtime_theme` constructs a
+//!   `syntect::highlighting::Theme` in memory from the active `Theme`'s own
+//!   color slots (`accent`/`success`/`warning`/`link`/`tag`/`muted`/`fg`) —
+//!   there's no dedicated "keyword"/"string"/"function" slot in
+//!   `shiki_config::Theme`, so this reuses the closest existing slot for
+//!   each (see `build_runtime_theme`'s own comment for the exact mapping).
+//!
+//! `SyntaxSet` is process-wide, loaded once behind `OnceLock` (non-trivial to
+//! build — it parses a bundle of `.sublime-syntax` files), same "expensive
+//! walk once" discipline as `App`'s various `refresh_*_cache` methods. The
+//! runtime `Theme` can't share that treatment: it's derived from the active
+//! shiki theme's colors, which change (theme picker live-preview, switching
+//! themes) — it's rebuilt per `CodeHighlighter::new` call instead, which is
+//! cheap (a dozen or so `ThemeItem`s, no file I/O).
 
+use std::str::FromStr;
 use std::sync::OnceLock;
 
 use ratatui::style::{Color, Modifier, Style};
 use ratatui::text::Span;
-use syntect::easy::HighlightLines;
-use syntect::highlighting::{FontStyle, ThemeSet};
-use syntect::parsing::{SyntaxReference, SyntaxSet};
+use syntect::highlighting::{
+    Color as SyntectColor, FontStyle, HighlightIterator, HighlightState, Highlighter,
+    ScopeSelectors, StyleModifier, Theme, ThemeItem, ThemeSettings,
+};
+use syntect::parsing::{ParseState, ScopeStack, SyntaxReference, SyntaxSet};
 
 fn syntax_set() -> &'static SyntaxSet {
     static SET: OnceLock<SyntaxSet> = OnceLock::new();
-    SET.get_or_init(SyntaxSet::load_defaults_newlines)
-}
-
-fn theme_set() -> &'static ThemeSet {
-    static SET: OnceLock<ThemeSet> = OnceLock::new();
-    SET.get_or_init(ThemeSet::load_defaults)
-}
-
-/// Picks a bundled syntect theme by the *app* theme's own background
-/// luminance, so a code block reads as dark-on-dark or light-on-light
-/// consistent with whichever shiki theme is active (e.g. catppuccin-latte)
-/// rather than a single fixed syntect theme clashing with a light palette.
-fn syntect_theme_name(dark: bool) -> &'static str {
-    if dark {
-        "base16-ocean.dark"
-    } else {
-        "InspiredGitHub"
-    }
+    SET.get_or_init(two_face::syntax::extra_newlines)
 }
 
 fn find_syntax<'a>(set: &'a SyntaxSet, lang: &str) -> Option<&'a SyntaxReference> {
@@ -45,33 +57,189 @@ fn find_syntax<'a>(set: &'a SyntaxSet, lang: &str) -> Option<&'a SyntaxReference
 }
 
 /// Whether `lang` (a fence's info-string language tag, already lowercased)
-/// is one `syntect`'s bundled syntax defs actually recognize — checked
-/// up front so the fence-language line itself can be styled to signal
-/// "this will be highlighted" vs. "this falls back to plain dimmed text".
+/// is one `syntect`'s (plus `two-face`'s extra bundle's) syntax defs actually
+/// recognize — checked up front so the fence-language line itself can be
+/// styled to signal "this will be highlighted" vs. "this falls back to plain
+/// dimmed text".
 pub(crate) fn is_known_language(lang: &str) -> bool {
     !lang.is_empty() && find_syntax(syntax_set(), lang).is_some()
+}
+
+/// The color inputs `CodeHighlighter` builds a syntect `Theme` from — every
+/// field is a color slot already resolved off the active `shiki_config::Theme`
+/// (`render::hex_to_color`), plus `dark` (from `render::is_dark_color(bg)`)
+/// for the one case (`Color::Reset`/`Color::Indexed`, the "default" theme's
+/// terminal-native colors) that has no fixed RGB to hand syntect at all. A
+/// plain struct instead of seven positional args, since `CodeHighlighter::new`
+/// and `build_runtime_theme` both need the full set together.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct SyntaxPalette {
+    pub(crate) fg: Color,
+    pub(crate) accent: Color,
+    pub(crate) muted: Color,
+    pub(crate) link: Color,
+    pub(crate) tag: Color,
+    pub(crate) success: Color,
+    pub(crate) warning: Color,
+    pub(crate) dark: bool,
+}
+
+/// Approximates a ratatui `Color` as a concrete RGB `syntect` can use.
+/// `Rgb` (every hex-based theme slot) passes through exactly; the ANSI names
+/// (used by the "default" theme, which deliberately has no fixed palette —
+/// see `Theme::terminal_default`) get a fixed approximation of that name's
+/// usual terminal appearance, since syntect has no concept of "whatever the
+/// terminal's own red is" to defer to. `Reset`/`Indexed` have no color to
+/// approximate at all, so they fall back to a plain light/dark gray picked
+/// from `dark` — legible against either background without guessing a hue.
+fn to_syntect_color(color: Color, dark: bool) -> SyntectColor {
+    let rgb = |r: u8, g: u8, b: u8| SyntectColor { r, g, b, a: 0xFF };
+    match color {
+        Color::Rgb(r, g, b) => rgb(r, g, b),
+        Color::Black => rgb(0x00, 0x00, 0x00),
+        Color::Red => rgb(0xcd, 0x31, 0x31),
+        Color::Green => rgb(0x0d, 0xbc, 0x79),
+        Color::Yellow => rgb(0xe5, 0xe5, 0x10),
+        Color::Blue => rgb(0x24, 0x72, 0xc8),
+        Color::Magenta => rgb(0xbc, 0x3f, 0xbc),
+        Color::Cyan => rgb(0x11, 0xa8, 0xcd),
+        Color::White => rgb(0xff, 0xff, 0xff),
+        Color::Gray => rgb(0xe5, 0xe5, 0xe5),
+        Color::DarkGray => rgb(0x66, 0x66, 0x66),
+        Color::LightRed => rgb(0xf1, 0x4c, 0x4c),
+        Color::LightGreen => rgb(0x23, 0xd1, 0x8b),
+        Color::LightYellow => rgb(0xf5, 0xf5, 0x43),
+        Color::LightBlue => rgb(0x3b, 0x8e, 0xea),
+        Color::LightMagenta => rgb(0xd6, 0x70, 0xd6),
+        Color::LightCyan => rgb(0x29, 0xb8, 0xdb),
+        Color::Reset | Color::Indexed(_) => {
+            if dark {
+                rgb(0xd0, 0xd0, 0xd0)
+            } else {
+                rgb(0x30, 0x30, 0x30)
+            }
+        }
+    }
+}
+
+/// One scope-selector rule, e.g. `("keyword", accent, None)` — builds a
+/// `ThemeItem` matching any scope beginning with `selector` (TextMate scope
+/// matching is prefix-based per path component, so `"keyword"` also matches
+/// `keyword.control.ts`, `keyword.operator.js`, etc.).
+fn scope_rule(selector: &str, color: SyntectColor, font_style: Option<FontStyle>) -> Option<ThemeItem> {
+    ScopeSelectors::from_str(selector).ok().map(|scope| ThemeItem {
+        scope,
+        style: StyleModifier {
+            foreground: Some(color),
+            background: None,
+            font_style,
+        },
+    })
+}
+
+/// Builds a `syntect::highlighting::Theme` from `palette` in memory, rather
+/// than loading a bundled `.tmTheme` — there's no per-token-role color slot
+/// in `shiki_config::Theme` (it's `bg`/`fg`/`accent`/`selection`/... , not
+/// `keyword`/`string`/`function`), so each TextMate scope category below is
+/// mapped onto whichever existing slot reads closest to how GitHub/most
+/// editor themes color that category:
+/// - `comment` → `muted`, italic (already the "de-emphasized text" slot)
+/// - `string`/`constant.character` → `success` (strings read as "data", the
+///   same role `success` plays elsewhere — green in most themes)
+/// - `constant.numeric`/`constant.language` → `warning` (numbers/booleans;
+///   distinct from strings without a dedicated color slot)
+/// - `keyword`/`storage` → `accent` — covers control-flow keywords
+///   (`if`/`return`) *and* the declaration keywords (`const`/`let`/
+///   `function`/`class`), which TextMate grammars scope as `storage.*`, not
+///   `keyword.*`; without `storage` here `function`/`const` in a ```tsx
+///   fence stayed plain-colored, which is the specific gap that prompted
+///   this file
+/// - `entity.name.function`/`support.function`/`entity.name.tag` → `link`
+///   (function/method/JSX-tag names — GitHub colors these distinctly from
+///   both keywords and plain identifiers)
+/// - `entity.name.type`/`entity.name.class`/`support.type`/`support.class`
+///   → `tag` (type/class/interface names)
+///
+/// Anything not listed (plain identifiers, punctuation, operators) falls
+/// through to `settings.foreground` (`fg`) — the same "everything not
+/// explicitly styled reads as normal text" default a real `.tmTheme` has.
+fn build_runtime_theme(palette: &SyntaxPalette) -> Theme {
+    let fg = to_syntect_color(palette.fg, palette.dark);
+    let accent = to_syntect_color(palette.accent, palette.dark);
+    let muted = to_syntect_color(palette.muted, palette.dark);
+    let link = to_syntect_color(palette.link, palette.dark);
+    let tag = to_syntect_color(palette.tag, palette.dark);
+    let success = to_syntect_color(palette.success, palette.dark);
+    let warning = to_syntect_color(palette.warning, palette.dark);
+
+    let scopes: Vec<ThemeItem> = [
+        ("comment", muted, Some(FontStyle::ITALIC)),
+        ("string", success, None),
+        ("constant.character", success, None),
+        ("constant.numeric", warning, None),
+        ("constant.language", warning, None),
+        ("keyword", accent, None),
+        ("storage", accent, None),
+        ("entity.name.function", link, None),
+        ("support.function", link, None),
+        ("entity.name.tag", link, None),
+        ("entity.name.type", tag, None),
+        ("entity.name.class", tag, None),
+        ("support.type", tag, None),
+        ("support.class", tag, None),
+    ]
+    .into_iter()
+    .filter_map(|(selector, color, font_style)| scope_rule(selector, color, font_style))
+    .collect();
+
+    Theme {
+        name: Some("shiki-adaptive".to_string()),
+        author: None,
+        settings: ThemeSettings {
+            foreground: Some(fg),
+            ..ThemeSettings::default()
+        },
+        scopes,
+    }
 }
 
 /// One code fence's worth of incremental highlighter state: created when a
 /// ` ```lang ` fence with a recognized language opens, fed one source line
 /// at a time in order, dropped the moment the fence closes. `syntect`'s
-/// `HighlightLines` keeps internal parse-stack state across lines (needed
-/// for correct highlighting of multi-line constructs like block comments),
-/// so it can't be recreated per-line — this struct exists specifically to
-/// carry that state across `markdown_to_lines_indexed`'s line-by-line loop.
+/// parse/highlight state keeps internal parse-stack state across lines
+/// (needed for correct highlighting of multi-line constructs like block
+/// comments), so it can't be recreated per-line — this struct exists
+/// specifically to carry that state across `markdown_to_lines_indexed`'s
+/// line-by-line loop.
+///
+/// Owns its `Theme` rather than borrowing one from a `'static` bundled
+/// `ThemeSet` (the original version did, since the theme was one of two
+/// fixed, process-wide values) — `build_runtime_theme` constructs a fresh
+/// one per active shiki theme, so there's nothing `'static` to borrow from
+/// any more. `syntect::highlighting::Highlighter` only borrows a `Theme` for
+/// as long as a single call needs it (it's a cheap wrapper, not something
+/// worth persisting), so it's reconstructed from `self.theme` inside every
+/// `highlight()` call instead of stored — that sidesteps the alternative
+/// (storing a `Theme` and a `Highlighter<'_>` borrowing it in the same
+/// struct, which Rust can't express without unsafe self-reference).
 pub(crate) struct CodeHighlighter {
-    highlighter: HighlightLines<'static>,
+    theme: Theme,
+    parse_state: ParseState,
+    highlight_state: HighlightState,
 }
 
 impl CodeHighlighter {
     /// `None` if `lang` isn't recognized — the caller falls back to the
     /// plain dimmed-text style code fences always used before this existed.
-    pub(crate) fn new(lang: &str, dark: bool) -> Option<Self> {
-        let set = syntax_set();
-        let syntax = find_syntax(set, lang)?;
-        let theme = theme_set().themes.get(syntect_theme_name(dark))?;
+    pub(crate) fn new(lang: &str, palette: &SyntaxPalette) -> Option<Self> {
+        let syntax = find_syntax(syntax_set(), lang)?;
+        let theme = build_runtime_theme(palette);
+        let highlighter = Highlighter::new(&theme);
+        let highlight_state = HighlightState::new(&highlighter, ScopeStack::new());
         Some(Self {
-            highlighter: HighlightLines::new(syntax, theme),
+            theme,
+            parse_state: ParseState::new(syntax),
+            highlight_state,
         })
     }
 
@@ -81,9 +249,17 @@ impl CodeHighlighter {
     /// before highlighting and stripped back off the last span afterward.
     pub(crate) fn highlight(&mut self, line: &str) -> Vec<Span<'static>> {
         let with_newline = format!("{line}\n");
-        let Ok(ranges) = self.highlighter.highlight_line(&with_newline, syntax_set()) else {
+        let Ok(ops) = self.parse_state.parse_line(&with_newline, syntax_set()) else {
             return vec![Span::styled(line.to_string(), Style::default())];
         };
+        let highlighter = Highlighter::new(&self.theme);
+        let ranges: Vec<(syntect::highlighting::Style, &str)> = HighlightIterator::new(
+            &mut self.highlight_state,
+            &ops[..],
+            &with_newline,
+            &highlighter,
+        )
+        .collect();
         ranges
             .into_iter()
             .map(|(style, text)| {
@@ -112,11 +288,32 @@ impl CodeHighlighter {
 mod tests {
     use super::*;
 
+    const PALETTE: SyntaxPalette = SyntaxPalette {
+        fg: Color::White,
+        accent: Color::Blue,
+        muted: Color::Gray,
+        link: Color::Cyan,
+        tag: Color::Magenta,
+        success: Color::Green,
+        warning: Color::Yellow,
+        dark: true,
+    };
+
     #[test]
     fn known_language_is_recognized() {
         assert!(is_known_language("rust"));
         assert!(is_known_language("rs"));
         assert!(is_known_language("python"));
+    }
+
+    #[test]
+    fn typescript_and_tsx_are_recognized() {
+        // Plain syntect's bundled defaults don't include TypeScript/TSX at
+        // all — this only passes because `syntax_set()` uses `two-face`'s
+        // extended bundle instead of `SyntaxSet::load_defaults_newlines`.
+        assert!(is_known_language("typescript"));
+        assert!(is_known_language("ts"));
+        assert!(is_known_language("tsx"));
     }
 
     #[test]
@@ -127,7 +324,7 @@ mod tests {
 
     #[test]
     fn highlighter_tokenizes_a_rust_line_into_multiple_styled_spans() {
-        let mut hl = CodeHighlighter::new("rust", true).expect("rust is a known language");
+        let mut hl = CodeHighlighter::new("rust", &PALETTE).expect("rust is a known language");
         let spans = hl.highlight("fn main() {}");
         let full: String = spans.iter().map(|s| s.content.as_ref()).collect();
         assert_eq!(full, "fn main() {}");
@@ -135,5 +332,45 @@ mod tests {
         // color — that's the whole point of real syntax highlighting vs.
         // the old flat-dim rendering.
         assert!(spans.len() > 1, "expected more than one styled span");
+    }
+
+    #[test]
+    fn tsx_keywords_and_strings_pick_up_the_active_palette_colors() {
+        let mut hl = CodeHighlighter::new("tsx", &PALETTE).expect("tsx is a known language");
+        let spans = hl.highlight(r#"const greet = (): string => "hi";"#);
+        let accent = Color::Rgb(0x24, 0x72, 0xc8); // to_syntect_color(Color::Blue, true)
+        let success = Color::Rgb(0x0d, 0xbc, 0x79); // to_syntect_color(Color::Green, true)
+        let const_span = spans
+            .iter()
+            .find(|s| s.content.as_ref() == "const")
+            .expect("`const` is tokenized as its own span");
+        assert_eq!(const_span.style.fg, Some(accent), "storage keywords use `accent`");
+        let string_span = spans
+            .iter()
+            .find(|s| s.content.as_ref().contains("hi"))
+            .expect("the string literal is tokenized as its own span");
+        assert_eq!(string_span.style.fg, Some(success), "string literals use `success`");
+    }
+
+    #[test]
+    fn different_shiki_themes_produce_different_code_colors() {
+        // The whole point of building the syntect Theme from `SyntaxPalette`
+        // at runtime: two different active shiki themes must not render a
+        // code fence in the same colors.
+        let mut warm = CodeHighlighter::new("rust", &PALETTE).unwrap();
+        let mut cool_palette = PALETTE;
+        cool_palette.accent = Color::Magenta;
+        let mut cool = CodeHighlighter::new("rust", &cool_palette).unwrap();
+        let warm_fn = warm
+            .highlight("fn main() {}")
+            .into_iter()
+            .find(|s| s.content.as_ref() == "fn")
+            .expect("`fn` is tokenized as its own span");
+        let cool_fn = cool
+            .highlight("fn main() {}")
+            .into_iter()
+            .find(|s| s.content.as_ref() == "fn")
+            .expect("`fn` is tokenized as its own span");
+        assert_ne!(warm_fn.style.fg, cool_fn.style.fg);
     }
 }


### PR DESCRIPTION
Fenced code blocks in the PREVIEW panel (` ```lang `) are meant to make code easy to read at a glance, but two gaps got in the way:

1. **TypeScript/TSX fences fell back to flat dimmed text.** Real syntax highlighting already existed for other languages via `syntect`, but `syntect`'s bundled syntax defaults don't include TypeScript or TSX at all — so a ` ```tsx ` or ` ```ts ` block never got real per-token colors like `function`/`const` the way GitHub does.
2. **Code-fence colors didn't match the active shiki theme.** Highlighting picked between exactly two fixed, bundled syntect themes by dark/light only, so every one of shiki's themes (gruvbox, nord, tokyo-night, catppuccin, ...) rendered code in the same two unrelated palettes.

This PR fixes both: it swaps in `two-face`'s extra syntax bundle (adds TypeScript/TSX plus ~150 other languages on top of syntect's own defaults), and builds the syntect highlighting theme at runtime from the *active* shiki theme's own colors (`accent` for keywords/`const`for strings, `warning` for numbers, `link` for function/type names, `muted` forcomments) instead of a fixed bundled theme — so switching themes now changes code-block colors too, and TypeScript/TSX highlights correctly out of the box.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation
- [ ] Refactor / internal change (no behavior change)
- [ ] CI / build / packaging

## Checklist

- [x] `cargo fmt --all` run
- [x] `cargo clippy --workspace --all-targets` clean
- [x] `cargo test --workspace` passing
- [ ] Verified manually (describe how below, if the change touches the TUI 

## How was this tested
- `cargo fmt --all -- --check` — clean                                                                                                                                                          - `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo test --workspace` — **260 passed, 0 failed** (shiki-cli 13, shiki-config 17, shiki-core 131, shiki-tui 99)                                                                             
New tests added: `shiki-tui/src/syntax.rs` (`typescript`/`ts`/`tsx` are recognized languages; a ```tsx fence tokenizes `const`/string literals into palette-colored spans; two different active palettes produce different code colors) and `shiki-tui/src/render.rs` (a ```tsx fctly-colored spans instead of one flat dimmed style).