### PR TITLE
feat: link hygiene on rename, vault imports, image paste

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,82 @@ semver yet (pre-1.0), but version bumps are still meaningful and tracked here.
 
 ## [Unreleased]
 
+### Added
+
+- **Rename updates every inbound `[[wikilink]]`**: renaming a note (the `r`
+  prompt in NOTES) no longer silently breaks the links other notes hold to
+  it. When the note has backlinks, a confirm asks first — `y` renames *and*
+  rewrites every matching link across every notebook (`[[old title]]`,
+  `[[old-slug]]`, preserving `|display` aliases and `#heading`/`^block`
+  suffixes, skipping fenced code), `n` renames without touching anything,
+  `Esc` cancels. Rewrites go through raw-text surgery per file (frontmatter
+  skipped, never synthesized into plain notes) and respect encrypted
+  notebooks via their cached passphrase; locked ones are skipped rather
+  than half-touched.
+- **`aliases:` frontmatter support** — an optional list of alternate names
+  that resolve exactly like the title does (same case-insensitive +
+  slug fallback) in wikilink resolution, backlinks, and the graph, so a
+  renamed note's old name keeps working even where a rewrite missed (an
+  edit in flight on another machine). The key is the same one Obsidian
+  writes, so imported vaults carry theirs over untouched; empty is omitted
+  from serialization entirely, so existing notes round-trip byte-stable.
+- **`[[note#heading]]` / `[[note^block]]` compatibility** — Obsidian-style
+  sub-addresses now parse as links to `note` everywhere (resolution,
+  backlinks, graph edges, outgoing-links panel); the suffix is stripped
+  before matching instead of being treated as part of the target text.
+- **`![[embed]]` images render in PREVIEW** — an Obsidian-style embed line
+  draws as terminal art (chafa) just like `![alt](path)` does, resolving by
+  bare file name anywhere in the notebook's immediate subfolders (the usual
+  `attachments/` layout of imported vaults) after the ordinary relative-
+  path chain misses. Alias/sub-address parts don't change which file is meant.
+- **Image paste (`Ctrl+V`) saves attachments**: with an image (screenshot)
+  on the clipboard while editing a note, it's saved as a PNG under the
+  current notebook's `[general] attachments_dir` (default `attachments/`,
+  resolved against the notebook root so the inserted
+  `![pasted-…](attachments/…)` link renders from any folder depth) and the
+  markdown link lands at the cursor as one undo step. Text pastes are
+  unaffected; `[editor] paste_images` (on) gates it, and it only engages
+  for real note edits — not config.toml, snippet bodies, the scratchpad,
+  or conflict files. Both toggles live in Settings (GENERAL/EDITOR).
+- **`shiki import obsidian <vault>`** — adopts an existing Obsidian vault
+  as a notebook: in-place by default (registered under
+  `[notebooks.<name>] path`, files stay put, `--git-init` runs git init
+  when the vault isn't already a repo) or copied into the data dir with
+  `--copy`. `--tags` merges inline `#hashtags` into each note's
+  frontmatter tags through a raw-YAML edit that preserves foreign
+  frontmatter verbatim (Obsidian doesn't write shiki's `notebook:`/
+  `date:` keys, and parsing through the strict struct would have
+  synthesized replacements); plain notes without frontmatter are left
+  untouched.
+- **`shiki import notion <export.zip | folder>`** — converts a Notion
+  markdown export into a fresh notebook: the `<Page> <32-hex-uuid>` name
+  suffixes are stripped from pages and folders, internal page links
+  (URL-percent-encoded, relative or nested) become `[[wikilinks]]` with
+  display aliases preserved when they differ from the target's name, and
+  CSV databases plus non-markdown assets are counted and reported as
+  skipped. Accepts the raw `.zip` or an already-extracted directory.
+
+### Fixed
+
+- A notebook untracked via delete's "keep files, just untrack" answer came
+  back on every relaunch: startup (`App::new`) listed notebooks straight
+  from disk without applying the `hidden` filter only `reload_notebooks`
+  had. One shared filter (`visible_notebooks`) decides for both now.
+  `shiki notebook list` hides them too (with a new `--all` flag showing
+  them marked `(hidden)`), and the browser extension's notebook picker
+  applies the same rule so untracked notebooks stop being capturable.
+- Every CLI subcommand launched the TUI instead of running: the
+  pre-config extension check called `cli.command.take()` unconditionally,
+  consuming whatever command was parsed and leaving `None` behind — which
+  the dispatch reads as "no args, launch TUI". The take is now guarded so
+  only a genuine `Extension` command is consumed.
+- The merge-conflict resolver modal (auto-opened when a pull comes back
+  with conflicts, reopenable any time with `p` while mid-merge) gained
+  `i` — edit inline: loads the conflicted file's raw content into the
+  normal inline editor, and saving writes it back and stages it as that
+  file's resolution, the same bookkeeping `o`/`t`/`e` trigger. Removing
+  conflict markers no longer requires an external editor.
+
 ## [0.9.2] - 2026-08-20
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -479,6 +479,13 @@ config-hidden names (they're filtered out of `App.notebooks` itself) so Settings
 one. It's a one-way action, not a 3-state cycle like `auto_push`/`auto_sync` — a hidden notebook is
 already invisible to NOTEBOOKS, so there's no "hide from here" state to cycle into.
 
+**The hidden filter has exactly one implementation** — `sync.rs::visible_notebooks(store, config)` —
+and both consumers must go through it: `App::reload_notebooks` and `App::new`. Startup used to call
+`store.list()` raw (twice, even), so an untracked notebook silently reappeared on every relaunch;
+`shiki notebook list` hides them too (`--all` shows them marked `(hidden)`), and
+`shiki-native-host`'s `handle_list_notebooks` applies the same rule so the browser extension's
+picker never offers an untracked notebook.
+
 SNIPPETS level 1 additionally supports `a` (new snippet: prompts for a trigger via
 `PendingInput::SettingsSnippetTrigger`, creates it with an empty label/body, and drills straight
 into level 2 so it can be filled in) and `d` (delete: `App.pending_delete_snippet` mirrors
@@ -488,8 +495,9 @@ delete in this app uses). Level 2 shows `label` (a `PendingInput::SettingsSnippe
 prompt) and `body` — `body` is the one field in all of Settings that *doesn't* use a `PendingInput`
 prompt, since a snippet body is arbitrary multi-line text: `Enter` on it instead opens the same
 `Mode::Edit`/`InlineEditor` machinery a note's own body uses, tracked via `App.editing_snippet:
-Option<String>` (checked in `save_and_exit_edit` right alongside `editing_config`, a three-way
-dispatch: config file / snippet body / note body). THEME is the odd one out structurally: `name`
+Option<String>` (checked in `save_and_exit_edit` right alongside `editing_config`, a dispatch that
+also covers the scratchpad flag and `App.editing_conflict: Option<(String, PathBuf)>` — see the
+conflict resolver's `i` below). THEME is the odd one out structurally: `name`
 doesn't edit anything inline at all, it opens the *existing* theme picker (leader+`c`) via
 `open_theme_picker` rather than duplicating its live-preview/commit logic; `overrides` stays
 purely informational (pointed at leader+`c`/`shiki theme create --from` in a status message), since
@@ -838,6 +846,34 @@ successful link the modal rebuilds via `open_links`, so the row visibly migrates
 Backlinks; `Ok(false)` ("nothing linkable left") is a status message, not an error — it means the
 file changed since the mention was detected.
 
+**Renaming a note rewrites every inbound `[[wikilink]]` (`wikilinks::rewrite_links_to`), behind a
+confirm when backlinks exist.** The rename flow (`PendingInput::RenameNote` handling) counts
+backlinks first via `App::backlink_count_for` (cross-notebook — resolution falls back globally, so
+links from *other* notebooks would dangle too); with any found it stages
+`App.pending_rename_links: Option<(String, PathBuf, String)>` and shows a three-way confirm:
+`y` → rewrite + rename, `n` → rename only (a real arm in `handle_confirm_key`, not the catch-all,
+which is cancel), `Esc` → nothing. The rewrite matches old title *and* old filename slug
+case-insensitively on each link's base target (before `#heading`/`^block`), preserves `|display`
+and suffix parts verbatim, skips fenced code blocks and frontmatter, edits files as raw text (so a
+plain note never grows synthesized frontmatter), and decrypts/re-encrypts through each notebook's
+cached passphrase — a locked notebook's files are skipped outright. It runs **before**
+`rename_note_at` (old names must still be current to match) and returns `(links, notes, touched)`
+so every touched notebook registers with auto_sync. Frontmatter gained an Obsidian-compatible
+`aliases: Vec<String>` field (`skip_serializing_if` empty), included as resolution keys everywhere
+(`resolve_one`, `resolve_one_global`, `backlinks`, `edges`) — so even links a rewrite missed keep
+resolving after a rename. `[[note#heading]]`/`[[note^block]]` sub-addresses parse everywhere too:
+`extract`'s regex stops the target capture at `#`/`^`, and the resolvers strip the suffix before
+matching.
+
+**The merge-conflict resolver modal** (auto-opened when a pull returns `ConflictsPending`,
+reopenable with `p` while mid-merge since closing with `Esc` resolves nothing) resolves per file
+with `o` ours / `t` theirs / `e` stage-as-is / **`i` edit inline** — `i` loads the raw conflicted
+file into the normal inline editor tracked by `App.editing_conflict`; saving writes the buffer back
+verbatim and stages it through the same `finish_resolving_conflict_file` bookkeeping, then reopens
+the modal unless that was the last file (whose resolution stages the "commit this merge?" confirm).
+Note editing stays blocked during a merge otherwise (`merge_blocks_editing`) — the normal save path
+would commit markers as content.
+
 **The theme picker's `Enter` (and `shiki theme set`) only reset `config.theme.overrides` when the
 base theme name is actually *changing*, not on every confirm/set.** Both used to zero out
 `ThemeOverrides` unconditionally — even re-confirming the theme that was already active with no
@@ -902,6 +938,22 @@ OS favorite doesn't need hand-editing config.toml — the footer always shows wh
 the resolved editor's bare binary name (e.g. `nvim`) when on, `native` when off. Every note CRUD
 operation (create via `a`, edit via `i`, delete via `d`, rename via `r`) already works identically
 regardless of which mode is active — `native` isn't a reduced-functionality fallback.
+
+**`shiki import obsidian <vault>` / `shiki import notion <zip|dir>`
+(`shiki-cli/src/commands/import.rs`) are the migration paths.** Obsidian adopts *in-place* by
+default — it only registers `[notebooks.<name>] path = "<abs>"` in config.toml (`--git-init`
+initializes a repo when the vault lacks one; without either, sync just won't work there yet) — or
+duplicates into the data dir with `--copy`. Its `--tags` merge (`merge_tags_into_frontmatter`)
+edits each note's frontmatter as **raw YAML through a generic mapping**, never through shiki's
+strict `Frontmatter` struct: foreign vaults routinely omit shiki's required `notebook:`/`date:`
+keys, so a struct round-trip would fail to parse, synthesize replacements, and clobber the
+author's own dates/titles on save (hit this exact bug live during development — the first smoke
+test rewrote a vault note's `date:` to today). Plain notes without frontmatter are never touched.
+Notion converts an export into a fresh notebook under the data dir: `<Page> <32-hex>` name
+suffixes stripped from every path segment and link target, percent-encoded internal `.md` links
+rewritten to `[[wikilinks]]` (display alias kept when it differs from the target's cleaned name,
+unresolvable targets left untouched), CSV databases counted-and-skipped. The source may be the raw
+`.zip` (extracted via the `zip` crate into a throwaway tempdir) or a pre-extracted folder.
 
 **Note version history (PREVIEW-scope `H`) is real git history, not a separate versioning
 system.** `shiki_core::git::file_history(repo_path, file_relative)` walks the revwalk from `HEAD`
@@ -1024,7 +1076,19 @@ image's source line. The `ImageCtx` is threaded through `markdown_to_lines_index
 precomputed by `App::refresh_note_preview_cache` as `preview_image_scale × panel width` and the
 preview cache is width-keyed, so a resize re-runs chafa at the new width automatically. When
 `chafa` is missing or the file doesn't exist, the renderer falls through to the icon+alt form —
-never a broken frame. `shiki doctor` checks `chafa`/`hunspell` availability.
+never a broken frame. `shiki doctor` checks `chafa`/`hunspell` availability. Obsidian's embed
+syntax renders too: `whole_line_embed_path` parses a whole-line `![[file]]` (alias/`#`/`^` parts
+stripped), and `resolve_embed_path` adds an Obsidian-style bare-name lookup — after the ordinary
+relative chain misses, each base dir's immediate subdirectories are tried (one level, bounded), so
+an imported vault's `attachments/` layout just works.
+
+**Image paste (`Ctrl+V`, `[editor] paste_images` on by default) saves the clipboard image as an
+attachment** (`shiki-tui/src/attachments.rs::save_image`): RGBA straight from arboard (which
+needed its `image-data` feature enabled) → PNG via the `png` crate → written under
+`{notebook}/attachments_dir/pasted-YYYYMMDD-HHMMSS.png` (numeric `-2`/`-3` suffixes on collision,
+never overwrite) with the markdown link inserted as one undo step. It only engages for real note
+edits — the `editing_config`/`editing_snippet`/`editing_scratchpad`/`editing_conflict` flags all
+gate it off — and text on the clipboard always wins over an image.
 
 **`Ctrl+D` in the inline editor inserts a timestamp (`insert_timestamp`, on by default) — and it
 deliberately yields precedence to `multi_cursor`'s own Ctrl+D ("add next occurrence").** The two

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -154,7 +154,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -165,7 +165,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -184,15 +184,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
+dependencies = [
+ "derive_arbitrary",
+]
+
+[[package]]
 name = "arboard"
 version = "3.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0348a1c054491f4bfe6ab86a7b6ab1e44e45d899005de92f58b3df180b36ddaf"
 dependencies = [
  "clipboard-win",
+ "image",
  "log",
  "objc2",
  "objc2-app-kit",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
  "objc2-foundation",
  "parking_lot",
  "percent-encoding",
@@ -409,6 +421,12 @@ name = "byteorder"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
+name = "byteorder-lite"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
 
 [[package]]
 name = "bytes"
@@ -740,6 +758,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
 
 [[package]]
+name = "crossbeam-utils"
+version = "0.8.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61803da095bee82a81bb1a452ecc25d3b2f1416d1897eb86430c6159ef717c17"
+
+[[package]]
 name = "crossterm"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -765,6 +789,12 @@ checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
 dependencies = [
  "winapi",
 ]
+
+[[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-bigint"
@@ -901,6 +931,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 
 [[package]]
+name = "derive_arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
 name = "derive_more"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -962,7 +1003,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1088,7 +1129,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1138,6 +1179,21 @@ name = "fastrand"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
+
+[[package]]
+name = "fax"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caf1079563223d5d59d83c85886a56e586cfd5c1a26292e971a0fa266531ac5a"
+
+[[package]]
+name = "fdeflate"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e6853b52649d4ac5c0bd02320cddc5ba956bdb407c4b75a2c6b75bf51500f8c"
+dependencies = [
+ "simd-adler32",
+]
 
 [[package]]
 name = "ff"
@@ -1502,6 +1558,17 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tracing",
+]
+
+[[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "zerocopy",
 ]
 
 [[package]]
@@ -1889,6 +1956,20 @@ checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
+]
+
+[[package]]
+name = "image"
+version = "0.25.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85ab80394333c02fe689eaf900ab500fbd0c2213da414687ebf995a65d5a6104"
+dependencies = [
+ "bytemuck",
+ "byteorder-lite",
+ "moxcms",
+ "num-traits",
+ "png",
+ "tiff",
 ]
 
 [[package]]
@@ -2323,6 +2404,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "moxcms"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb85c154ba489f01b25c0d36ae69a87e4a1c73a72631fc6c0eb6dde34a73e44b"
+dependencies = [
+ "num-traits",
+ "pxfm",
+]
+
+[[package]]
 name = "nix"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2360,7 +2451,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2832,6 +2923,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "png"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60769b8b31b2a9f263dae2776c37b1b28ae246943cf719eb6946a1db05128a61"
+dependencies = [
+ "bitflags 2.13.1",
+ "crc32fast",
+ "fdeflate",
+ "flate2",
+ "miniz_oxide",
+]
+
+[[package]]
 name = "poly1305"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2954,6 +3058,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "007d8adb5ddab6f8e3f491ac63566a7d5002cc7ed73901f72057943fa71ae1ae"
 
 [[package]]
+name = "pxfm"
+version = "0.1.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d55d956fa96f5ec02be2e13af0e20391a5aa83d6a074e3ad368959d0fab299ea"
+
+[[package]]
+name = "quick-error"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
+
+[[package]]
 name = "quick-xml"
 version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3016,7 +3132,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3394,7 +3510,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3453,7 +3569,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3613,7 +3729,7 @@ dependencies = [
  "tempfile",
  "ureq",
  "urlencoding",
- "zip",
+ "zip 8.6.0",
  "zipsign-api",
 ]
 
@@ -3744,16 +3860,20 @@ dependencies = [
  "clap",
  "crossterm",
  "ratatui",
+ "regex",
  "rpassword",
  "serde_json",
  "serde_yaml",
  "shiki-config",
  "shiki-core",
  "shiki-tui",
+ "tempfile",
  "tokio",
  "toml 1.1.4+spec-1.1.0",
  "tracing",
  "tracing-subscriber",
+ "walkdir",
+ "zip 2.4.2",
 ]
 
 [[package]]
@@ -3809,12 +3929,14 @@ dependencies = [
  "comrak",
  "crossterm",
  "directories",
+ "png",
  "ratatui",
  "ratatui-textarea",
  "serde_yaml",
  "shiki-config",
  "shiki-core",
  "syntect",
+ "tempfile",
  "thiserror 2.0.20",
  "tokio",
  "tracing",
@@ -3916,7 +4038,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4081,7 +4203,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4094,7 +4216,7 @@ dependencies = [
  "parking_lot",
  "rustix",
  "signal-hook",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4104,7 +4226,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
 dependencies = [
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4217,6 +4339,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ad99c4c6d32803332c548b1af0540b357b3f5fc0be8f6c6bfe8b2e6ae784070"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "tiff"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b63feaf3343d35b6ca4d50483f94843803b0f51634937cc2ec519fc32232bc52"
+dependencies = [
+ "fax",
+ "flate2",
+ "half",
+ "quick-error",
+ "weezl",
+ "zune-jpeg",
 ]
 
 [[package]]
@@ -4856,6 +4992,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "weezl"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a28ac98ddc8b9274cb41bb4d9d4d5c425b6020c50c46f25559911905610b4a88"
+
+[[package]]
 name = "wezterm-bidi"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4949,7 +5091,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5374,6 +5516,23 @@ dependencies = [
 
 [[package]]
 name = "zip"
+version = "2.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fabe6324e908f85a1c52063ce7aa26b68dcb7eb6dbc83a2d148403c9bc3eba50"
+dependencies = [
+ "arbitrary",
+ "crc32fast",
+ "crossbeam-utils",
+ "displaydoc",
+ "flate2",
+ "indexmap",
+ "memchr",
+ "thiserror 2.0.20",
+ "zopfli",
+]
+
+[[package]]
+name = "zip"
 version = "8.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d04a6b5381502aa6087c94c669499eb1602eb9c5e8198e534de571f7154809b"
@@ -5420,4 +5579,19 @@ dependencies = [
  "crc32fast",
  "log",
  "simd-adler32",
+]
+
+[[package]]
+name = "zune-core"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d56377fd46368984a170bc5aac5567e52ca5da874caa60bea39fcbca78fb658b"
+
+[[package]]
+name = "zune-jpeg"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27bc9d5b815bc103f142aa054f561d9187d191692ec7c2d1e2b4737f8dbd7296"
+dependencies = [
+ "zune-core",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,6 +52,8 @@ serde_yaml = "0.9"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 regex = "1"
+walkdir = "2"
+zip = { version = "2", default-features = false, features = ["deflate"] }
 pulldown-cmark = "0.13"
 anyhow = "1"
 thiserror = "2"
@@ -73,7 +75,8 @@ tempfile = "3"
 # `default-features = false` drops the default `image-data` feature (and its
 # `image`/`objc2-core-graphics`/etc. transitive deps) — shiki only ever
 # copies/pastes plain text through this, never images.
-arboard = { version = "3", default-features = false }
+arboard = { version = "3", default-features = false, features = ["image-data"] }
+png = "0.18"
 # age::scrypt — symmetric passphrase-based encryption for `[notebooks.<name>]
 # encrypt = true`. Pure-Rust, no system libsodium/openssl dependency. The
 # `armor` feature is required for ASCII-armored output (so ciphertext still

--- a/IDEA.md
+++ b/IDEA.md
@@ -242,13 +242,26 @@ falling back to the global `[git]` values for anything left unset. A failed push
 etc.) never blocks or loses anything — the commit already happened locally either way, and the next
 sync attempt (manual or automatic) just tries the push again.
 
+#### Merge conflicts (the resolver modal)
+
+A pull that can't fast-forward (both sides diverged) leaves the notebook mid-merge and **opens the
+conflict resolver automatically** — one file per row, real side-by-side OURS/THEIRS diffs loaded
+from libgit2 when you press `enter` on one. Per file: `o` keeps ours, `t` keeps theirs, `i` opens
+the conflicted file in the normal inline editor (markers and all — removing them and saving stages
+the result as that file's resolution), `e` stages the file as-is on disk (for edits made externally).
+`a` aborts the whole merge. Resolving the last file asks "all conflicts resolved — commit this
+merge?" (`y` commits with a `shiki: merge <branch>` message). Closing the modal with `Esc` resolves
+and aborts nothing — it stays mid-merge, note editing is blocked while so (saving through the normal
+path would happily commit markers as content), and pressing `p` again on that notebook reopens the
+resolver instead of attempting a second pull.
+
 #### `[keybindings.notes]` — active while NOTES is focused
 
 | Key | Action |
 |---|---|
 | `a` | New note (empty title stamps today's date). After the title, a template picker opens — every `.md` file in `~/.config/shiki/templates/` plus a "blank" option; `j`/`k` browse, `Enter` picks one and jumps straight to editing (`{{title}}`/`{{date}}`/`{{time}}`/`{{notebook}}` already substituted, and a `{{cursor}}` marker — never saved to disk — leaves the cursor exactly where it was in the template instead of at the top), `Esc`/`q` cancels the note entirely. Typing `@` anywhere in the title prompt (with or without a title before it) opens a quick dropdown instead — `today`/`yesterday`/`tomorrow` (a computed date, no template) plus every available template, fuzzy-filtered as you keep typing; `Enter` creates the note and jumps straight to editing, skipping the title→Enter→pick-a-template two-step entirely |
 | `f` | New folder — empty name cancels rather than creating something unnamed. Created at the current breadcrumb depth, so it can be nested arbitrarily by descending first |
-| `r` | Rename note |
+| `r` | Rename note. When other notes still link to this one, a confirm appears first: `y` renames **and** rewrites every inbound `[[wikilink]]` (across every notebook — old title and old filename slug both match case-insensitively; `|display` aliases and `#heading`/`^block` suffixes are preserved verbatim, fenced code is skipped), `n` renames without touching any link (frontmatter `aliases:` can rescue stragglers later — see the note-format section below), `Esc` cancels outright. With zero backlinks it renames directly, no dialog |
 | `d` | Delete the selected note *or* folder (with confirmation) — a folder deletes everything inside it too. In `v` select mode, deletes every selected item at once. Moved to the trash rather than permanently removed, so leader+`u` can undo it |
 | `i` | Edit inline (or the OS favorite editor if `general.use_favorite_editor`) |
 | `E` | Edit externally ($EDITOR) |
@@ -305,7 +318,11 @@ diagram it can't parse falls back to the previous flat styling rather than break
 
 A `![alt](path)` image that stands alone on its own source line renders as real terminal art in
 PREVIEW by shelling out to `chafa` (a terminal image renderer) — the same external-binary pattern
-as `pretty-pdf` and `hunspell`, so nothing is bundled. The art is drawn at `preview_image_scale` ×
+as `pretty-pdf` and `hunspell`, so nothing is bundled. Obsidian's embed syntax works too: a
+`![[file]]` line (alias `|text` and `#heading`/`^block` suffixes stripped) renders the same way,
+and its file reference resolves by bare name across the notebook's immediate subfolders after the
+ordinary relative chain (note's folder → notebook root → data_dir) misses — the usual
+`attachments/` layout of imported vaults. The art is drawn at `preview_image_scale` ×
 the preview panel's width, is ANSI-SGR-colored half-block art, and scrolls like any other row (a
 real terminal-graphics protocol — kitty/sixel — would anchor images to screen coordinates and
 break scrolling). The path resolves against the note's own folder, then the notebook root, then
@@ -391,6 +408,12 @@ The rest of the editor's mouse/keyboard UX is opt-in via `[editor]` (Settings' E
   typing two real `[` characters in a row.
 - `paste_url_as_link` (on by default): pasting a bare URL over an active selection wraps it as
   `[selected text](url)` instead of replacing the selection with the raw URL.
+- `paste_images` (on by default): `Ctrl+V` with an *image* on the clipboard saves it as a PNG under
+  `[general] attachments_dir` (default `attachments/`, created at the notebook root so the inserted
+  `![pasted-…](attachments/…)` link resolves from any note depth) and drops the markdown link at
+  the cursor as a single undo step — screenshots straight into notes. Only engages for real note
+  edits (not config.toml/snippet/scratchpad/conflict-file buffers), and only when the clipboard
+  actually holds an image; text pastes behave exactly as before either way.
 - `snippet_expand_tab` (on by default): `Tab`, when the text immediately before the cursor matches
   a configured snippet trigger, replaces that trigger text with the snippet's body instead of
   inserting a literal tab.
@@ -489,6 +512,10 @@ shiki query --saved due-soon                        # run a query saved under [q
 shiki theme list          # list built-in themes, marking the active one
 shiki theme set <name>    # switch theme (persisted to config.toml)
 shiki theme create [--from <name>]  # scaffold all 19 color overrides from a real palette
+shiki import obsidian ~/vaults/personal          # adopt a vault in-place as notebook "personal"
+shiki import obsidian ~/vaults/work --copy --tags --git-init  # copy in, merge inline #tags, git init
+shiki import notion ~/Downloads/Export-....zip   # UUID-stripped, links -> wikilinks
+shiki import notion ~/Downloads/export --name work
 shiki doctor              # environment check: config, data dir, git, editor, terminal, keybindings, snippets
 ```
 
@@ -725,6 +752,7 @@ could collide with one.
 title: My note
 date: 2026-07-22
 tags: [rust, tui, ideas]
+aliases: [My old title]
 notebook: personal
 links: [[another-note]], [[third-link]]
 template: default
@@ -740,9 +768,20 @@ Content in **markdown**.
 [[wikilink]] to another note — navigable from the TUI.
 ```
 
+`aliases` is optional and Obsidian-compatible: every entry resolves like the title does (same
+case-insensitive match plus slug fallback) wherever wikilinks are resolved, so links written against
+an old name keep working after a rename. The key is omitted entirely from serialization when empty,
+so notes that never use aliases round-trip byte-stable.
+
+Wikilinks also tolerate Obsidian's sub-address syntax — `[[note#heading]]` and `[[note^block-id]]`
+resolve to `note` everywhere (the suffix is stripped before matching, never treated as part of the
+target text).
+
 Notebooks also tolerate `.txt` and `.mdx` files alongside `.md` when listing/reading notes — a
 notebook pointed at an existing Obsidian vault or similar commonly has both. New notes are always
-created as `.md`; renaming a `.txt`/`.mdx` note preserves its original extension.
+created as `.md`; renaming a `.txt`/`.mdx` note preserves its original extension. Dot-directories
+are never listed or descended into — beyond shiki's own `.git`, that keeps an adopted vault's
+`.obsidian/` (settings), `.trash/`, and friends from showing up as notebook folders.
 
 ---
 
@@ -861,6 +900,9 @@ preview_images = true
 chafa_path = ""
 # Fraction of the preview panel's width the art is drawn at (0.0, 1.0].
 preview_image_scale = 0.5
+# Notebook-root folder pasted images (Ctrl+V with an image on the
+# clipboard) are saved into; the inserted link resolves from any note depth.
+attachments_dir = "attachments"
 
 [keybindings]
 leader = "space"
@@ -982,6 +1024,7 @@ auto_list_continue = true  # Enter continues a list/checkbox line; empty item ex
 format_shortcuts = true    # Ctrl+B / Ctrl+Alt+I wrap the selection in bold/italic
 auto_pair_brackets = true  # typing ( ` " wraps the selection or inserts an empty pair
 paste_url_as_link = true   # pasting a URL over a selection wraps it as a markdown link
+paste_images = true        # Ctrl+V with an image saves it to attachments/ and inserts the link
 snippet_expand_tab = true  # Tab expands a matching snippet trigger
 typewriter_scroll = false  # keeps the cursor's line vertically centered while typing
 move_line = true          # Alt+Up/Alt+Down move the current line past its neighbor

--- a/README.md
+++ b/README.md
@@ -124,8 +124,15 @@ the [website](https://sazardev.github.io/shiki/#themes).
   flags duplicate/colliding keybindings, `/`-menu snippet triggers, unrecognized `config.toml` keys,
   and colliding notebook paths before they cause confusion.
 - **CLI commands** alongside the TUI (`new`, `capture`, `list`, `edit`, `show`, `search`,
-  `daily`, `sync`, `export`, `publish`, `tasks`, `graph`, `query`, `notebook`, `theme`,
+  `daily`, `sync`, `export`, `publish`, `tasks`, `graph`, `query`, `notebook`, `theme`, `import`,
   `config`, `doctor`) for quick one-off operations without opening the UI.
+- **One-command migration**: `shiki import obsidian <vault>` adopts an existing Obsidian vault as
+  a notebook in place (`--copy` to duplicate, `--tags` to merge inline #hashtags into frontmatter),
+  and `shiki import notion <export.zip>` converts a Notion export — UUID-stripped names, internal
+  links become `[[wikilinks]]`. Renaming notes updates every inbound `[[wikilink]]` (behind a
+  confirm), Obsidian's `aliases:` and `[[note#heading]]` syntax resolve natively, `![[embed]]`
+  images render in PREVIEW, and pasting a screenshot with `Ctrl+V` saves it into the notebook's
+  `attachments/` and inserts the link.
 
 ## Install
 

--- a/shiki-cli/Cargo.toml
+++ b/shiki-cli/Cargo.toml
@@ -30,3 +30,7 @@ toml.workspace = true
 serde_json.workspace = true
 serde_yaml.workspace = true
 rpassword.workspace = true
+regex.workspace = true
+walkdir = "2"
+zip = { version = "2", default-features = false, features = ["deflate"] }
+tempfile.workspace = true

--- a/shiki-cli/src/commands/import.rs
+++ b/shiki-cli/src/commands/import.rs
@@ -1,0 +1,588 @@
+//! `shiki import` — one-command migration from the two sources people
+//! actually have: an existing Obsidian vault (`obsidian`, adopted
+//! in-place by default) and a Notion markdown export (`notion`, converted
+//! into a fresh notebook under shiki's data dir).
+
+use anyhow::{Context as _, Result};
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+use walkdir::WalkDir;
+
+use shiki_config::config::NotebookGitOverride;
+use shiki_config::Config;
+use shiki_core::NotebookStore;
+
+/// What `import obsidian` did, for the summary printout.
+struct ObsidianReport {
+    notes: usize,
+    folders: usize,
+    assets: usize,
+}
+
+pub fn obsidian(
+    config: &mut Config,
+    store: &NotebookStore,
+    raw_path: &str,
+    name: Option<&str>,
+    copy: bool,
+    convert_tags: bool,
+    git_init: bool,
+) -> Result<()> {
+    let src = expand_home(raw_path)?;
+    anyhow::ensure!(
+        src.is_dir(),
+        "'{}' isn't a directory (pass the vault's root folder)",
+        src.display()
+    );
+    let default_name = src
+        .file_name()
+        .map(|n| n.to_string_lossy().to_string())
+        .context("could not derive a notebook name from that path — pass --name")?;
+    let name = name.unwrap_or(&default_name);
+    shiki_core::notebook::validate_relative_path(name)
+        .with_context(|| format!("'{name}' can't be a notebook name"))?;
+    anyhow::ensure!(
+        store.get(name).is_err(),
+        "a notebook named '{name}' already exists — pass --name to pick another"
+    );
+
+    if copy {
+        let report = copy_obsidian_into_data_dir(store, &src, name)?;
+        println!(
+            "imported '{name}' into the data dir: {} notes, {} folders, {} other files",
+            report.notes, report.folders, report.assets
+        );
+        if convert_tags {
+            if let Ok(nb) = store.get(name) {
+                let (updated, skipped) = convert_inline_tags_reported(&nb.path);
+                println!(
+                    "{updated} notes gained frontmatter tags; {skipped} plain notes left untouched"
+                );
+            }
+        }
+        return Ok(());
+    }
+
+    // Adopt in-place: register the vault's own directory as the notebook's
+    // path — zero duplication, matching shiki's bring-your-own-notes
+    // philosophy ([notebooks.<name>] path).
+    let abs = src.canonicalize().unwrap_or_else(|_| src.clone());
+    if !abs.join(".git").is_dir() {
+        if git_init {
+            shiki_core::git::init_repo(&abs)
+                .with_context(|| format!("could not git init '{}'", abs.display()))?;
+            println!("git repo initialized at '{}'", abs.display());
+        } else {
+            println!(
+                "note: '{}' is not a git repo — re-run with --git-init to enable sync",
+                abs.display()
+            );
+        }
+    }
+    config.notebooks.insert(
+        name.to_string(),
+        NotebookGitOverride {
+            path: Some(abs.display().to_string()),
+            ..Default::default()
+        },
+    );
+    config.save(&Config::default_path()?)?;
+    println!(
+        "adopted '{}' as notebook '{name}' (registered in config.toml)",
+        abs.display()
+    );
+
+    let report = survey_obsidian(&abs);
+    println!(
+        "{} notes, {} folders, {} other files picked up (dot-directories ignored)",
+        report.notes, report.folders, report.assets
+    );
+    if convert_tags {
+        let (converted, skipped) = convert_inline_tags_reported(&abs);
+        println!("{converted} notes gained frontmatter tags; {skipped} plain notes left untouched (no frontmatter to merge into)");
+    } else {
+        println!("(tip: re-run with --tags to merge inline #hashtags into frontmatter)");
+    }
+    Ok(())
+}
+
+fn survey_obsidian(root: &Path) -> ObsidianReport {
+    let mut report = ObsidianReport {
+        notes: 0,
+        folders: 0,
+        assets: 0,
+    };
+    for entry in WalkDir::new(root)
+        .min_depth(1)
+        .into_iter()
+        .filter_entry(|e| !is_dot_entry(e))
+    {
+        let Ok(entry) = entry else { continue };
+        match entry.file_type() {
+            t if t.is_dir() => report.folders += 1,
+            _ => {
+                if is_note_file(entry.path()) {
+                    report.notes += 1;
+                } else {
+                    report.assets += 1;
+                }
+            }
+        }
+    }
+    report
+}
+
+fn copy_obsidian_into_data_dir(
+    store: &NotebookStore,
+    src: &Path,
+    name: &str,
+) -> Result<ObsidianReport> {
+    let nb = store.create(name)?;
+    let mut report = ObsidianReport {
+        notes: 0,
+        folders: 0,
+        assets: 0,
+    };
+    copy_tree(src, &nb.path, &mut report)?;
+    Ok(report)
+}
+
+fn copy_tree(src: &Path, dest: &Path, report: &mut ObsidianReport) -> Result<()> {
+    for entry in std::fs::read_dir(src)?.filter_map(|e| e.ok()) {
+        let name = entry.file_name().to_string_lossy().to_string();
+        if name.starts_with('.') {
+            continue;
+        }
+        let from = entry.path();
+        let to = dest.join(&name);
+        if from.is_dir() {
+            std::fs::create_dir_all(&to)?;
+            report.folders += 1;
+            copy_tree(&from, &to, report)?;
+        } else {
+            std::fs::copy(&from, &to)?;
+            if is_note_file(&from) {
+                report.notes += 1;
+            } else {
+                report.assets += 1;
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Merges inline hashtags into every frontmatter-carrying note under
+/// `root`. Plain files without frontmatter are deliberately untouched —
+/// importing must never invent structure inside someone else's vault.
+/// Returns (notes updated, plain notes skipped).
+fn convert_inline_tags_reported(root: &Path) -> (usize, usize) {
+    let mut updated = 0;
+    let mut skipped = 0;
+    for entry in WalkDir::new(root)
+        .min_depth(1)
+        .into_iter()
+        .filter_entry(|e| !is_dot_entry(e))
+    {
+        let Ok(entry) = entry else { continue };
+        if !entry.file_type().is_file() || !is_note_file(entry.path()) {
+            continue;
+        }
+        let path = entry.path();
+        let Ok(contents) = std::fs::read_to_string(path) else {
+            continue;
+        };
+        match merge_tags_into_frontmatter(&contents) {
+            Some((new_contents, _)) => {
+                if std::fs::write(path, new_contents).is_ok() {
+                    updated += 1;
+                }
+            }
+            None => skipped += 1,
+        }
+    }
+    (updated, skipped)
+}
+
+/// Rewrites one note's frontmatter block so its `tags` also carries every
+/// inline `#hashtag` found in the body. Works on the *raw* YAML via a
+/// generic mapping round-trip rather than shiki's strict `Frontmatter`
+/// struct — foreign vaults routinely omit `notebook:`/`date:` (Obsidian
+/// doesn't write them), and parsing through the strict struct would fail,
+/// synthesize a brand-new frontmatter, and silently clobber the author's
+/// own dates/titles on save. Returns the new file contents plus how many
+/// tags were added; `None` means "leave this file alone" (no frontmatter,
+/// unparseable YAML, or no inline tags to add).
+fn merge_tags_into_frontmatter(contents: &str) -> Option<(String, usize)> {
+    let rest = contents.strip_prefix("---\n")?;
+    let mut offset = 0;
+    let mut end = None;
+    for line in rest.split_inclusive('\n') {
+        if line.trim_end_matches('\n') == "---" {
+            end = Some(offset);
+            break;
+        }
+        offset += line.len();
+    }
+    let end = end?;
+    let yaml = &rest[..end];
+    let body = rest[end + 3..].trim_start_matches('\n').to_string();
+
+    let mut mapping: serde_yaml::Mapping = serde_yaml::from_str(yaml).ok()?;
+    let inline = shiki_core::tags::inline_hashtags(&body);
+    if inline.is_empty() {
+        return None;
+    }
+    let existing: Vec<String> = mapping
+        .get(serde_yaml::Value::from("tags"))
+        .cloned()
+        .and_then(|v| serde_yaml::from_value(v).ok())
+        .unwrap_or_default();
+    let added: Vec<&String> = inline
+        .iter()
+        .filter(|t| !existing.iter().any(|e| e == *t))
+        .collect();
+    if added.is_empty() {
+        return None;
+    }
+    let added_count = added.len();
+    let mut merged = existing;
+    merged.extend(added.into_iter().cloned());
+    mapping.insert(
+        serde_yaml::Value::from("tags"),
+        serde_yaml::Value::from(merged),
+    );
+    let serialized = serde_yaml::to_string(&mapping).ok()?;
+    Some((format!("---\n{serialized}---\n\n{body}"), added_count))
+}
+
+fn is_note_file(path: &Path) -> bool {
+    matches!(
+        path.extension().and_then(|e| e.to_str()),
+        Some("md") | Some("txt") | Some("mdx")
+    )
+}
+
+fn is_dot_entry(entry: &walkdir::DirEntry) -> bool {
+    entry.depth() > 0 && entry.file_name().to_string_lossy().starts_with('.')
+}
+
+// ---------------------------------------------------------------------------
+// Notion
+// ---------------------------------------------------------------------------
+
+/// Notion exports name every page/folder `<Title> <32-hex-uuid>` — strip
+/// that suffix wherever it appears.
+fn clean_notion_segment(segment: &str) -> String {
+    static RE: std::sync::OnceLock<regex::Regex> = std::sync::OnceLock::new();
+    let re = RE.get_or_init(|| regex::Regex::new(r"\s+[0-9a-fA-F]{32}$").unwrap());
+    re.replace_all(segment.trim(), "").trim().to_string()
+}
+
+/// Minimal percent-decoding for Notion's URL-encoded internal links
+/// (`My%20Page%20abc123.md`) — enough for filenames, which is all these
+/// ever contain.
+fn decode_percent(input: &str) -> String {
+    let bytes = input.as_bytes();
+    let mut out: Vec<u8> = Vec::with_capacity(bytes.len());
+    let mut i = 0;
+    while i < bytes.len() {
+        if bytes[i] == b'%' {
+            if let Some(b) = bytes.get(i + 1..i + 3).and_then(|h| {
+                std::str::from_utf8(h)
+                    .ok()
+                    .and_then(|s| u8::from_str_radix(s, 16).ok())
+            }) {
+                out.push(b);
+                i += 3;
+                continue;
+            }
+        }
+        out.push(bytes[i]);
+        i += 1;
+    }
+    String::from_utf8_lossy(&out).into_owned()
+}
+
+/// Rewrites a Notion export body's markdown links that point at other
+/// exported pages (`[Text](Folder/Page%20Name%20uuid.md)`) into shiki
+/// wikilinks resolved against `titles` (cleaned-stem → cleaned title).
+/// Anything that doesn't resolve — images, CSV attachments, external URLs —
+/// passes through untouched.
+fn rewrite_notion_links(body: &str, titles: &BTreeMap<String, String>) -> (String, usize) {
+    static RE: std::sync::OnceLock<regex::Regex> = std::sync::OnceLock::new();
+    let re = RE.get_or_init(|| regex::Regex::new(r"\[([^\]]*)\]\(([^)\s]+\.md)\)").unwrap());
+    let mut rewrites = 0usize;
+    let out = re.replace_all(body, |caps: &regex::Captures| {
+        let display = caps[1].trim();
+        let target = decode_percent(&caps[2]);
+        let stem = Path::new(&target)
+            .file_stem()
+            .map(|s| s.to_string_lossy().to_string())
+            .unwrap_or_default();
+        let cleaned = clean_notion_segment(&stem);
+        match titles.get(&cleaned.to_lowercase()) {
+            Some(title) => {
+                rewrites += 1;
+                if display.is_empty() || display.eq_ignore_ascii_case(&cleaned) {
+                    format!("[[{title}]]")
+                } else {
+                    format!("[[{title}|{display}]]")
+                }
+            }
+            None => caps[0].to_string(),
+        }
+    });
+    (out.into_owned(), rewrites)
+}
+
+pub fn notion(store: &NotebookStore, raw_path: &str, name: Option<&str>) -> Result<()> {
+    let src = expand_home(raw_path)?;
+    anyhow::ensure!(src.exists(), "'{}' doesn't exist", src.display());
+
+    // Zip exports get unpacked into a throwaway dir; everything downstream
+    // only sees ordinary folders. `scratch` owns that dir for the whole
+    // function (a no-op tempdir when the input was already a folder).
+    let scratch;
+    let root: PathBuf = if src.is_file() && src.extension().and_then(|e| e.to_str()) == Some("zip")
+    {
+        let tmp = tempfile::Builder::new()
+            .prefix("shiki-notion-import-")
+            .tempdir()?;
+        let root = tmp.path().to_path_buf();
+        extract_zip(&src, &root)?;
+        scratch = tmp;
+        root
+    } else if src.is_dir() {
+        scratch = tempfile::tempdir()?; // never written to, just keeps types aligned
+        src.clone()
+    } else {
+        anyhow::bail!("'{}' is neither a .zip export nor a folder", src.display());
+    };
+
+    let default_name = src
+        .file_stem()
+        .map(|n| clean_notion_segment(&n.to_string_lossy()))
+        .filter(|n| !n.is_empty())
+        .unwrap_or_else(|| "notion-import".to_string());
+    let name = name.unwrap_or(&default_name);
+    shiki_core::notebook::validate_relative_path(name)
+        .with_context(|| format!("'{name}' can't be a notebook name"))?;
+    anyhow::ensure!(
+        store.get(name).is_err(),
+        "a notebook named '{name}' already exists — pass --name to pick another"
+    );
+    let nb = store.create(name)?;
+
+    // First pass: index every exported page's cleaned stem → cleaned title,
+    // so second-pass link rewriting can resolve across the whole export.
+    let mut titles: BTreeMap<String, String> = BTreeMap::new();
+    let mut md_files: Vec<PathBuf> = Vec::new();
+    let mut csv_count = 0usize;
+    let mut asset_count = 0usize;
+    for entry in WalkDir::new(&root).min_depth(1).into_iter().flatten() {
+        if !entry.file_type().is_file() || is_dot_entry(&entry) {
+            continue;
+        }
+        let ext = entry
+            .path()
+            .extension()
+            .and_then(|e| e.to_str())
+            .unwrap_or("");
+        match ext {
+            "csv" => csv_count += 1,
+            "md" => {
+                md_files.push(entry.path().to_path_buf());
+                let stem = entry
+                    .path()
+                    .file_stem()
+                    .map(|s| s.to_string_lossy().to_string())
+                    .unwrap_or_default();
+                let cleaned = clean_notion_segment(&stem);
+                if !cleaned.is_empty() {
+                    titles.insert(cleaned.to_lowercase(), cleaned);
+                }
+            }
+            _ => asset_count += 1,
+        }
+    }
+
+    let mut imported = 0usize;
+    let mut folders: BTreeMap<PathBuf, ()> = BTreeMap::new();
+    let mut links_rewritten = 0usize;
+    let mut failed = 0usize;
+    for md in &md_files {
+        let rel = match md.strip_prefix(&root) {
+            Ok(r) => r,
+            Err(_) => continue,
+        };
+        // Create the destination folders one cleaned segment at a time,
+        // remembering which ones already exist so the walk stays cheap and
+        // idempotent.
+        let rel_parent = rel.parent().unwrap_or(Path::new(""));
+        let mut acc = PathBuf::new();
+        for seg in rel_parent.components() {
+            let seg_name = seg.as_os_str().to_string_lossy().to_string();
+            let cleaned_seg = clean_notion_segment(&seg_name);
+            acc.push(if cleaned_seg.is_empty() {
+                seg_name
+            } else {
+                cleaned_seg
+            });
+            if !folders.contains_key(&acc) {
+                let parent_of = acc.parent().map(|p| p.to_path_buf()).unwrap_or_default();
+                let last = acc
+                    .file_name()
+                    .map(|s| s.to_os_string())
+                    .unwrap_or_default();
+                nb.create_folder_in(&parent_of, &last.to_string_lossy())?;
+                folders.insert(acc.clone(), ());
+            }
+        }
+        let relative_parent = acc.to_string_lossy().to_string();
+        let target_dir = if relative_parent.is_empty() {
+            PathBuf::from("")
+        } else {
+            acc.clone()
+        };
+        let Ok(body) = std::fs::read_to_string(md) else {
+            failed += 1;
+            continue;
+        };
+        let (rewritten, count) = rewrite_notion_links(&body, &titles);
+        links_rewritten += count;
+        let stem = md
+            .file_stem()
+            .map(|s| s.to_string_lossy().to_string())
+            .unwrap_or_default();
+        let title = clean_notion_segment(&stem);
+        let title = if title.is_empty() {
+            "untitled".to_string()
+        } else {
+            title
+        };
+        match nb.create_note_in(&target_dir, &title, rewritten) {
+            Ok(_) => imported += 1,
+            Err(_) => failed += 1,
+        }
+    }
+
+    println!(
+        "imported '{name}' from the Notion export: {imported} pages, {} folders, \
+         {links_rewritten} links converted to wikilinks; {csv_count} CSV databases and \
+         {asset_count} other files skipped (Notion databases have no plain-text equivalent)",
+        folders.len()
+    );
+    if failed > 0 {
+        println!("{failed} pages could not be read/imported");
+    }
+    drop(scratch);
+    Ok(())
+}
+
+fn extract_zip(zip_path: &Path, dest: &Path) -> Result<()> {
+    let file =
+        std::fs::File::open(zip_path).with_context(|| format!("opening {}", zip_path.display()))?;
+    let mut archive = zip::ZipArchive::new(file)
+        .with_context(|| format!("reading {} as a zip archive", zip_path.display()))?;
+    archive.extract(dest).context("unpacking the zip export")?;
+    Ok(())
+}
+
+/// `~/…` expansion for the source path argument — imports usually come from
+/// somewhere in the home directory and shell quoting varies.
+fn expand_home(raw: &str) -> Result<PathBuf> {
+    let trimmed = raw.trim();
+    if trimmed == "~" || trimmed.starts_with("~/") {
+        let home = std::env::var_os("HOME")
+            .or_else(|| std::env::var_os("USERPROFILE"))
+            .context("could not resolve '~' (no HOME set)")?;
+        let expanded = if trimmed == "~" {
+            PathBuf::from(home)
+        } else {
+            PathBuf::from(home).join(trimmed.trim_start_matches("~/"))
+        };
+        Ok(expanded)
+    } else {
+        Ok(PathBuf::from(trimmed))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn notion_segments_lose_their_uuid_tail() {
+        assert_eq!(
+            clean_notion_segment("Weekly Plan 0123456789abcdef0123456789abcdef"),
+            "Weekly Plan"
+        );
+        assert_eq!(clean_notion_segment("Just A Page"), "Just A Page");
+        // Only a full 32-char hex tail counts — real titles ending in
+        // hex-ish words survive.
+        assert_eq!(clean_notion_segment("Cafe deadbeef"), "Cafe deadbeef");
+    }
+
+    #[test]
+    fn percent_decoding_handles_spaces_and_utf8() {
+        assert_eq!(
+            decode_percent("My%20Page%201234abcd.md"),
+            "My Page 1234abcd.md"
+        );
+        assert_eq!(decode_percent("plain.md"), "plain.md");
+        assert_eq!(decode_percent("caf%C3%A9%20menu.md"), "café menu.md");
+    }
+
+    #[test]
+    fn notion_links_become_wikilinks_only_when_the_target_exists() {
+        let titles = BTreeMap::from([("weekly plan".to_string(), "Weekly Plan".to_string())]);
+        let body = "See [Weekly Plan](Weekly%20Plan%200123456789abcdef0123456789abcdef.md) \
+                    and [Missing](Nowhere%20fedcba98765432100123456789abcdef.md), \
+                    plus [an image](pic.png).";
+        let (out, count) = rewrite_notion_links(body, &titles);
+        assert_eq!(count, 1);
+        assert!(out.contains("[[Weekly Plan]]"), "{out}");
+        assert!(
+            out.contains("[Missing](Nowhere%20fedcba98765432100123456789abcdef.md)"),
+            "{out}"
+        );
+        assert!(out.contains("[an image](pic.png)"), "{out}");
+    }
+
+    #[test]
+    fn home_expansion_expands_tilde_prefixes_only() {
+        assert_eq!(
+            expand_home("/abs/path").unwrap(),
+            PathBuf::from("/abs/path")
+        );
+    }
+
+    #[test]
+    fn tag_merge_preserves_foreign_frontmatter_verbatim() {
+        let contents = "---\ntitle: Welcome\ndate: 2026-01-15\ntags: [start]\n---\n\n# Welcome\n\nbody with #idea here.\n";
+        let (out, added) = merge_tags_into_frontmatter(contents).unwrap();
+        assert_eq!(added, 1);
+        // The author's own keys survive untouched — only tags gains an entry.
+        assert!(out.contains("title: Welcome"), "{out}");
+        assert!(out.contains("date: 2026-01-15"), "{out}");
+        assert!(out.contains("start"), "{out}");
+        assert!(out.contains("idea"), "{out}");
+        assert!(
+            !out.contains("notebook:"),
+            "must not invent a notebook field: {out}"
+        );
+    }
+
+    #[test]
+    fn tag_merge_skips_notes_without_frontmatter_or_without_tags_to_add() {
+        // No frontmatter at all.
+        assert_eq!(merge_tags_into_frontmatter("plain body #tag\n"), None);
+        // Frontmatter but nothing new inline.
+        let no_new =
+            "---\ntitle: T\nnotebook: nb\ndate: 2026-01-01\ntags: [a]\n---\n\nnothing inline\n";
+        assert_eq!(merge_tags_into_frontmatter(no_new), None);
+        // Already merged (duplicate) -> no-op.
+        let dup = "---\ntitle: T\ndate: 2026-01-01\ntags: [idea]\n---\n\n#idea again\n";
+        assert_eq!(merge_tags_into_frontmatter(dup), None);
+    }
+}

--- a/shiki-cli/src/commands/mod.rs
+++ b/shiki-cli/src/commands/mod.rs
@@ -6,6 +6,7 @@ pub mod edit;
 pub mod export;
 pub mod extension;
 pub mod graph;
+pub mod import;
 pub mod list;
 pub mod new;
 pub mod notebook;

--- a/shiki-cli/src/commands/notebook.rs
+++ b/shiki-cli/src/commands/notebook.rs
@@ -9,8 +9,33 @@ pub fn create(store: &NotebookStore, name: &str) -> Result<()> {
     Ok(())
 }
 
-pub fn list(store: &NotebookStore, json: bool) -> Result<()> {
-    let notebooks = store.list()?;
+pub fn list(store: &NotebookStore, config: &Config, json: bool, all: bool) -> Result<()> {
+    // Notebooks untracked via "keep files, just untrack" ([notebooks.<name>]
+    // hidden = true) stay hidden here too, matching what the TUI lists —
+    // `--all` is the explicit way to see them (marked), e.g. to find
+    // something you untracked and want back.
+    let notebooks: Vec<_> = store
+        .list()?
+        .into_iter()
+        .filter(|nb| {
+            all || !config
+                .notebooks
+                .get(&nb.name)
+                .is_some_and(|over| over.hidden)
+        })
+        .collect();
+    let label = |nb: &shiki_core::Notebook| -> String {
+        if all
+            && config
+                .notebooks
+                .get(&nb.name)
+                .is_some_and(|over| over.hidden)
+        {
+            format!("{} (hidden)", nb.name)
+        } else {
+            nb.name.clone()
+        }
+    };
 
     if json {
         let items: Vec<serde_json::Value> = notebooks
@@ -19,12 +44,14 @@ pub fn list(store: &NotebookStore, json: bool) -> Result<()> {
                 Ok(notes) => serde_json::json!({
                     "name": nb.name,
                     "path": nb.path,
+                    "hidden": config.notebooks.get(&nb.name).is_some_and(|over| over.hidden),
                     "note_count": notes.len(),
                     "error": null,
                 }),
                 Err(e) => serde_json::json!({
                     "name": nb.name,
                     "path": nb.path,
+                    "hidden": config.notebooks.get(&nb.name).is_some_and(|over| over.hidden),
                     "note_count": null,
                     "error": e.to_string(),
                 }),
@@ -38,13 +65,13 @@ pub fn list(store: &NotebookStore, json: bool) -> Result<()> {
         println!("(no notebooks)");
         return Ok(());
     }
-    for nb in notebooks {
+    for nb in &notebooks {
         match nb.all_notes_recursive() {
-            Ok(notes) => println!("{}  ({} notes)", nb.name, notes.len()),
+            Ok(notes) => println!("{}  ({} notes)", label(nb), notes.len()),
             // A failed walk (permissions, I/O) is not the same thing as a
             // genuinely empty notebook — `unwrap_or(0)` used to make the two
             // indistinguishable in this output.
-            Err(e) => println!("{}  (error reading notes: {e})", nb.name),
+            Err(e) => println!("{}  (error reading notes: {e})", label(nb)),
         }
     }
     Ok(())

--- a/shiki-cli/src/main.rs
+++ b/shiki-cli/src/main.rs
@@ -239,6 +239,48 @@ enum Commands {
         #[command(subcommand)]
         action: commands::extension::ExtensionAction,
     },
+    /// Imports notes from other apps (Obsidian vaults, Notion exports)
+    Import {
+        #[command(subcommand)]
+        action: ImportAction,
+    },
+}
+
+#[derive(Subcommand)]
+enum ImportAction {
+    /// Adopts an existing Obsidian vault as a shiki notebook — in-place by
+    /// default (registered under `[notebooks.<name>] path`, files stay
+    /// where they are), or copied into the data dir with `--copy`.
+    Obsidian {
+        /// Path to the vault's root folder (`~` expands).
+        path: String,
+        /// Notebook name (defaults to the folder's own name).
+        #[arg(long)]
+        name: Option<String>,
+        /// Copy everything into a fresh notebook under the data dir
+        /// instead of adopting the folder in place.
+        #[arg(long)]
+        copy: bool,
+        /// Merge inline #hashtags into each note's frontmatter tags
+        /// (notes without frontmatter are left untouched).
+        #[arg(long)]
+        tags: bool,
+        /// With adoption: run `git init` when the vault isn't already a
+        /// repo, so sync works from day one.
+        #[arg(long)]
+        git_init: bool,
+    },
+    /// Converts a Notion markdown export (the `.zip`, or an already-
+    /// extracted folder) into a fresh notebook: UUID suffixes are stripped
+    /// from page/folder names, internal page links become `[[wikilinks]]`,
+    /// CSV databases are reported but skipped.
+    Notion {
+        /// Path to the export's `.zip` or extracted folder (`~` expands).
+        path: String,
+        /// Notebook name (defaults to the zip/folder name, cleaned).
+        #[arg(long)]
+        name: Option<String>,
+    },
 }
 
 #[derive(Subcommand)]
@@ -250,6 +292,10 @@ enum NotebookAction {
         /// Emits a JSON array instead of plain text — for scripting.
         #[arg(long)]
         json: bool,
+        /// Also lists notebooks untracked via "keep files, just untrack"
+        /// (marked `(hidden)`), which are excluded by default.
+        #[arg(long)]
+        all: bool,
     },
     Rename {
         old: String,
@@ -356,8 +402,13 @@ fn main() -> Result<()> {
 
     // Handled before `Context::load()` — doctor and extension need to work
     // even when the config is broken.
-    if let Some(Commands::Extension { action }) = cli.command.take() {
-        return commands::extension::run(action);
+    // `matches!` guards the `take()`: a bare `take()` would consume *any*
+    // command into this check and leave `cli.command` as None, silently
+    // routing every other subcommand (list, sync, import…) into the TUI.
+    if matches!(cli.command, Some(Commands::Extension { .. })) {
+        if let Some(Commands::Extension { action }) = cli.command.take() {
+            return commands::extension::run(action);
+        }
     }
     if matches!(cli.command, Some(Commands::Doctor)) {
         return commands::doctor::run();
@@ -541,7 +592,9 @@ fn main() -> Result<()> {
         Some(Commands::Doctor) => unreachable!("handled before Context::load() above"),
         Some(Commands::Notebook { action }) => match action {
             NotebookAction::Create { name } => commands::notebook::create(&ctx.store, &name),
-            NotebookAction::List { json } => commands::notebook::list(&ctx.store, json),
+            NotebookAction::List { json, all } => {
+                commands::notebook::list(&ctx.store, &ctx.config, json, all)
+            }
             NotebookAction::Rename { old, new } => {
                 commands::notebook::rename(&ctx.store, &old, &new)
             }
@@ -568,5 +621,25 @@ fn main() -> Result<()> {
             }
         },
         Some(Commands::Extension { .. }) => unreachable!("handled before Context::load"),
+        Some(Commands::Import { action }) => match action {
+            ImportAction::Obsidian {
+                path,
+                name,
+                copy,
+                tags,
+                git_init,
+            } => commands::import::obsidian(
+                &mut ctx.config,
+                &ctx.store,
+                &path,
+                name.as_deref(),
+                copy,
+                tags,
+                git_init,
+            ),
+            ImportAction::Notion { path, name } => {
+                commands::import::notion(&ctx.store, &path, name.as_deref())
+            }
+        },
     }
 }

--- a/shiki-config/src/config.rs
+++ b/shiki-config/src/config.rs
@@ -183,6 +183,13 @@ pub struct General {
     /// so a value outside that range can't blow up the chafa command.
     #[serde(default = "default_preview_image_scale")]
     pub preview_image_scale: f64,
+    /// Notebook-root folder pasted images are saved into (`Ctrl+V` with an
+    /// image on the clipboard). Resolved against the notebook's root, so a
+    /// link written from any nested note still resolves through the
+    /// preview's usual folder→notebook→data-dir chain. Defaults to
+    /// `"attachments"`; an empty value falls back to the same default.
+    #[serde(default = "default_attachments_dir")]
+    pub attachments_dir: String,
 }
 
 impl Default for General {
@@ -214,8 +221,13 @@ impl Default for General {
             preview_images: true,
             chafa_path: String::new(),
             preview_image_scale: default_preview_image_scale(),
+            attachments_dir: default_attachments_dir(),
         }
     }
+}
+
+pub fn default_attachments_dir() -> String {
+    "attachments".into()
 }
 
 fn default_status_message_timeout_secs() -> u64 {
@@ -1121,6 +1133,14 @@ pub struct EditorConfig {
     /// itself a URL, otherwise paste behaves exactly as before.
     #[serde(default = "default_true")]
     pub paste_url_as_link: bool,
+    /// Ctrl+V with an *image* on the clipboard saves it as a PNG under
+    /// `[general] attachments_dir` (inside the current notebook) and
+    /// inserts `![name](attachments/name.png)` at the cursor — screenshots
+    /// straight into notes, no intermediate file juggling. Text pastes are
+    /// unaffected either way; this only decides what happens when the
+    /// clipboard holds an image. Defaults to `true`.
+    #[serde(default = "default_true")]
+    pub paste_images: bool,
     /// Tab, when the text immediately before the cursor matches a
     /// configured snippet trigger, replaces that trigger text with the
     /// snippet's body instead of inserting a literal tab. Falls through to
@@ -1187,6 +1207,7 @@ impl Default for EditorConfig {
             format_shortcuts: true,
             auto_pair_brackets: true,
             paste_url_as_link: true,
+            paste_images: true,
             snippet_expand_tab: true,
             typewriter_scroll: false,
             move_line: true,

--- a/shiki-core/src/note.rs
+++ b/shiki-core/src/note.rs
@@ -34,6 +34,16 @@ pub struct Frontmatter {
     pub date: NaiveDate,
     #[serde(default)]
     pub tags: Vec<String>,
+    /// Alternate names `[[wikilinks]]` resolve against, alongside the
+    /// title and the filename slug — the same `aliases:` key Obsidian
+    /// writes, so vaults coming from there carry theirs over untouched.
+    /// The main use here: renaming a note can rewrite every inbound
+    /// `[[link]]`, but anything that slips through (an edit in flight on
+    /// another machine, a link written later from memory) still resolves
+    /// if the old name is listed as an alias. Empty is omitted entirely on
+    /// serialize, so notes that never use aliases round-trip byte-stable.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub aliases: Vec<String>,
     pub notebook: String,
     #[serde(default)]
     pub links: Vec<String>,
@@ -49,6 +59,7 @@ impl Frontmatter {
             title: title.into(),
             date: chrono::Local::now().date_naive(),
             tags: Vec::new(),
+            aliases: Vec::new(),
             notebook: notebook.into(),
             links: Vec::new(),
             template: None,
@@ -241,6 +252,7 @@ impl Note {
             title,
             date,
             tags: Vec::new(),
+            aliases: Vec::new(),
             notebook,
             links: Vec::new(),
             template: None,

--- a/shiki-core/src/notebook.rs
+++ b/shiki-core/src/notebook.rs
@@ -154,7 +154,15 @@ impl Notebook {
         let mut notes = Vec::new();
         for path in entries {
             if path.is_dir() {
-                if path.file_name().is_some_and(|n| n == ".git") {
+                // Every dot-directory is invisible: `.git` is the original
+                // case, but an adopted Obsidian vault also brings
+                // `.obsidian/`, `.trash/`, `.smart-env/`… — none of those
+                // are folders a user wants showing up (or being recursed
+                // into) as notebook folders.
+                if path
+                    .file_name()
+                    .is_some_and(|n| n.to_string_lossy().starts_with('.'))
+                {
                     continue;
                 }
                 if let Some(name) = path.file_name() {
@@ -752,6 +760,29 @@ mod tests {
             3,
             "non-note extensions must be excluded: {stems:?}"
         );
+    }
+
+    #[test]
+    fn list_dir_skips_every_dot_directory_not_just_git() {
+        // An adopted Obsidian vault carries `.obsidian/` (settings),
+        // `.trash/` (its own soft deletes), `.smart-env/` — none of those
+        // are notebook folders and none of their contents are notes.
+        let tmp = tempfile::tempdir().unwrap();
+        let nb = test_notebook(tmp.path(), "vault");
+        nb.create_note("Real note", "body").unwrap();
+        for dot in [".git", ".obsidian", ".trash", ".smart-env"] {
+            let dir = nb.path.join(dot);
+            std::fs::create_dir_all(&dir).unwrap();
+            std::fs::write(dir.join("hidden-note.md"), "# hidden").unwrap();
+        }
+
+        let (folders, notes) = nb.list_dir(Path::new("")).unwrap();
+
+        assert!(folders.is_empty(), "dot-dirs must not list: {folders:?}");
+        assert_eq!(notes.len(), 1, "only the real note shows up");
+        assert_eq!(notes[0].frontmatter.title, "Real note");
+        // And the recursive walk doesn't descend into them either.
+        assert_eq!(nb.all_notes_recursive().unwrap().len(), 1);
     }
 
     #[test]

--- a/shiki-core/src/tags.rs
+++ b/shiki-core/src/tags.rs
@@ -1,6 +1,9 @@
 use std::collections::BTreeMap;
 use std::path::PathBuf;
 
+use regex::Regex;
+use std::sync::OnceLock;
+
 use crate::note::Note;
 use crate::notebook::Notebook;
 
@@ -106,6 +109,41 @@ pub fn rename_tag(
     Ok((notes_updated, notebooks_touched))
 }
 
+/// Every inline `#hashtag` in a markdown body, deduplicated in order of
+/// first appearance — the Obsidian convention the import path converts
+/// into frontmatter tags (shiki itself only indexes frontmatter). Rules:
+/// the tag starts at a `#` immediately followed by a non-space character
+/// (which is exactly what keeps ATX headings like `# Heading` out), allows
+/// letters/digits/`_`/`-`/`/` (nested tags), must contain at least one
+/// letter so `#1`-style issue references don't count, and fenced code
+/// blocks are skipped entirely — a `# comment` inside a code example is
+/// text.
+pub fn inline_hashtags(body: &str) -> Vec<String> {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    let re = RE.get_or_init(|| Regex::new(r"(?:^|[\s(\[{>])#([\w/\-]+)").unwrap());
+    let mut out: Vec<String> = Vec::new();
+    let mut in_fence = false;
+    for line in body.split('\n') {
+        if line.trim_start().starts_with("```") {
+            in_fence = !in_fence;
+            continue;
+        }
+        if in_fence {
+            continue;
+        }
+        for caps in re.captures_iter(line) {
+            let tag = caps[1].to_string();
+            if !tag.chars().any(char::is_alphabetic) {
+                continue;
+            }
+            if !out.contains(&tag) {
+                out.push(tag);
+            }
+        }
+    }
+    out
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -176,6 +214,26 @@ mod tests {
             all_tags(&pool),
             vec!["alpha".to_string(), "work".to_string(), "zeta".to_string()]
         );
+    }
+
+    #[test]
+    fn inline_hashtags_extracts_dedupes_and_skips_fences_and_headings() {
+        let body = "# Heading one\n\nnote with #work and #work again, nested #work/rust, \
+                    issue #123 stays out, code:\n```sh\n# not-a-tag here\n```\nend #ok_1\n";
+        assert_eq!(
+            inline_hashtags(body),
+            vec![
+                "work".to_string(),
+                "work/rust".to_string(),
+                "ok_1".to_string()
+            ]
+        );
+    }
+
+    #[test]
+    fn inline_hashtags_empty_body_is_empty() {
+        assert!(inline_hashtags("").is_empty());
+        assert!(inline_hashtags("# \n## \n123 #456").is_empty());
     }
 
     #[test]

--- a/shiki-core/src/wikilinks.rs
+++ b/shiki-core/src/wikilinks.rs
@@ -7,12 +7,33 @@ use std::sync::OnceLock;
 use crate::note::Note;
 
 /// Finds all `[[wikilinks]]` in a note's markdown body.
+///
+/// The captured target is the *base* name only — Obsidian-style
+/// sub-addresses (`[[note#heading]]`, `[[note^block-id]]`) and display
+/// aliases (`[[note|my text]]`) are consumed by the regex but not included,
+/// since resolution is per-note and neither suffix affects which note a
+/// link points at. `[[#heading]]` (a link into the *current* note) captures
+/// an empty target, which resolves to nothing rather than accidentally
+/// matching some other note's empty title.
 pub fn extract(body: &str) -> Vec<String> {
     static RE: OnceLock<Regex> = OnceLock::new();
-    let re = RE.get_or_init(|| Regex::new(r"\[\[([^\[\]|]+)(?:\|[^\[\]]+)?\]\]").unwrap());
+    let re = RE.get_or_init(|| {
+        Regex::new(r"\[\[([^\[\]|#^]*)(?:[#^][^\[\]|]*)?(?:\|[^\[\]]+)?\]\]").unwrap()
+    });
     re.captures_iter(body)
         .map(|c| c[1].trim().to_string())
         .collect()
+}
+
+/// Does this raw link target (as written between the brackets, possibly
+/// with a `#heading`/`^block` suffix) refer to `name`, case-insensitively?
+/// Comparison happens on the base part alone; the suffix is irrelevant for
+/// identity.
+fn split_link_base(link: &str) -> &str {
+    match link.find(['#', '^']) {
+        Some(pos) => &link[..pos],
+        None => link,
+    }
 }
 
 /// Resolves a single wikilink's target text to an existing note's path,
@@ -20,13 +41,22 @@ pub fn extract(body: &str) -> Vec<String> {
 /// a link can point at a note nested in any folder. Tries an exact
 /// (case-insensitive) title match first, then falls back to comparing
 /// slugs, so `[[Weekend Hiking Trip]]` and `[[weekend-hiking-trip]]` both
-/// resolve to the same note.
+/// resolve to the same note. A note's frontmatter aliases participate in
+/// the same matching, so `[[its-old-name]]` still lands on a renamed note
+/// that carries that alias.
 pub fn resolve_one(link: &str, notes: &[Note]) -> Option<PathBuf> {
     let link = link.trim();
     let slug = Note::slugify(link);
     notes
         .iter()
-        .find(|n| n.frontmatter.title.eq_ignore_ascii_case(link) || n.file_stem() == slug)
+        .find(|n| {
+            n.frontmatter.title.eq_ignore_ascii_case(link)
+                || n.file_stem() == slug
+                || n.frontmatter.aliases.iter().any(|a| {
+                    let alias = a.trim();
+                    alias.eq_ignore_ascii_case(link) || Note::slugify(alias) == slug
+                })
+        })
         .map(|n| n.path.clone())
 }
 
@@ -53,7 +83,14 @@ pub fn resolve_one_global<'a>(
     let link = link.trim();
     let slug = Note::slugify(link);
     for (nb, note) in global {
-        if note.frontmatter.title.eq_ignore_ascii_case(link) || note.file_stem() == slug {
+        if note.frontmatter.title.eq_ignore_ascii_case(link)
+            || note.file_stem() == slug
+            || note
+                .frontmatter
+                .aliases
+                .iter()
+                .any(|a| a.trim().eq_ignore_ascii_case(link))
+        {
             return Some((note.path.clone(), Some(&nb.name)));
         }
     }
@@ -65,25 +102,33 @@ pub fn resolve_one_global<'a>(
 /// `resolve_one`, used to answer "what links here?" without every note
 /// needing to maintain its own back-reference list.
 ///
-/// Builds a title/slug -> path index once up front rather than calling
-/// `resolve_one` (a linear scan + `slugify` over every note) once per link
+/// Builds a title/slug/alias -> path index once up front rather than
+/// calling `resolve_one` (a linear scan + `slugify` over every note) once per link
 /// per note — that combination made this function cost O(notes × total
 /// links in the notebook), visibly slow on a notebook with a few thousand
 /// notes even though each note only has a handful of links.
 pub fn backlinks<'a>(target: &std::path::Path, notes: &'a [Note]) -> Vec<&'a Note> {
     let mut by_title: HashMap<String, &std::path::Path> = HashMap::with_capacity(notes.len());
     let mut by_slug: HashMap<String, &std::path::Path> = HashMap::with_capacity(notes.len());
+    let mut by_alias: HashMap<String, &std::path::Path> = HashMap::with_capacity(notes.len());
     for n in notes {
         by_title
             .entry(n.frontmatter.title.to_ascii_lowercase())
             .or_insert(&n.path);
         by_slug.entry(n.file_stem()).or_insert(&n.path);
+        for alias in &n.frontmatter.aliases {
+            let alias = alias.trim().to_ascii_lowercase();
+            if !alias.is_empty() {
+                by_alias.entry(alias).or_insert(&n.path);
+            }
+        }
     }
     let resolve = |link: &str| -> Option<&std::path::Path> {
-        let link = link.trim();
+        let base = split_link_base(link).trim();
         by_title
-            .get(&link.to_ascii_lowercase())
-            .or_else(|| by_slug.get(&Note::slugify(link)))
+            .get(&base.to_ascii_lowercase())
+            .or_else(|| by_slug.get(&Note::slugify(base)))
+            .or_else(|| by_alias.get(&base.to_ascii_lowercase()))
             .copied()
     };
     notes
@@ -126,8 +171,8 @@ pub fn unlinked_mentions<'a>(target: &Note, notes: &'a [Note]) -> Vec<&'a Note> 
 /// Every resolved link between notes in `notes`, as deduplicated
 /// `(from, to)` index pairs — the adjacency list `shiki graph` renders and
 /// `orphans` derives connectivity from. Self-links are dropped (a note
-/// linking to itself isn't a connection). Uses the same title/slug index
-/// `backlinks` builds, for the same O(notes × links) reason.
+/// linking to itself isn't a connection). Uses the same title/slug/alias
+/// index `backlinks` builds, for the same O(notes × links) reason.
 pub fn edges(notes: &[Note]) -> Vec<(usize, usize)> {
     let mut index: HashMap<String, usize> = HashMap::with_capacity(notes.len() * 2);
     for (i, n) in notes.iter().enumerate() {
@@ -135,15 +180,20 @@ pub fn edges(notes: &[Note]) -> Vec<(usize, usize)> {
             .entry(n.frontmatter.title.to_ascii_lowercase())
             .or_insert(i);
         index.entry(n.file_stem()).or_insert(i);
+        for alias in &n.frontmatter.aliases {
+            let alias = alias.trim().to_ascii_lowercase();
+            if !alias.is_empty() {
+                index.entry(alias).or_insert(i);
+            }
+        }
     }
     let mut out = Vec::new();
     let mut seen = std::collections::HashSet::new();
     for (from, n) in notes.iter().enumerate() {
         for link in extract(&n.body) {
-            let link = link.trim();
             let to = index
                 .get(&link.to_ascii_lowercase())
-                .or_else(|| index.get(&Note::slugify(link)));
+                .or_else(|| index.get(Note::slugify(&link).as_str()));
             if let Some(&to) = to {
                 if to != from && seen.insert((from, to)) {
                     out.push((from, to));
@@ -236,6 +286,138 @@ fn find_unlinked(line: &str, needle: &str) -> Option<usize> {
     None
 }
 
+/// Rewrites every `[[wikilink]]` in `pool` that points at a renamed note so
+/// it points at the new title instead — the rename-note counterpart of
+/// `tags::rename_tag`, run over the same kind of whole-store pool so links
+/// from *other* notebooks are fixed too (cross-notebook resolution means
+/// they'd otherwise dangle silently). `old_targets` is every name the note
+/// used to answer to — pass both its old frontmatter title and its old
+/// filename slug; a link matches when its base target (before any
+/// `#heading`/`^block` suffix) equals one of them case-insensitively.
+/// Display aliases (`[[target|text]]`) and suffixes are preserved verbatim;
+/// only the target itself is swapped.
+///
+/// Files are rewritten as raw text rather than round-tripped through
+/// `Note::save_with_crypto`, deliberately: a plain `.md` file that never
+/// had frontmatter must not grow one just because it linked to the renamed
+/// note. Encrypted notebooks work through the same path — the file is
+/// decrypted with that notebook's key before matching and re-encrypted on
+/// write, exactly like any other read-modify-write; an encrypted file with
+/// no cached passphrase for its notebook is skipped (there's nothing safe
+/// to do to it). Fenced code blocks are left alone — a `[[link]]` inside a
+/// code example is text, not a link. Returns `(links_rewritten,
+/// notes_updated)` across the whole pool plus the names of every notebook
+/// that ended up touched (for per-notebook change tracking); a no-op is
+/// `Ok((0, 0, vec![]))`.
+pub fn rewrite_links_to(
+    old_targets: &[String],
+    new_title: &str,
+    pool: &[(crate::Notebook, Note)],
+) -> crate::Result<(usize, usize, Vec<String>)> {
+    use crate::crypto::looks_encrypted;
+
+    static RE: OnceLock<Regex> = OnceLock::new();
+    let re = RE.get_or_init(|| {
+        // Same shape `extract` matches, but capturing everything around the
+        // target so it can be stitched back on unchanged: the `[[` opener,
+        // the base target, the optional `#heading`/`^block` suffix, the
+        // optional `|display alias`, and the `]]` closer.
+        Regex::new(r"(\[\[)([^\[\]|#^]*)([#^][^\[\]|]*)?(\|[^\[\]]+)?(\]\])").unwrap()
+    });
+    let old_lc: Vec<String> = old_targets
+        .iter()
+        .map(|t| t.trim().to_lowercase())
+        .collect();
+    let new_title = new_title.trim();
+    let new_lc = new_title.to_lowercase();
+    if old_lc.is_empty() || new_lc.is_empty() {
+        return Ok((0, 0, Vec::new()));
+    }
+
+    let mut links_rewritten = 0usize;
+    let mut notes_updated = 0usize;
+    let mut notebooks_touched: Vec<String> = Vec::new();
+    for (nb, note) in pool {
+        let raw = match std::fs::read_to_string(&note.path) {
+            Ok(raw) => raw,
+            Err(_) => continue,
+        };
+        // Decrypt up front when needed — an encrypted notebook without its
+        // passphrase cached this session can't be touched at all, so its
+        // files are skipped rather than half-handled.
+        let (text, was_encrypted) = if looks_encrypted(&raw) {
+            let Some(crypto) = nb.crypto.as_ref() else {
+                continue;
+            };
+            match crypto.decrypt(&raw) {
+                Ok(plain) => (plain, true),
+                Err(_) => continue,
+            }
+        } else {
+            (raw, false)
+        };
+
+        // Same frontmatter-skip as `link_mention`: the YAML block never
+        // contains body links.
+        let mut lines: Vec<String> = text.split('\n').map(str::to_string).collect();
+        let mut start = 0;
+        if lines.first().map(|l| l.trim_end_matches('\r')) == Some("---") {
+            if let Some(close) = lines[1..]
+                .iter()
+                .position(|l| l.trim_end_matches('\r') == "---")
+            {
+                start = close + 2;
+            }
+        }
+
+        let mut changed = false;
+        let mut in_fence = false;
+        for line in lines.iter_mut().skip(start) {
+            if line.trim_start().starts_with("```") {
+                in_fence = !in_fence;
+                continue;
+            }
+            if in_fence {
+                continue;
+            }
+            let rewritten = re.replace_all(line.as_str(), |caps: &regex::Captures| {
+                let target = caps[2].trim();
+                let tl = target.to_lowercase();
+                if !old_lc.contains(&tl) || tl == new_lc {
+                    return caps[0].to_string();
+                }
+                links_rewritten += 1;
+                format!(
+                    "[[{new_title}{}{}]]",
+                    caps.get(3).map(|m| m.as_str()).unwrap_or(""),
+                    caps.get(4).map(|m| m.as_str()).unwrap_or("")
+                )
+            });
+            if rewritten != line.as_str() {
+                *line = rewritten.into_owned();
+                changed = true;
+            }
+        }
+
+        if changed {
+            let out = if was_encrypted {
+                nb.crypto
+                    .as_ref()
+                    .expect("checked above")
+                    .encrypt(&lines.join("\n"))?
+            } else {
+                lines.join("\n")
+            };
+            std::fs::write(&note.path, out)?;
+            notes_updated += 1;
+            if !notebooks_touched.contains(&nb.name) {
+                notebooks_touched.push(nb.name.clone());
+            }
+        }
+    }
+    Ok((links_rewritten, notes_updated, notebooks_touched))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -255,6 +437,173 @@ mod tests {
         assert_eq!(
             extract(body),
             vec!["Weekend Hiking Trip".to_string(), "Gift Ideas".to_string()]
+        );
+    }
+
+    #[test]
+    fn extract_strips_heading_block_and_alias_suffixes() {
+        let body = "a [[Note#Section]] b [[Other^block-id]] c [[Third|label]] d [[#self]] e";
+        assert_eq!(
+            extract(body),
+            vec![
+                "Note".to_string(),
+                "Other".to_string(),
+                "Third".to_string(),
+                String::new()
+            ]
+        );
+    }
+
+    fn note_with_aliases(path: &str, title: &str, aliases: &[&str], body: &str) -> Note {
+        let mut n = note(path, title, body);
+        n.frontmatter.aliases = aliases.iter().map(|a| a.to_string()).collect();
+        n
+    }
+
+    #[test]
+    fn resolve_one_matches_frontmatter_aliases() {
+        let notes = vec![note_with_aliases(
+            "a/hiking.md",
+            "Weekend Hiking Trip",
+            &["Old Name"],
+            "",
+        )];
+        assert_eq!(
+            resolve_one("old name", &notes),
+            Some(PathBuf::from("a/hiking.md"))
+        );
+        // An alias's slug form resolves too, same as titles do.
+        assert_eq!(
+            resolve_one("old-name", &notes),
+            Some(PathBuf::from("a/hiking.md"))
+        );
+        // And an unknown alias still misses.
+        assert_eq!(resolve_one("other alias", &notes), None);
+    }
+
+    #[test]
+    fn backlinks_count_alias_and_heading_links() {
+        let target = note_with_aliases("a/hiking.md", "Weekend Hiking Trip", &["Old Name"], "");
+        let linker = note(
+            "a/journal.md",
+            "Journal",
+            "[[Old Name#Gear]] and [[weekend hiking trip]]",
+        );
+        let notes = vec![target.clone(), linker];
+        assert_eq!(backlinks(&target.path, &notes).len(), 1);
+    }
+
+    /// Writes `contents` to a real file under `root` and returns the Note
+    /// (path matching what's on disk) plus its notebook — the shape
+    /// `rewrite_links_to`'s pool needs.
+    fn on_disk(root: &std::path::Path, name: &str, contents: &str) -> (crate::Notebook, Note) {
+        std::fs::create_dir_all(root).unwrap();
+        let path = root.join(name);
+        std::fs::write(&path, contents).unwrap();
+        let nb = crate::Notebook::new("nb", root.to_path_buf());
+        let n = note(path.to_str().unwrap(), "Whatever", "");
+        (nb, n)
+    }
+
+    #[test]
+    fn rewrite_links_to_rewrites_title_and_slug_preserving_suffix_and_alias() {
+        let tmp = tempfile::tempdir().unwrap();
+        let body = "---\ntitle: Journal\n---\n\nSee [[Old Name]], [[old-name|custom text]] \
+                   and [[Old Name#Gear]].\n";
+        let (nb, linker) = on_disk(tmp.path(), "journal.md", body);
+
+        let (links, files, touched) = rewrite_links_to(
+            &[String::from("Old Name"), String::from("old-name")],
+            "New Name",
+            &[(nb, linker)],
+        )
+        .unwrap();
+
+        assert_eq!((links, files), (3, 1));
+        assert_eq!(touched, vec!["nb".to_string()]);
+        let out = std::fs::read_to_string(tmp.path().join("journal.md")).unwrap();
+        assert_eq!(
+            out,
+            "---\ntitle: Journal\n---\n\nSee [[New Name]], [[New Name|custom text]] \
+             and [[New Name#Gear]].\n"
+        );
+    }
+
+    #[test]
+    fn rewrite_links_to_skips_code_fences() {
+        let tmp = tempfile::tempdir().unwrap();
+        let body = "real: [[Old Name]]\n\n```md\nexample: [[Old Name]] stays\n```\n";
+        let (nb, linker) = on_disk(tmp.path(), "journal.md", body);
+
+        let (links, _, _) =
+            rewrite_links_to(&[String::from("Old Name")], "New Name", &[(nb, linker)]).unwrap();
+
+        assert_eq!(links, 1);
+        let out = std::fs::read_to_string(tmp.path().join("journal.md")).unwrap();
+        assert!(out.contains("real: [[New Name]]"));
+        assert!(out.contains("example: [[Old Name]] stays"));
+    }
+
+    #[test]
+    fn rewrite_links_to_never_adds_frontmatter_to_plain_files() {
+        let tmp = tempfile::tempdir().unwrap();
+        let body = "plain note linking [[Old Name]]\n";
+        let (nb, linker) = on_disk(tmp.path(), "plain.md", body);
+
+        let (_, files, _) =
+            rewrite_links_to(&[String::from("Old Name")], "New Name", &[(nb, linker)]).unwrap();
+
+        assert_eq!(files, 1);
+        let out = std::fs::read_to_string(tmp.path().join("plain.md")).unwrap();
+        assert_eq!(out, "plain note linking [[New Name]]\n");
+    }
+
+    #[test]
+    fn rewrite_links_to_reencrypts_encrypted_notebooks_in_place() {
+        let tmp = tempfile::tempdir().unwrap();
+        let crypto = crate::crypto::NotebookCrypto::new("passphrase");
+        let encrypted = crypto
+            .encrypt("---\ntitle: Journal\n---\n\nlinking [[Old Name]] here\n")
+            .unwrap();
+        std::fs::write(tmp.path().join("journal.md"), &encrypted).unwrap();
+        let nb =
+            crate::Notebook::new("nb", tmp.path().to_path_buf()).with_crypto(Some(crypto.clone()));
+        let linker = note(
+            tmp.path().join("journal.md").to_str().unwrap(),
+            "Journal",
+            "",
+        );
+
+        let (links, files, _) =
+            rewrite_links_to(&[String::from("Old Name")], "New Name", &[(nb, linker)]).unwrap();
+
+        assert_eq!((links, files), (1, 1));
+        let raw = std::fs::read_to_string(tmp.path().join("journal.md")).unwrap();
+        assert!(crate::crypto::looks_encrypted(&raw));
+        assert_eq!(
+            crypto.decrypt(&raw).unwrap(),
+            "---\ntitle: Journal\n---\n\nlinking [[New Name]] here\n"
+        );
+    }
+
+    #[test]
+    fn rewrite_links_to_skips_a_locked_notebook_without_touching_it() {
+        let tmp = tempfile::tempdir().unwrap();
+        let crypto = crate::crypto::NotebookCrypto::new("passphrase");
+        let encrypted = crypto.encrypt("[[Old Name]]\n").unwrap();
+        std::fs::write(tmp.path().join("locked.md"), &encrypted).unwrap();
+        // No crypto attached — the notebook is locked this session.
+        let nb = crate::Notebook::new("nb", tmp.path().to_path_buf());
+        let linker = note(tmp.path().join("locked.md").to_str().unwrap(), "L", "");
+
+        let before = std::fs::read_to_string(tmp.path().join("locked.md")).unwrap();
+        let (links, files, _) =
+            rewrite_links_to(&[String::from("Old Name")], "New Name", &[(nb, linker)]).unwrap();
+
+        assert_eq!((links, files), (0, 0));
+        assert_eq!(
+            std::fs::read_to_string(tmp.path().join("locked.md")).unwrap(),
+            before
         );
     }
 

--- a/shiki-native-host/src/main.rs
+++ b/shiki-native-host/src/main.rs
@@ -333,7 +333,21 @@ fn handle_ping() -> anyhow::Result<serde_json::Value> {
 
 fn handle_list_notebooks() -> anyhow::Result<serde_json::Value> {
     let (config, store) = load_config_and_store()?;
-    let notebooks = store.list().unwrap_or_default();
+    // Same filter the TUI applies: notebooks untracked via "keep files,
+    // just untrack" ([notebooks.<name>] hidden = true) must not show up in
+    // the extension's notebook picker either — untracking from the TUI
+    // would otherwise leave them capturable from the browser.
+    let notebooks: Vec<_> = store
+        .list()
+        .unwrap_or_default()
+        .into_iter()
+        .filter(|nb| {
+            !config
+                .notebooks
+                .get(&nb.name)
+                .is_some_and(|over| over.hidden)
+        })
+        .collect();
     let infos: Vec<NotebookInfo> = notebooks
         .into_iter()
         .map(|nb| {

--- a/shiki-tui/Cargo.toml
+++ b/shiki-tui/Cargo.toml
@@ -28,4 +28,8 @@ base64.workspace = true
 unicode-width.workspace = true
 directories.workspace = true
 arboard.workspace = true
+png.workspace = true
 serde_yaml.workspace = true
+
+[dev-dependencies]
+tempfile.workspace = true

--- a/shiki-tui/src/app.rs
+++ b/shiki-tui/src/app.rs
@@ -761,6 +761,14 @@ pub struct App {
     /// True while the editor contains the session-only scratchpad buffer.
     /// It has no path and is discarded unless explicitly saved as a note.
     pub(crate) editing_scratchpad: bool,
+    /// `Some((notebook, relative file))` while the editor holds a merge-
+    /// conflicted file's raw content (the resolver modal's `i` — "edit
+    /// inline", the in-app version of what previously required an external
+    /// editor before `e` could stage it). Saving writes the raw text back
+    /// to disk *and* stages it as that file's resolution via
+    /// `git::resolve_conflict`, reusing the same post-resolution bookkeeping
+    /// (`finish_resolving_conflict_file`) the `o`/`t`/`e` keys go through.
+    pub(crate) editing_conflict: Option<(String, std::path::PathBuf)>,
     /// True from the moment THEME's `name` row opens the theme picker from
     /// inside Settings until the picker closes — `show_settings` is hidden
     /// first (its render call in `draw()` comes after the theme picker's,
@@ -1015,6 +1023,12 @@ pub struct App {
     /// `Some` while drilled into one conflicted file's side-by-side ours/
     /// theirs diff view; `None` while browsing the flat file list.
     pub(crate) conflict_viewing: Option<ConflictView>,
+    /// `Some((notebook, path, new title))` staged between the rename
+    /// prompt and the "linked from N notes — update [[links]]?" confirm —
+    /// the rename itself only runs once that's answered, since the answer
+    /// decides whether `wikilinks::rewrite_links_to` fires first. Same
+    /// one-shot staging pattern as `pending_revert`.
+    pub(crate) pending_rename_links: Option<(String, std::path::PathBuf, String)>,
     /// Notebook name staged while the `confirm` dialog asks "commit this
     /// merge?" — mirrors `pending_revert`'s pattern.
     pub(crate) pending_finish_merge: Option<String>,
@@ -1220,7 +1234,13 @@ fn load_log_history(path: &std::path::Path, limit: usize) -> Vec<LogEntry> {
 
 impl App {
     pub fn new(config: Config, store: NotebookStore) -> shiki_core::Result<Self> {
-        let notebooks = store.list()?;
+        // One filtered list for everything below (theme resolution included)
+        // — this used to call `store.list()` twice and, worse, never applied
+        // the "keep files, just untrack" hidden filter at all, so a notebook
+        // untracked mid-session reappeared on every relaunch. The same
+        // `visible_notebooks` filter `reload_notebooks` uses decides here
+        // too.
+        let notebooks = crate::sync::visible_notebooks(&store, &config);
         // Resolve for the initially selected notebook so a per-notebook
         // override on it applies from the very first frame.
         let theme = config
@@ -1229,7 +1249,6 @@ impl App {
         let show_dates = config.general.show_dates;
         let note_sort = NoteSort::from_config_str(&config.general.default_note_sort);
         let keymaps = KeyMaps::from_config(&config.keybindings);
-        let notebooks = store.list()?;
         // Deliberately tolerant, not `?` — an encrypted-and-locked default
         // notebook (no passphrase can possibly be cached yet, this is
         // startup) must not crash the whole app before it even has a
@@ -1344,6 +1363,7 @@ impl App {
             editing_config: false,
             editing_snippet: None,
             editing_scratchpad: false,
+            editing_conflict: None,
             reopen_settings_after_theme_picker: false,
             pending_delete_snippet: None,
             log_history,
@@ -1425,6 +1445,7 @@ impl App {
             conflict_branch: String::new(),
             conflict_viewing: None,
             pending_finish_merge: None,
+            pending_rename_links: None,
             pending_abort_merge: None,
             notebook_passphrases: std::collections::HashMap::new(),
             passphrase_prompt_notebook: None,

--- a/shiki-tui/src/attachments.rs
+++ b/shiki-tui/src/attachments.rs
@@ -1,0 +1,122 @@
+//! Saving clipboard images as note attachments: `Ctrl+V` in the editor
+//! with an image on the clipboard writes it into the notebook's configured
+//! attachments folder (`[general] attachments_dir`, resolved against the
+//! notebook root) as a PNG and returns the markdown link to insert. The
+//! preview already resolves image paths through note-folder → notebook
+//! root → data-dir, so the written link renders everywhere in the notebook
+//! with no extra bookkeeping.
+
+use std::path::{Path, PathBuf};
+
+/// Saves `image` (RGBA, straight from arboard) as
+/// `<notebook>/<attachments_dir>/<pasted-TIMESTAMP>.png`, creating the
+/// folder when needed and appending `-2`/`-3`/… on a same-second name
+/// collision instead of overwriting. Returns `(absolute file path,
+/// markdown link text)` — the link is relative to the *notebook root*, so
+/// it resolves from any note depth via the preview's base-dir chain.
+pub fn save_image(
+    notebook_root: &Path,
+    attachments_dir: &str,
+    image: &arboard::ImageData<'_>,
+) -> shiki_core::Result<(PathBuf, String)> {
+    let dir_name = if attachments_dir.trim().is_empty() {
+        shiki_config::config::default_attachments_dir()
+    } else {
+        attachments_dir.trim().to_string()
+    };
+    let dir = notebook_root.join(dir_name);
+    std::fs::create_dir_all(&dir)?;
+
+    let stem = format!("pasted-{}", chrono::Local::now().format("%Y%m%d-%H%M%S"));
+    let file = unique_file(&dir, &stem);
+
+    encode_png(&file, image)?;
+
+    let file_name = file
+        .file_name()
+        .map(|n| n.to_string_lossy().to_string())
+        .unwrap_or_default();
+    Ok((file, format!("![{stem}](attachments/{file_name})")))
+}
+
+/// `stem.png`, or `stem-2.png`/`stem-3.png`/… past the first collision.
+fn unique_file(dir: &Path, stem: &str) -> PathBuf {
+    let first = dir.join(format!("{stem}.png"));
+    if !first.exists() {
+        return first;
+    }
+    for n in 2.. {
+        let candidate = dir.join(format!("{stem}-{n}.png"));
+        if !candidate.exists() {
+            return candidate;
+        }
+    }
+    unreachable!()
+}
+
+/// RGBA8 → PNG on disk. png-crate errors funnel through `Io` via
+/// `Error::other` so the caller sees one message either way.
+fn encode_png(path: &Path, image: &arboard::ImageData<'_>) -> shiki_core::Result<()> {
+    let png_err = |e: png::EncodingError| std::io::Error::other(e.to_string());
+    let file = std::fs::File::create(path)?;
+    let buf = std::io::BufWriter::new(file);
+    let mut encoder = png::Encoder::new(buf, image.width as u32, image.height as u32);
+    encoder.set_color(png::ColorType::Rgba);
+    encoder.set_depth(png::BitDepth::Eight);
+    let mut writer = encoder.write_header().map_err(png_err)?;
+    writer.write_image_data(&image.bytes).map_err(png_err)?;
+    writer.finish().map_err(png_err)?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn tiny_image() -> arboard::ImageData<'static> {
+        arboard::ImageData {
+            width: 2,
+            height: 2,
+            bytes: std::borrow::Cow::Owned(vec![10u8; 2 * 2 * 4]),
+        }
+    }
+
+    #[test]
+    fn saves_png_and_returns_notebook_relative_link() {
+        let tmp = tempfile::tempdir().unwrap();
+
+        let (path, link) = save_image(tmp.path(), "attachments", &tiny_image()).unwrap();
+
+        assert!(path.is_file());
+        assert!(path.starts_with(tmp.path().join("attachments")));
+        assert_eq!(path.extension().unwrap(), "png");
+        let stem = path.file_stem().unwrap().to_string_lossy().to_string();
+        assert!(stem.starts_with("pasted-"), "{stem}");
+        // Link text carries the file name, relative to the notebook root.
+        let name = path.file_name().unwrap().to_string_lossy().to_string();
+        assert_eq!(link, format!("![{stem}](attachments/{name})"));
+    }
+
+    #[test]
+    fn colliding_names_get_a_numeric_suffix_not_an_overwrite() {
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::write(tmp.path().join("pasted.png"), b"occupied").unwrap();
+
+        let second = unique_file(tmp.path(), "pasted");
+
+        assert_eq!(second, tmp.path().join("pasted-2.png"));
+        // And the chain keeps going.
+        std::fs::write(&second, b"occupied too").unwrap();
+        assert_eq!(
+            unique_file(tmp.path(), "pasted"),
+            tmp.path().join("pasted-3.png")
+        );
+    }
+
+    #[test]
+    fn empty_dir_name_falls_back_to_attachments() {
+        let tmp = tempfile::tempdir().unwrap();
+        let (path, _) = save_image(tmp.path(), "   ", &tiny_image()).unwrap();
+        assert!(path.starts_with(tmp.path().join("attachments")));
+    }
+}

--- a/shiki-tui/src/clipboard.rs
+++ b/shiki-tui/src/clipboard.rs
@@ -53,3 +53,20 @@ pub fn copy_os(text: &str) -> bool {
 pub fn paste_os() -> Option<String> {
     os_clipboard()?.lock().ok()?.get_text().ok()
 }
+
+/// Reads an *image* from the real OS clipboard, if one is there — the
+/// entry point for pasting screenshots straight into a note. `None` means
+/// no display server, or the clipboard holds text rather than an image
+/// (callers try `paste_os` first, so text keeps winning).
+pub fn paste_image() -> Option<arboard::ImageData<'static>> {
+    let cb = os_clipboard()?;
+    let mut cb = cb.lock().ok()?;
+    let img = cb.get_image().ok()?;
+    // arboard's own buffer is borrowed-lifetime; detach it so the image
+    // outlives the clipboard lock.
+    Some(arboard::ImageData {
+        width: img.width,
+        height: img.height,
+        bytes: std::borrow::Cow::Owned(img.bytes.into_owned()),
+    })
+}

--- a/shiki-tui/src/draw.rs
+++ b/shiki-tui/src/draw.rs
@@ -869,8 +869,7 @@ fn render_conflicts(frame: &mut Frame, frame_area: Rect, app: &App) {
                 })
                 .collect()
         };
-        let hint =
-            "o keep ours \u{B7} t keep theirs \u{B7} e mark resolved (edited) \u{B7} esc back";
+        let hint = "o keep ours \u{B7} t keep theirs \u{B7} i edit inline \u{B7} e mark resolved (edited) \u{B7} esc back";
         let ours_title = format!(" {}OURS  \u{2014}  {hint} ", icons::GIT);
         let theirs_title = format!(" {}THEIRS  \u{2014}  {hint} ", icons::GIT);
         let ours_paragraph = ratatui::widgets::Paragraph::new(to_lines(&view.ours))
@@ -893,7 +892,7 @@ fn render_conflicts(frame: &mut Frame, frame_area: Rect, app: &App) {
         .collect();
     let highlight_symbol = format!("{}", icons::ARROW);
     let title = format!(
-        " {}Merge conflicts on '{}' [{} file{}]  \u{2014}  enter resolve \u{B7} o ours \u{B7} t theirs \u{B7} a abort \u{B7} esc close ",
+        " {}Merge conflicts on '{}' [{} file{}]  \u{2014}  enter resolve \u{B7} o ours \u{B7} t theirs \u{B7} i edit inline \u{B7} a abort \u{B7} esc close ",
         icons::WARNING,
         app.conflict_branch,
         app.conflict_files.len(),

--- a/shiki-tui/src/key_handlers.rs
+++ b/shiki-tui/src/key_handlers.rs
@@ -552,6 +552,10 @@ impl App {
                 "preview_image_scale",
                 self.config.general.preview_image_scale.to_string(),
             ),
+            GeneralField::AttachmentsDir => (
+                "attachments_dir",
+                self.config.general.attachments_dir.clone(),
+            ),
             GeneralField::UseFavoriteEditor
             | GeneralField::EnableCaptureDaemon
             | GeneralField::MouseDragSelection
@@ -721,6 +725,10 @@ impl App {
             EditorField::PasteUrlAsLink => {
                 self.config.editor.paste_url_as_link = !self.config.editor.paste_url_as_link;
                 ("paste_url_as_link", self.config.editor.paste_url_as_link)
+            }
+            EditorField::PasteImages => {
+                self.config.editor.paste_images = !self.config.editor.paste_images;
+                ("paste_images", self.config.editor.paste_images)
             }
             EditorField::SnippetExpandTab => {
                 self.config.editor.snippet_expand_tab = !self.config.editor.snippet_expand_tab;
@@ -2145,6 +2153,7 @@ impl App {
                 KeyCode::Char('o') => self.resolve_selected_conflict(ConflictSideChoice::Ours),
                 KeyCode::Char('t') => self.resolve_selected_conflict(ConflictSideChoice::Theirs),
                 KeyCode::Char('e') => self.mark_selected_conflict_resolved(),
+                KeyCode::Char('i') => self.open_conflict_in_editor(),
                 KeyCode::Char('j') | KeyCode::Down => {
                     if let Some(view) = &mut self.conflict_viewing {
                         view.scroll = view.scroll.saturating_add(1);
@@ -2176,6 +2185,8 @@ impl App {
             KeyCode::Enter => self.view_selected_conflict(),
             KeyCode::Char('o') => self.resolve_selected_conflict(ConflictSideChoice::Ours),
             KeyCode::Char('t') => self.resolve_selected_conflict(ConflictSideChoice::Theirs),
+            KeyCode::Char('e') => self.mark_selected_conflict_resolved(),
+            KeyCode::Char('i') => self.open_conflict_in_editor(),
             KeyCode::Char('a') => self.start_abort_merge(),
             KeyCode::Char('j') | KeyCode::Down => {
                 if self.conflict_selected + 1 < self.conflict_files.len() {
@@ -2272,6 +2283,38 @@ impl App {
             }
         };
         self.finish_resolving_conflict_file(&nb.path.clone(), &file, &content);
+    }
+    /// The in-app version of the "edit by hand" escape hatch: loads the
+    /// conflicted file's raw content (markers and all) into the same inline
+    /// editor a note edit uses, so removing conflict markers never requires
+    /// an external `$EDITOR`. Saving (`save_and_exit_edit`'s
+    /// `editing_conflict` arm) writes the raw text back and stages it as
+    /// this file's resolution — the same bookkeeping `e` triggers after an
+    /// external edit, just without leaving the TUI.
+    fn open_conflict_in_editor(&mut self) {
+        let Some(nb) = self.conflict_notebook_ref() else {
+            return;
+        };
+        let Some(file) = self.conflict_target_file() else {
+            return;
+        };
+        let contents = match std::fs::read_to_string(nb.path.join(&file)) {
+            Ok(c) => c,
+            Err(e) => {
+                self.set_status(format!("could not read '{}': {e}", file.display()));
+                return;
+            }
+        };
+        let mut editor = InlineEditor::from_contents(&contents);
+        let title = format!(" {}Resolving: {} ", icons::PENCIL, file.display());
+        self.style_inline_editor(&mut editor, title);
+        self.editor = Some(editor);
+        self.editing_conflict = Some((self.conflict_notebook.clone(), file));
+        // The editor renders full-screen over everything; leaving the modal
+        // visible underneath would just repaint behind it. It comes back
+        // (with the resolved file gone from its list) once the save lands.
+        self.show_conflicts = false;
+        self.mode = Mode::Edit;
     }
     fn finish_resolving_conflict_file(
         &mut self,
@@ -4297,6 +4340,102 @@ impl App {
             self.start_input(PendingInput::RenameNote, title);
         }
     }
+    /// How many notes (across every visible notebook — cross-notebook
+    /// `[[wikilinks]]` are legal since resolution falls back globally)
+    /// currently link to the note at `path`. The number the rename flow
+    /// quotes in its "update links?" confirm.
+    fn backlink_count_for(&self, path: &std::path::Path) -> usize {
+        let pool = self.visible_notes_pool();
+        let notes_only: Vec<shiki_core::Note> = pool.into_iter().map(|(_, n)| n).collect();
+        shiki_core::wikilinks::backlinks(path, &notes_only).len()
+    }
+    /// Every note of every notebook the session can see, paired with its
+    /// (crypto-attached) notebook — the pool `rewrite_links_to` walks. A
+    /// locked encrypted notebook contributes nothing rather than failing
+    /// the whole walk.
+    fn visible_notes_pool(&self) -> Vec<(shiki_core::Notebook, shiki_core::Note)> {
+        let mut pool = Vec::new();
+        for nb in &self.notebooks {
+            if let Ok(notes) = nb.all_notes_recursive() {
+                for note in notes {
+                    pool.push((nb.clone(), note));
+                }
+            }
+        }
+        pool
+    }
+    /// The plain half of the rename flow: file + frontmatter title swap,
+    /// no link rewriting.
+    fn perform_rename_note(&mut self, nb_name: &str, path: &std::path::Path, new_title: &str) {
+        let Some(nb) = self.notebooks.iter().find(|n| n.name == nb_name).cloned() else {
+            self.set_status(format!("'{nb_name}' no longer available"));
+            return;
+        };
+        match nb.rename_note_at(path, new_title) {
+            Ok(_) => {
+                self.refresh_notes_preserve_selection();
+                self.note_changed(nb_name);
+                self.set_status(format!("renamed to '{new_title}'"));
+            }
+            Err(e) => self.set_status(format!("could not rename: {e}")),
+        }
+    }
+    /// The confirmed-yes side: rewrite every inbound `[[link]]` first (the
+    /// old title/slug must still be current for the match to find them),
+    /// then do the actual rename. Both notebooks that gained rewritten
+    /// notes *and* the renamed one register a change, so auto_sync picks
+    /// everything up.
+    fn perform_rename_with_link_update(
+        &mut self,
+        nb_name: &str,
+        path: &std::path::Path,
+        new_title: &str,
+    ) {
+        let Some(nb) = self.notebooks.iter().find(|n| n.name == nb_name).cloned() else {
+            self.set_status(format!("'{nb_name}' no longer available"));
+            return;
+        };
+        let old = match shiki_core::Note::from_file_in_notebook_with_crypto(
+            path,
+            nb_name,
+            nb.crypto.as_ref(),
+        ) {
+            Ok(n) => n,
+            Err(e) => {
+                self.set_status(format!("could not read note before renaming: {e}"));
+                return;
+            }
+        };
+        let old_targets = vec![old.frontmatter.title.clone(), old.file_stem()];
+        let pool = self.visible_notes_pool();
+        let (links, files, touched) =
+            match shiki_core::wikilinks::rewrite_links_to(&old_targets, new_title, &pool) {
+                Ok(result) => result,
+                Err(e) => {
+                    self.set_status(format!("could not update links: {e}"));
+                    return;
+                }
+            };
+        match nb.rename_note_at(path, new_title) {
+            Ok(_) => {
+                self.refresh_notes_preserve_selection();
+                for name in &touched {
+                    self.note_changed(name);
+                }
+                if !touched.iter().any(|name| name == nb_name) {
+                    self.note_changed(nb_name);
+                }
+                self.set_status(if links > 0 {
+                    format!(
+                        "renamed to '{new_title}' — {links} link(s) updated across {files} note(s)"
+                    )
+                } else {
+                    format!("renamed to '{new_title}'")
+                });
+            }
+            Err(e) => self.set_status(format!("could not rename: {e}")),
+        }
+    }
     /// Starts a move or copy — in `Mode::Visual`, for every item in the
     /// selected range; otherwise for whichever single note/folder is
     /// currently selected. Both branches populate the same `pending_batch`
@@ -4878,6 +5017,31 @@ impl App {
             self.mode = Mode::Normal;
             return;
         }
+        // A merge-conflict edit: the raw buffer *is* the resolution — write
+        // it back and stage it, then bring the resolver modal back up (the
+        // edited file has left its list) unless the whole merge is done, in
+        // which case `finish_resolving_conflict_file` has already staged the
+        // "commit this merge?" confirm on top of it.
+        if let Some((notebook, file)) = self.editing_conflict.take() {
+            let nb_path = self
+                .notebooks
+                .iter()
+                .find(|n| n.name == notebook)
+                .map(|n| n.path.clone());
+            self.mode = Mode::Normal;
+            match nb_path {
+                Some(nb_path) => {
+                    let contents = editor.map(|e| e.contents()).unwrap_or_default();
+                    self.finish_resolving_conflict_file(&nb_path, &file, &contents);
+                }
+                None => self.set_status(format!("'{notebook}' no longer available")),
+            }
+            if !self.conflict_files.is_empty() || self.pending_finish_merge.is_some() {
+                self.conflict_viewing = None;
+                self.show_conflicts = true;
+            }
+            return;
+        }
         if let (Some(editor), Some(mut note)) = (editor, self.selected_note().cloned()) {
             note.body = editor.contents();
             // Pin relative due specs (`@due(+3d)`, `@due(mon)`) to real
@@ -5139,13 +5303,21 @@ impl App {
                     self.selected_notebook().cloned(),
                     self.selected_note().map(|n| n.path.clone()),
                 ) {
-                    match nb.rename_note_at(&path, &value) {
-                        Ok(_) => {
-                            self.refresh_notes_preserve_selection();
-                            self.note_changed(&nb.name);
-                            self.set_status(format!("renamed to '{value}'"));
-                        }
-                        Err(e) => self.set_status(format!("could not rename: {e}")),
+                    // Renaming breaks every inbound `[[wikilink]]` that
+                    // matched the old title/slug — count them first, and
+                    // when there are any, ask before rewriting (the "no"
+                    // answer renames anyway; aliases can rescue stragglers).
+                    let backlink_count = self.backlink_count_for(&path);
+                    if backlink_count > 0 {
+                        self.pending_rename_links = Some((nb.name.clone(), path, value.clone()));
+                        self.confirm = Some(confirm::ConfirmDialog::with_hint(
+                            format!("Rename to '{value}'?"),
+                            format!(
+                                "[y] rename + update {backlink_count} link(s)  [n] rename without updating links"
+                            ),
+                        ));
+                    } else {
+                        self.perform_rename_note(&nb.name, &path, &value);
                     }
                 }
             }
@@ -5396,6 +5568,10 @@ impl App {
                                 }
                                 "preview_image_scale"
                             }
+                            GeneralField::AttachmentsDir => {
+                                self.config.general.attachments_dir = value.clone();
+                                "attachments_dir"
+                            }
                             GeneralField::UseFavoriteEditor => "use_favorite_editor",
                             GeneralField::EnableCaptureDaemon => "enable_capture_daemon",
                             GeneralField::MouseDragSelection => "mouse_drag_selection",
@@ -5633,10 +5809,22 @@ impl App {
                             path.display()
                         )),
                     }
+                } else if let Some((nb_name, path, new_title)) = self.pending_rename_links.take() {
+                    self.perform_rename_with_link_update(&nb_name, &path, &new_title);
                 } else if let Some(notebook) = self.pending_finish_merge.take() {
                     self.finish_merge_notebook(&notebook);
                 } else if let Some(notebook) = self.pending_abort_merge.take() {
                     self.abort_merge_notebook(&notebook);
+                }
+            }
+            // The rename flow's third answer: rename, but leave every
+            // inbound `[[link]]` pointing at the old name (Esc is the real
+            // cancel — it lands in `_` below and stages nothing).
+            KeyCode::Char('n') | KeyCode::Char('N') => {
+                if let Some((nb_name, path, new_title)) = self.pending_rename_links.take() {
+                    self.perform_rename_note(&nb_name, &path, &new_title);
+                } else {
+                    self.set_status("cancelled".into());
                 }
             }
             _ => {
@@ -5646,6 +5834,7 @@ impl App {
                 self.pending_batch_delete = None;
                 self.pending_delete_snippet = None;
                 self.pending_notebook_adopt = None;
+                self.pending_rename_links = None;
                 self.pending_finish_merge = None;
                 self.pending_abort_merge = None;
             }
@@ -6735,11 +6924,26 @@ impl App {
             self.editor_redo_groups.clear();
         }
     }
-    /// Ctrl+V — tries the real OS clipboard first; if arboard can't reach
-    /// one (no display server), falls through to `ratatui-textarea`'s own
-    /// internal yank register (`paste()`), exactly what Ctrl+V already did
-    /// before `os_clipboard` existed, so nothing regresses in that case.
+    /// Ctrl+V — an *image* on the clipboard wins when `paste_images` is on
+    /// and a real note is being edited (not config.toml, a snippet body,
+    /// the scratchpad, or a conflict file): it's saved into the current
+    /// notebook's attachments folder and its markdown link inserted as one
+    /// undo step. Text still takes priority everywhere else, and if
+    /// arboard can't reach any clipboard (no display server), falls
+    /// through to `ratatui-textarea`'s own internal yank register
+    /// (`paste()`), exactly what Ctrl+V already did before `os_clipboard`
+    /// existed, so nothing regresses in that case.
     fn editor_paste_os(&mut self) {
+        let editing_a_note = !self.editing_config
+            && !self.editing_scratchpad
+            && self.editing_snippet.is_none()
+            && self.editing_conflict.is_none();
+        if self.config.editor.paste_images && editing_a_note {
+            if let Some(image) = crate::clipboard::paste_image() {
+                self.insert_pasted_image(&image);
+                return;
+            }
+        }
         match crate::clipboard::paste_os() {
             Some(text) => {
                 let edits = self.insert_pasted_text(&text);
@@ -6757,6 +6961,30 @@ impl App {
                     self.editor_redo_groups.clear();
                 }
             }
+        }
+    }
+    /// Saves a clipboard image into the current notebook's attachments
+    /// dir (`[general] attachments_dir`, resolved against the notebook
+    /// root so the written link resolves from any folder depth) and drops
+    /// the markdown link at the cursor.
+    fn insert_pasted_image(&mut self, image: &arboard::ImageData<'_>) {
+        let Some(nb) = self.selected_notebook().cloned() else {
+            self.set_status("no notebook selected — image not saved".into());
+            return;
+        };
+        match crate::attachments::save_image(&nb.path, &self.config.general.attachments_dir, image)
+        {
+            Ok((_path, link)) => {
+                let Some(editor) = &mut self.editor else {
+                    return;
+                };
+                if editor.textarea.insert_str(&link) {
+                    self.editor_undo_groups.push(1);
+                    self.editor_redo_groups.clear();
+                    self.set_status(format!("image saved: {link}"));
+                }
+            }
+            Err(e) => self.set_status(format!("could not save pasted image: {e}")),
         }
     }
     /// Shared by `editor_paste_os` (Ctrl+V) and `on_paste` (bracketed

--- a/shiki-tui/src/lib.rs
+++ b/shiki-tui/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod app;
+pub(crate) mod attachments;
 pub(crate) mod capture;
 pub mod clipboard;
 pub mod confirm;

--- a/shiki-tui/src/panel_settings.rs
+++ b/shiki-tui/src/panel_settings.rs
@@ -89,10 +89,11 @@ pub enum GeneralField {
     PreviewImages,
     ChafaPath,
     PreviewImageScale,
+    AttachmentsDir,
 }
 
 impl GeneralField {
-    pub const ALL: [GeneralField; 25] = [
+    pub const ALL: [GeneralField; 26] = [
         GeneralField::DefaultNotebook,
         GeneralField::Editor,
         GeneralField::DailyTemplate,
@@ -118,6 +119,7 @@ impl GeneralField {
         GeneralField::PreviewImages,
         GeneralField::ChafaPath,
         GeneralField::PreviewImageScale,
+        GeneralField::AttachmentsDir,
     ];
 }
 
@@ -181,6 +183,7 @@ pub enum EditorField {
     FormatShortcuts,
     AutoPairBrackets,
     PasteUrlAsLink,
+    PasteImages,
     SnippetExpandTab,
     TypewriterScroll,
     MoveLine,
@@ -193,7 +196,7 @@ pub enum EditorField {
 }
 
 impl EditorField {
-    pub const ALL: [EditorField; 19] = [
+    pub const ALL: [EditorField; 20] = [
         EditorField::MouseSelection,
         EditorField::FindReplace,
         EditorField::OsClipboard,
@@ -204,6 +207,7 @@ impl EditorField {
         EditorField::FormatShortcuts,
         EditorField::AutoPairBrackets,
         EditorField::PasteUrlAsLink,
+        EditorField::PasteImages,
         EditorField::SnippetExpandTab,
         EditorField::TypewriterScroll,
         EditorField::MoveLine,
@@ -455,6 +459,7 @@ fn general_rows(app: &App) -> Vec<Line<'static>> {
             "preview_image_scale",
             cfg.general.preview_image_scale.to_string(),
         ),
+        row_line(app, "attachments_dir", cfg.general.attachments_dir.clone()),
     ]
 }
 
@@ -550,6 +555,7 @@ fn editor_rows(app: &App) -> Vec<Line<'static>> {
             "paste_url_as_link",
             cfg.editor.paste_url_as_link.to_string(),
         ),
+        row_line(app, "paste_images", cfg.editor.paste_images.to_string()),
         row_line(
             app,
             "snippet_expand_tab",

--- a/shiki-tui/src/render.rs
+++ b/shiki-tui/src/render.rs
@@ -756,16 +756,20 @@ pub(crate) fn markdown_to_lines_indexed(
             continue;
         }
 
-        // A block-level `![alt](path)` image on its own line renders as
-        // terminal art (via `term_image`, which shells out to chafa) when
-        // that's enabled and possible — multi-row, so it reuses the same
-        // one-source-line-to-many-rows mechanism as tables and mermaid.
-        // Anything else (inline image mid-line, missing chafa, remote URL,
-        // undecodable file) falls through to the single-span icon+alt below.
+        // A block-level `![alt](path)` image — or Obsidian's `![[file]]`
+        // embed form, which imported vaults are full of — on its own line
+        // renders as terminal art (via `term_image`, which shells out to
+        // chafa) when that's enabled and possible. Embeds get the extra
+        // name-anywhere-in-the-vault resolution since they usually carry a
+        // bare file name. Anything else (inline image mid-line, missing
+        // chafa, remote URL, undecodable file) falls through to the
+        // single-span icon+alt below.
         if let Some(ctx) = images {
             if ctx.enabled && ctx.chafa.is_some() {
-                if let Some(spec) = crate::term_image::whole_line_image_path(line) {
-                    let resolved = crate::term_image::resolve_image_path(&ctx.base_dirs, &spec);
+                let spec = crate::term_image::whole_line_embed_path(line)
+                    .or_else(|| crate::term_image::whole_line_image_path(line));
+                if let Some(spec) = spec {
+                    let resolved = crate::term_image::resolve_embed_path(&ctx.base_dirs, &spec);
                     if let (Some(path), Some(chafa)) = (resolved, &ctx.chafa) {
                         if let Some(rows) = crate::term_image::render_rows(chafa, &path, ctx.cols) {
                             for row in rows {

--- a/shiki-tui/src/sync.rs
+++ b/shiki-tui/src/sync.rs
@@ -1,4 +1,26 @@
 use crate::app::App;
+use shiki_config::Config;
+use shiki_core::{Notebook, NotebookStore};
+
+/// Every notebook on disk except the ones untracked via "keep files, just
+/// untrack" ([`shiki_config::config::NotebookGitOverride::hidden`]) — the
+/// one filter both startup (`App::new`) and `App::reload_notebooks` must go
+/// through, so a notebook untracked mid-session stays untracked after a
+/// restart too (startup used to skip this filter entirely, which made an
+/// untracked notebook silently come back on every relaunch).
+pub(crate) fn visible_notebooks(store: &NotebookStore, config: &Config) -> Vec<Notebook> {
+    store
+        .list()
+        .unwrap_or_default()
+        .into_iter()
+        .filter(|nb| {
+            !config
+                .notebooks
+                .get(&nb.name)
+                .is_some_and(|over| over.hidden)
+        })
+        .collect()
+}
 
 /// One in-flight git operation's eventual result, sent back over
 /// `App::sync_rx` from the background thread `spawn_git_op` starts. `kind`
@@ -36,21 +58,13 @@ impl App {
     pub(crate) fn reload_notebooks(&mut self) {
         // A notebook "deleted" via the keep-files/just-untrack choice (see
         // `App::handle_delete_notebook_confirm_key`) still fully exists on
-        // disk and in `self.store` — it's excluded here, and only here, so
-        // it stops showing up anywhere the notebook list is used, without
-        // needing its own invalidation logic anywhere else.
-        self.notebooks = self
-            .store
-            .list()
-            .unwrap_or_default()
+        // disk and in `self.store` — it's excluded by `visible_notebooks`
+        // (the same filter startup uses), so it stops showing up anywhere
+        // the notebook list is used, without needing its own invalidation
+        // logic anywhere else.
+        let visible = visible_notebooks(&self.store, &self.config);
+        self.notebooks = visible
             .into_iter()
-            .filter(|nb| {
-                !self
-                    .config
-                    .notebooks
-                    .get(&nb.name)
-                    .is_some_and(|over| over.hidden)
-            })
             // Attaches whatever passphrase is cached for an encrypted
             // notebook (`resolved_notebook_crypto` — `None` if it isn't
             // encrypted, or if nothing's been typed in yet this session).
@@ -586,5 +600,64 @@ impl App {
         if self.show_drawer {
             self.refresh_drawer_statuses();
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::visible_notebooks;
+    use shiki_config::config::NotebookGitOverride;
+    use shiki_config::Config;
+    use shiki_core::NotebookStore;
+
+    #[test]
+    fn visible_notebooks_excludes_hidden_but_keeps_the_rest() {
+        let tmp = tempfile::tempdir().unwrap();
+        let store = NotebookStore::new(tmp.path().to_path_buf());
+        store.create("personal").unwrap();
+        store.create("work").unwrap();
+
+        // No overrides at all — everything on disk shows up.
+        let config = Config::default();
+        let names: Vec<String> = visible_notebooks(&store, &config)
+            .into_iter()
+            .map(|n| n.name)
+            .collect();
+        assert_eq!(names, vec!["personal".to_string(), "work".to_string()]);
+
+        // Untracking "work" ("keep files, just untrack") hides exactly that
+        // one — the filter startup and reload_notebooks must agree on.
+        let mut config = Config::default();
+        config.notebooks.insert(
+            "work".to_string(),
+            NotebookGitOverride {
+                hidden: true,
+                ..Default::default()
+            },
+        );
+        let names: Vec<String> = visible_notebooks(&store, &config)
+            .into_iter()
+            .map(|n| n.name)
+            .collect();
+        assert_eq!(names, vec!["personal".to_string()]);
+    }
+
+    #[test]
+    fn visible_notebooks_treats_an_override_without_hidden_as_visible() {
+        // A per-notebook override that only tunes sync policy (the common
+        // [notebooks.<name>] table) must not hide the notebook.
+        let tmp = tempfile::tempdir().unwrap();
+        let store = NotebookStore::new(tmp.path().to_path_buf());
+        store.create("personal").unwrap();
+
+        let mut config = Config::default();
+        config.notebooks.insert(
+            "personal".to_string(),
+            NotebookGitOverride {
+                auto_push: Some(true),
+                ..Default::default()
+            },
+        );
+        assert_eq!(visible_notebooks(&store, &config).len(), 1);
     }
 }

--- a/shiki-tui/src/term_image.rs
+++ b/shiki-tui/src/term_image.rs
@@ -88,6 +88,51 @@ pub fn whole_line_image_path(line: &str) -> Option<String> {
     }
 }
 
+/// Parses Obsidian's embed syntax `![[file]]` — returning the file
+/// reference only when the embed is the *whole* line (modulo surrounding
+/// whitespace), like `whole_line_image_path`. Alias (`|text`) and
+/// sub-address (`#heading`/`^block`) parts are stripped; empty or remote
+/// references yield `None`.
+pub fn whole_line_embed_path(line: &str) -> Option<String> {
+    let t = line.trim();
+    if !(t.starts_with("![[") && t.ends_with("]]")) {
+        return None;
+    }
+    let inner = &t[3..t.len() - 2];
+    let inner = inner.split('|').next().unwrap_or("");
+    let inner = inner.split(['#', '^']).next().unwrap_or("").trim();
+    if inner.is_empty() || inner.starts_with("http://") || inner.starts_with("https://") {
+        None
+    } else {
+        Some(inner.to_string())
+    }
+}
+
+/// Resolves an embed `spec` against the ctx's base directories — first the
+/// ordinary relative-path chain (`resolve_image_path`), then an
+/// Obsidian-style name lookup: vaults commonly keep images in some
+/// subfolder (`attachments/`, `_files/`, the note's own folder…) while the
+/// embed only carries the bare file name, so each base directory's
+/// immediate subdirectories are tried too. Depth stays bounded (one level),
+/// keeping this cheap enough to run during a preview refresh.
+pub fn resolve_embed_path(base_dirs: &[PathBuf], spec: &str) -> Option<PathBuf> {
+    if let Some(found) = resolve_image_path(base_dirs, spec) {
+        return Some(found);
+    }
+    for base in base_dirs {
+        let Ok(entries) = std::fs::read_dir(base) else {
+            continue;
+        };
+        for entry in entries.flatten() {
+            let candidate = entry.path().join(spec);
+            if candidate.is_file() {
+                return Some(candidate);
+            }
+        }
+    }
+    None
+}
+
 /// Resolves an image `spec` against the ctx's base directories, returning
 /// the first existing absolute path. An absolute `spec` is checked as-is.
 pub fn resolve_image_path(base_dirs: &[PathBuf], spec: &str) -> Option<PathBuf> {
@@ -322,6 +367,56 @@ mod tests {
         assert_eq!(whole_line_image_path("# heading"), None);
         assert_eq!(whole_line_image_path("[link](url)"), None);
         assert_eq!(whole_line_image_path(""), None);
+    }
+
+    #[test]
+    fn embed_syntax_extracts_the_file_reference() {
+        assert_eq!(
+            whole_line_embed_path("![[screenshot.png]]").as_deref(),
+            Some("screenshot.png")
+        );
+        assert_eq!(
+            whole_line_embed_path("  ![[attachments/diagram.png]]  ").as_deref(),
+            Some("attachments/diagram.png")
+        );
+        // Alias and sub-address parts don't change which file is meant.
+        assert_eq!(
+            whole_line_embed_path("![[photo.png|the vault door]]").as_deref(),
+            Some("photo.png")
+        );
+        assert_eq!(
+            whole_line_embed_path("![[note#Section]]").as_deref(),
+            Some("note")
+        );
+    }
+
+    #[test]
+    fn embed_syntax_rejects_everything_that_is_not_a_local_embed() {
+        // Markdown form belongs to the other parser.
+        assert_eq!(whole_line_embed_path("![alt](img.png)"), None);
+        // Not the whole line / not an embed at all.
+        assert_eq!(whole_line_embed_path("text ![[a.png]] more"), None);
+        assert_eq!(whole_line_embed_path("[[a.png]]"), None);
+        // Empty, remote.
+        assert_eq!(whole_line_embed_path("![[ ]]"), None);
+        assert_eq!(whole_line_embed_path("![[https://x/y.png]]"), None);
+    }
+
+    #[test]
+    fn resolve_embed_finds_a_bare_name_inside_subfolders() {
+        let dir = std::env::temp_dir().join("shiki-embed-resolve-test");
+        let _ = std::fs::create_dir_all(&dir);
+        let attachments = dir.join("attachments");
+        let _ = std::fs::create_dir_all(&attachments);
+        std::fs::write(attachments.join("pic.png"), "fake png").unwrap();
+        let bases = vec![dir.clone()];
+        let resolved = resolve_embed_path(&bases, "pic.png").unwrap();
+        assert_eq!(resolved, attachments.join("pic.png"));
+        // And a spec that already carries its folder resolves directly,
+        // without the scan.
+        let direct = resolve_embed_path(&bases, "attachments/pic.png").unwrap();
+        assert_eq!(direct, attachments.join("pic.png"));
+        let _ = std::fs::remove_dir_all(&dir);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

The "Obsidian hygiene" batch — closes the gaps that stop Obsidian users from taking shiki seriously, plus two real bugs found on the way.

**Link integrity**
- Renaming a note rewrites every inbound `[[wikilink]]` (old title + old slug, case-insensitive, `|alias` and `#heading`/`^block` suffixes preserved, fenced code skipped, encrypted notebooks honored) behind a 3-way confirm: `y` rewrite+rename / `n` rename only / `Esc` cancel
- New `aliases:` frontmatter field (Obsidian-compatible) participates in resolution, backlinks and graph; empty keys are omitted so existing notes round-trip byte-stable
- `[[note#heading]]` / `[[note^block]]` sub-addresses parse everywhere (suffix stripped before matching)

**Migration**
- `shiki import obsidian <vault>`: adopt-in-place by default (`[notebooks.<name>] path`, optional `--git-init`), `--copy` to duplicate, `--tags` merges inline #hashtags via a raw-YAML edit that preserves foreign frontmatter verbatim
- `shiki import notion <zip|dir>`: UUID suffixes stripped from pages/folders, internal links → `[[wikilinks]]` with display aliases, CSVs counted-and-skipped

**Attachments**
- `Ctrl+V` with an image saves a PNG under `[general] attachments_dir` (notebook root, resolves from any depth) and inserts the link as one undo step (`[editor] paste_images`, both in Settings)

**Rendering / UX**
- `![[embed]]` lines render as terminal art (chafa), resolving bare names across notebook subfolders
- `list_dir` skips every dot-directory (`.obsidian`, `.trash`, …), not just `.git`
- Conflict resolver modal gains `i` edit-inline (native editor stages the resolution on save); the whole modal is now documented (IDEA.md/CLAUDE.md/CHANGELOG)

## Bugs fixed

1. **Hidden notebooks reappeared on relaunch**: `App::new` listed from disk without the `hidden` filter (and called `store.list()` twice). One shared `visible_notebooks` filter now decides for startup + reload; `shiki notebook list` hides them (`--all` shows them marked), native-host picker follows.
2. **Every CLI subcommand launched the TUI**: the pre-config extension check called `cli.command.take()` unconditionally — any parsed command was consumed into the check and dispatch saw `None`. Guarded now.

## Test plan

- [x] `cargo test --workspace` green (354 tests, ~20 new: link rewrite incl. encrypted/plain/fence cases, aliases, sub-address parsing, embeds, PNG save, hashtag extraction, Notion cleaning, hidden filter)
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] Live tmux run: rename confirm rewrites the neighbor's link on disk; pull-conflict → resolver auto-opens → `i` edit → save → merge commit lands (`shiki: merge 'main'`)
- [x] End-to-end smoke: `import obsidian` (adopt + git-init + tags, frontmatter preserved byte-exact) and `import notion` (dir + zip paths)
- [x] Hidden-notebook regression checked live against CLI list/--all