### PR TITLE
feat(tui): add bold and italic slash menu commands

### DIFF
--- a/shiki-tui/src/slash_menu.rs
+++ b/shiki-tui/src/slash_menu.rs
@@ -35,6 +35,8 @@ pub fn builtins() -> Vec<SlashCommand> {
         builtin("h1", "Heading 1", "# {{cursor}}"),
         builtin("h2", "Heading 2", "## {{cursor}}"),
         builtin("h3", "Heading 3", "### {{cursor}}"),
+        builtin("bold", "Bold text", "**{{cursor}}**"),
+        builtin("italic", "Italic text", "*{{cursor}}*"),
         builtin("code", "Code block", "```\n{{cursor}}\n```"),
         builtin("math", "Math block", "$$\n{{cursor}}\n$$"),
         builtin(


### PR DESCRIPTION
Summary

Adds bold and italic entries to the slash menu (/), so wrapping the cursor in **bold**/*italic* markers no longer requires typing the asterisks by hand. Sits alongside the existing h1/h2/h3/code/math builtins in shiki-tui/src/slash_menu.rs.

Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation
- [ ] Refactor / internal change (no behavior change)
- [ ] CI / build / packaging

Checklist

- [ ] cargo fmt --all run
- [ ] cargo clippy --workspace --all-targets clean
- [ ] cargo test --workspace passing
- [ ] CHANGELOG.md updated under ## [Unreleased] (for user-facing changes)
- [ ] Verified manually

How was this tested?
