### PR TITLE
fix(mermaid): don't panic on sequence-diagram self-messages

### DIFF
--- a/shiki-tui/src/mermaid.rs
+++ b/shiki-tui/src/mermaid.rs
@@ -807,13 +807,20 @@ fn render_sequence(seq: &Sequence, styles: &Styles) -> Vec<Line<'static>> {
         // pipes themselves intact).
         let lo = col_starts[from_idx.min(to_idx)];
         let hi = col_starts[from_idx.max(to_idx)];
-        for cell in row[lo + 1..hi].iter_mut() {
-            if *cell == ' ' {
-                *cell = fill;
+        if from_idx == to_idx {
+            // A self-message (`A->>A: text`): there is no span to fill and
+            // slicing `lo + 1..hi` would panic, so mark the participant's
+            // own pipe with a loop glyph instead.
+            row[lo] = '↺';
+        } else {
+            for cell in row[lo + 1..hi].iter_mut() {
+                if *cell == ' ' {
+                    *cell = fill;
+                }
             }
+            // Arrowhead on the target's pipe: `▶` when moving right, `◀` left.
+            row[col_starts[to_idx]] = if from_idx < to_idx { '▶' } else { '◀' };
         }
-        // Arrowhead on the target's pipe: `▶` when moving right, `◀` left.
-        row[col_starts[to_idx]] = if from_idx < to_idx { '▶' } else { '◀' };
         let mut spans = vec![Span::styled(
             row.iter().collect::<String>(),
             Style::default().fg(styles.accent),
@@ -934,5 +941,14 @@ mod tests {
         let (_, lines) = render("graph TD\n%% a comment\nA --> B", FG, ACCENT, MUTED).unwrap();
         let t = text(&lines);
         assert_eq!(t, vec!["A", "└─ ───▶", "   B"]);
+    }
+    #[test]
+    fn sequence_self_message_does_not_panic() {
+        let src = "sequenceDiagram\nCron->>DB: read\nCron->>Cron: skip if empty\nCron->>DB: write";
+        let (_, lines) = render(src, FG, ACCENT, MUTED).unwrap();
+        let t = text(&lines);
+        assert!(t[2].contains('↺'), "self-message loop glyph: {t:?}");
+        assert!(t[2].contains("skip if empty"), "{t:?}");
+        assert!(t[3].contains('▶'), "later messages still render: {t:?}");
     }
 }


### PR DESCRIPTION
## Problem

A sequence diagram with a self-message (`A->>A: text`) crashes the TUI as soon as the note is previewed:

```
thread 'main' panicked at shiki-tui/src/mermaid.rs:810:24:
slice index starts at 1 but ends at 0
```

In `render_sequence`, `from_idx == to_idx` makes `lo == hi`, so `row[lo + 1..hi]` is an inverted range. Because the panic skips terminal teardown, mouse tracking is also left on and the shell fills with `35;46;31M…` until the user runs `reset`.

Repro:

```mermaid
sequenceDiagram
  Cron->>DB: read
  Cron->>Cron: skip if empty
```

## Fix

Branch on the self-message case: draw `↺` on the participant's own pipe instead of filling a span/arrowhead. Other messages are unchanged.

Adds `sequence_self_message_does_not_panic` as a regression test. `cargo test -p shiki-tui`, `cargo fmt --check`, and `cargo clippy -p shiki-tui` are clean.